### PR TITLE
Fix pro-rata calculation bug when exceeding other portion

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -84,7 +84,11 @@ function App() {
     if (currentCompany) {
       const newScenarios = calculateEnhancedScenarios(currentCompany)
       
-      if (!newScenarios || newScenarios.length === 0) {
+      // Check if the result is an error object
+      if (newScenarios && newScenarios.error) {
+        showError(newScenarios.errorMessage)
+        setScenarios([]) // Clear scenarios
+      } else if (!newScenarios || newScenarios.length === 0) {
         // Check if ownership exceeds 100%
         const totalPriorOwnership = (currentCompany.priorInvestors || []).reduce((sum, inv) => sum + (inv.ownershipPercent || 0), 0)
         const totalFounderOwnership = (currentCompany.founders || []).reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)

--- a/react-app/src/utils/calculations.js
+++ b/react-app/src/utils/calculations.js
@@ -82,16 +82,26 @@ export const calculateScenario = (inputs) => {
   const proRataAmount = Math.round((roundSize * (proRataPercent || 0) / 100) * 100) / 100
   // const newMoneyAmount = Math.round((roundSize - proRataAmount) * 100) / 100
   
+  // Validate that pro-rata doesn't exceed the "Other" portion
+  if (proRataAmount > otherPortion) {
+    // Return an error object that can be handled by the UI
+    return {
+      error: true,
+      errorMessage: `Pro-rata amount ($${proRataAmount.toFixed(2)}M) exceeds available "Other" portion ($${otherPortion.toFixed(2)}M). Please reduce pro-rata percentage or increase "Other" portion.`,
+      proRataAmount,
+      otherPortion,
+      roundSize,
+      postMoneyVal,
+      preMoneyVal
+    }
+  }
+  
   // Adjust new investor portions - pro-rata comes from "Other" bucket
   let adjustedInvestorPortion = investorPortion  // US portion stays the same
   let adjustedOtherPortion = Math.round((otherPortion - proRataAmount) * 100) / 100
   
-  // Calculate actual pro-rata amount (limited by available "Other" portion)
+  // Calculate actual pro-rata amount (now we know it's valid)
   let actualProRataAmount = proRataAmount
-  if (adjustedOtherPortion < 0) {
-    actualProRataAmount = otherPortion  // Can't exceed what's available in "Other"
-    adjustedOtherPortion = 0
-  }
   
   // Calculate ownership percentages (post-money basis including SAFEs)
   const totalValue = postMoneyVal

--- a/react-app/src/utils/pro-rata-error.test.js
+++ b/react-app/src/utils/pro-rata-error.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { calculateEnhancedScenario } from './multiPartyCalculations'
+
+describe('Pro-Rata Error Handling - Multi-Party', () => {
+  it('should return error when total pro-rata exceeds other portion', () => {
+    const result = calculateEnhancedScenario({
+      postMoneyVal: 100,
+      roundSize: 20,
+      investorPortion: 18,
+      otherPortion: 2, // Only $2M available for other/pro-rata
+      investorName: 'LSVP',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 'investor1',
+          name: 'Investor 1',
+          ownershipPercent: 10, // 10% ownership * $20M round = $2M pro-rata
+          hasProRataRights: true
+        },
+        {
+          id: 'investor2',
+          name: 'Investor 2',
+          ownershipPercent: 5, // 5% ownership * $20M round = $1M pro-rata
+          hasProRataRights: true
+        }
+      ],
+      founders: [],
+      safes: []
+    })
+    
+    expect(result).toBeTruthy()
+    expect(result.error).toBe(true)
+    expect(result.errorMessage).toContain('Total pro-rata amount')
+    expect(result.errorMessage).toContain('$3.00M') // Total pro-rata attempted
+    expect(result.errorMessage).toContain('$2.00M') // Available other portion
+    expect(result.proRataAmount).toBe(3) // Shows the total attempted pro-rata
+    expect(result.otherPortion).toBe(2) // Shows the available other portion
+  })
+  
+  it('should work when pro-rata exactly matches other portion', () => {
+    const result = calculateEnhancedScenario({
+      postMoneyVal: 100,
+      roundSize: 20,
+      investorPortion: 17,
+      otherPortion: 3, // Exactly $3M available for pro-rata
+      investorName: 'LSVP',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 'investor1',
+          name: 'Investor 1',
+          ownershipPercent: 10, // 10% ownership * $20M round = $2M pro-rata
+          hasProRataRights: true
+        },
+        {
+          id: 'investor2',
+          name: 'Investor 2',
+          ownershipPercent: 5, // 5% ownership * $20M round = $1M pro-rata
+          hasProRataRights: true
+        }
+      ],
+      founders: [],
+      safes: []
+    })
+    
+    expect(result).toBeTruthy()
+    expect(result.error).toBeFalsy() // Should succeed at exact boundary
+    expect(result.otherAmount).toBe(0) // All other portion consumed by pro-rata
+  })
+  
+  it('should work when some investors have no pro-rata rights', () => {
+    const result = calculateEnhancedScenario({
+      postMoneyVal: 100,
+      roundSize: 20,
+      investorPortion: 18,
+      otherPortion: 2,
+      investorName: 'LSVP',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 'investor1',
+          name: 'Investor 1',
+          ownershipPercent: 10, // 10% ownership * $20M round = $2M pro-rata
+          hasProRataRights: true
+        },
+        {
+          id: 'investor2',
+          name: 'Investor 2',
+          ownershipPercent: 5,
+          hasProRataRights: false // No pro-rata rights
+        }
+      ],
+      founders: [],
+      safes: []
+    })
+    
+    expect(result).toBeTruthy()
+    expect(result.error).toBeFalsy() // Should succeed as only $2M pro-rata needed
+    expect(result.otherAmount).toBe(0) // All other portion consumed
+  })
+  
+  it('should return error for zero other portion with pro-rata rights', () => {
+    const result = calculateEnhancedScenario({
+      postMoneyVal: 100,
+      roundSize: 20,
+      investorPortion: 20, // Entire round to LSVP
+      otherPortion: 0, // No other portion
+      investorName: 'LSVP',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 'investor1',
+          name: 'Investor 1',
+          ownershipPercent: 10,
+          hasProRataRights: true
+        }
+      ],
+      founders: [],
+      safes: []
+    })
+    
+    expect(result).toBeTruthy()
+    expect(result.error).toBe(true)
+    expect(result.errorMessage).toContain('exceeds available')
+    expect(result.errorMessage).toContain('$2.00M') // Attempted pro-rata
+    expect(result.errorMessage).toContain('$0.00M') // Zero available
+  })
+})

--- a/react-app/src/utils/socialSharing.js
+++ b/react-app/src/utils/socialSharing.js
@@ -14,7 +14,7 @@ function generateScenarioSummary(scenarioData) {
   if (!scenarioData) return 'Investment scenario analysis'
 
   const result = calculateScenario(scenarioData)
-  if (!result) return 'Investment scenario analysis'
+  if (!result || result.error) return 'Investment scenario analysis'
 
   const parts = []
   
@@ -38,7 +38,7 @@ function generateScenarioSummary(scenarioData) {
       }
     }
     
-    if (scenarioData.preRoundFounderOwnership > 0) {
+    if (scenarioData.preRoundFounderOwnership > 0 && result.founderDilution !== undefined) {
       parts.push(`Founder dilution: ${result.founderDilution.toFixed(1)}%`)
     }
     
@@ -61,7 +61,7 @@ function generateScenarioDescription(scenarioData) {
   }
 
   const result = calculateScenario(scenarioData)
-  if (!result) {
+  if (!result || result.error) {
     return 'Investment scenario analysis with detailed cap table modeling.'
   }
 

--- a/react-app/src/utils/socialSharing.test.js
+++ b/react-app/src/utils/socialSharing.test.js
@@ -119,7 +119,7 @@ describe('Social Sharing Utilities', () => {
     it('should generate comprehensive description for advanced scenario', () => {
       // This test verifies that the description generation works
       // The actual DOM updates are mocked, so we focus on the logic
-      const advancedUrl = 'http://localhost:3000/?pmv=13&rs=3&ip=2.75&op=0.25&in=US&adv=1&pf=70&pr=25'
+      const advancedUrl = 'http://localhost:3000/?pmv=13&rs=3&ip=2&op=1&in=US&adv=1&pf=70&pr=20'
       
       // Mock the description meta tag specifically
       const mockDescMeta = mockMetaTag('description')
@@ -135,7 +135,7 @@ describe('Social Sharing Utilities', () => {
       // Verify that setAttribute was called on the description meta tag
       expect(mockDescMeta.setAttribute).toHaveBeenCalledWith(
         'content',
-        expect.stringContaining('US invests $2.75M')
+        expect.stringContaining('US invests $2M')
       )
     })
   })


### PR DESCRIPTION
## Summary
- Fixed critical bug where pro-rata calculations produced incorrect results when pro-rata amount exceeded the available "Other" portion
- Now shows clear error messages instead of displaying negative values or incorrect calculations
- Added comprehensive validation and error handling throughout the calculation pipeline

## Problem
When prior investors' pro-rata rights totaled more than the "Other" portion of a round, the app would:
- Display negative values in the UI
- Show incorrect ownership percentages
- Silently cap pro-rata at available amount without warning

Example: In a $20M round with $18M to lead investor and $2M "Other", if prior investors had pro-rata rights totaling $3M, the display would show incorrect/negative values.

## Solution
- Added validation in `calculations.js` and `multiPartyCalculations.js` to detect invalid configurations
- Return error objects with descriptive messages when pro-rata exceeds available portion
- Updated UI to display clear error messages to users
- Enhanced error handling in scenario generation and social sharing utilities

## Testing
- Updated existing pro-rata tests to expect error behavior
- Added new test suite `pro-rata-error.test.js` with comprehensive edge cases
- All 226 tests passing

## Example Error Message
When configuration is invalid, users now see:
> "Total pro-rata amount ($3.00M) exceeds available 'Other' portion ($2.00M). Please reduce pro-rata rights or increase 'Other' portion."

🤖 Generated with [Claude Code](https://claude.ai/code)