### PR TITLE
Add pro-rata rights to individual SAFEs

### DIFF
--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -124,7 +124,9 @@ const InputForm = ({ company, onUpdate }) => {
       amount: 0,
       cap: 0,
       discount: 0,
-      investorName: ''
+      investorName: '',
+      proRata: false,
+      proRataOverride: null
     }
     const newValues = {
       ...values,
@@ -151,6 +153,40 @@ const InputForm = ({ company, onUpdate }) => {
         safes: (values.safes || []).map(safe =>
           safe.id === safeId
             ? { ...safe, investorName: value }
+            : safe
+        )
+      }
+      setValues(newValues)
+      onUpdate(newValues)
+      return
+    }
+
+    // Handle pro-rata toggle (boolean). Clear override when disabling.
+    if (field === 'proRata') {
+      const newValues = {
+        ...values,
+        safes: (values.safes || []).map(safe =>
+          safe.id === safeId
+            ? { ...safe, proRata: Boolean(value), proRataOverride: value ? safe.proRataOverride : null }
+            : safe
+        )
+      }
+      setValues(newValues)
+      onUpdate(newValues)
+      return
+    }
+
+    // Handle pro-rata override (nullable number). Null = use calculated amount.
+    if (field === 'proRataOverride') {
+      const parsed = parseFloat(value)
+      const next = (isNaN(parsed) || value === '' || value === null || value === undefined)
+        ? null
+        : Math.max(0, parsed)
+      const newValues = {
+        ...values,
+        safes: (values.safes || []).map(safe =>
+          safe.id === safeId
+            ? { ...safe, proRataOverride: next }
             : safe
         )
       }
@@ -460,7 +496,7 @@ const InputForm = ({ company, onUpdate }) => {
                           if (safe.cap > 0 && safe.discount > 0) {
                             const capPrice = safe.cap
                             const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                            return capPrice < discountPrice 
+                            return capPrice < discountPrice
                               ? `$${capPrice.toFixed(1)}M`
                               : `$${discountPrice.toFixed(1)}M`
                           } else if (safe.cap > 0) {
@@ -476,11 +512,11 @@ const InputForm = ({ company, onUpdate }) => {
                           if (safe.cap > 0 && safe.discount > 0) {
                             const capPrice = safe.cap
                             const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                            return capPrice < discountPrice 
+                            return capPrice < discountPrice
                               ? `(Using cap vs ${safe.discount}% discount)`
                               : `(Using discount vs $${capPrice.toFixed(1)}M cap)`
                           } else if (safe.cap > 0) {
-                            return `(Cap: $${safe.cap.toFixed(1)}M)`  
+                            return `(Cap: $${safe.cap.toFixed(1)}M)`
                           } else if (safe.discount > 0) {
                             return `(${safe.discount}% discount)`
                           }
@@ -490,6 +526,83 @@ const InputForm = ({ company, onUpdate }) => {
                     </div>
                   </div>
                 )}
+
+                {/* Pro-rata rights for this SAFE */}
+                <div className="investor-pro-rata">
+                  <label className="pro-rata-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(safe.proRata)}
+                      onChange={(e) => updateSafe(safe.id, 'proRata', e.target.checked)}
+                    />
+                    <span className="checkbox-label">Pro-rata rights</span>
+                  </label>
+                </div>
+
+                {safe.proRata && safe.amount > 0 && values.roundSize > 0 && (() => {
+                  // Compute conversion price matching calculateSafeConversions
+                  let conversionPrice = 0
+                  if (safe.cap > 0 && safe.discount > 0) {
+                    conversionPrice = Math.min(safe.cap, safePreMoneyVal * (1 - safe.discount / 100))
+                  } else if (safe.cap > 0) {
+                    conversionPrice = Math.min(safe.cap, safePreMoneyVal)
+                  } else if (safe.discount > 0) {
+                    conversionPrice = safePreMoneyVal * (1 - safe.discount / 100)
+                  } else {
+                    conversionPrice = safePreMoneyVal
+                  }
+                  if (conversionPrice <= 0) return null
+                  const safeOwnership = (safe.amount / conversionPrice) * 100
+                  const calculatedProRata = (safeOwnership / 100) * values.roundSize
+                  const hasOverride = safe.proRataOverride != null
+                  const displayAmount = hasOverride ? safe.proRataOverride : calculatedProRata
+                  const matchesLead = (safe.investorName || '').trim() === (values.investorName || 'US').trim()
+                  if (matchesLead && safe.investorName) {
+                    return (
+                      <div className="pro-rata-hint">
+                        <span className="hint-text">
+                          Pro-rata handled via {values.investorName || 'US'} round portion
+                        </span>
+                      </div>
+                    )
+                  }
+                  return (
+                    <div className="pro-rata-allocation">
+                      <div className="pro-rata-allocation-row">
+                        <FormInput
+                          label="Allocation"
+                          type="number"
+                          value={displayAmount}
+                          onChange={(value) => updateSafe(safe.id, 'proRataOverride', value)}
+                          prefix="$"
+                          suffix="M"
+                          step="0.01"
+                          min="0"
+                        />
+                      </div>
+                      {hasOverride && (
+                        <div className="pro-rata-hint">
+                          <span className="hint-text">
+                            Pro-rata right: ${parseFloat(calculatedProRata.toPrecision(10))}M
+                            {safe.proRataOverride < calculatedProRata
+                              ? ` (taking less)`
+                              : safe.proRataOverride > calculatedProRata
+                                ? ` (taking more)`
+                                : ''}
+                          </span>
+                          <button
+                            type="button"
+                            className="reset-pro-rata-btn"
+                            onClick={() => updateSafe(safe.id, 'proRataOverride', null)}
+                            title="Reset to calculated pro-rata"
+                          >
+                            reset
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })()}
               </div>
             ))}
           </div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -103,9 +103,16 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     ? scenario.priorInvestors.reduce((sum, inv) => sum + (inv.proRataAmount || 0), 0)
     : (scenario.proRataAmount || 0)
 
-  // Remaining other for truly new investors (after ALL pro-rata)
+  // SAFE pro-rata attributed under "Other" (SAFEs not matched to the lead)
+  const safeProRataRowsForDisplay = (scenario.safeDetails || [])
+    .filter(s => (s.proRataAmount || 0) > 0 && (s.investorName || '') !== investorName)
+  const totalSafeProRataAmountForDisplay = safeProRataRowsForDisplay.reduce(
+    (sum, s) => sum + (s.proRataAmount || 0), 0
+  )
+
+  // Remaining other for truly new investors (after ALL pro-rata, prior + SAFE)
   const remainingOther = scenario.otherAmountOriginal
-    ? scenario.otherAmountOriginal - totalProRataAmount
+    ? scenario.otherAmountOriginal - totalProRataAmount - totalSafeProRataAmountForDisplay
     : scenario.otherAmount
 
   // Display values when investor is combined with a prior investor
@@ -256,16 +263,33 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                     </div>
 
                     {/* Pro-rata breakdown in advanced mode (exclude combined investor) */}
-                    {displayProRataTotal > 0 && (
+                    {(displayProRataTotal > 0 || totalSafeProRataAmountForDisplay > 0) && (
                       <>
-                        {proRataInvestorsForDisplay.map((investor, idx, arr) => (
+                        {proRataInvestorsForDisplay.map((investor, idx) => {
+                          const hasMoreAfter = (idx < proRataInvestorsForDisplay.length - 1)
+                            || safeProRataRowsForDisplay.length > 0
+                            || remainingOther > 0.01
+                          return (
                             <div key={investor.id || idx} className="table-row sub-sub-row">
-                              <div className="label">    {remainingOther > 0.01 ? '├─' : (idx === arr.length - 1 ? '└─' : '├─')} {investor.name} (pro-rata)</div>
+                              <div className="label">    {hasMoreAfter ? '├─' : '└─'} {investor.name} (pro-rata)</div>
                               <div className="amount amount-positive">+{formatDollar(investor.proRataAmount)}</div>
                               <div className="percent">{formatPercent((investor.proRataAmount / scenario.postMoneyVal) * 100)}</div>
                             </div>
-                          ))
-                        }
+                          )
+                        })}
+                        {safeProRataRowsForDisplay.map((safe, idx) => {
+                          const hasMoreAfter = (idx < safeProRataRowsForDisplay.length - 1) || remainingOther > 0.01
+                          const label = safe.investorName
+                            ? `${safe.investorName} (SAFE pro-rata)`
+                            : `SAFE #${safe.index} (pro-rata)`
+                          return (
+                            <div key={`safe-pr-${safe.id || idx}`} className="table-row sub-sub-row">
+                              <div className="label">    {hasMoreAfter ? '├─' : '└─'} {label}</div>
+                              <div className="amount amount-positive">+{formatDollar(safe.proRataAmount)}</div>
+                              <div className="percent">{formatPercent((safe.proRataAmount / scenario.postMoneyVal) * 100)}</div>
+                            </div>
+                          )
+                        })}
                         {remainingOther > 0.01 && (
                           <div className="table-row sub-sub-row">
                             <div className="label">    └─ New investors</div>
@@ -403,15 +427,28 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               <div className="percent percent-bold">{formatPercent(scenario.totalSafePercent)}</div>
             </div>
             {/* Individual SAFEs */}
-            {!collapsed.safes && scenario.safeDetails.map((safe, safeIndex) => (
-              <div key={safe.id || safeIndex} className="table-row sub-row">
-                <div className="label">{safeIndex === scenario.safeDetails.length - 1 ? '└─' : '├─'} SAFE #{safe.index}{safe.investorName && <span className="safe-attribution"> ({safe.investorName})</span>}</div>
-                <div className="amount amount-neutral">
-                  <span style={{ fontSize: '0.85rem' }}>${safe.amount}M @ ${safe.conversionPrice}M</span>
+            {!collapsed.safes && scenario.safeDetails.map((safe, safeIndex) => {
+              const isLast = safeIndex === scenario.safeDetails.length - 1
+              const showProRata = (safe.proRataAmount || 0) > 0
+              return (
+                <div key={safe.id || safeIndex} style={{ display: 'contents' }}>
+                  <div className="table-row sub-row">
+                    <div className="label">{isLast && !showProRata ? '└─' : '├─'} SAFE #{safe.index}{safe.investorName && <span className="safe-attribution"> ({safe.investorName})</span>}</div>
+                    <div className="amount amount-neutral">
+                      <span style={{ fontSize: '0.85rem' }}>${safe.amount}M @ ${safe.conversionPrice}M</span>
+                    </div>
+                    <div className="percent">{formatPercent(safe.percent)}</div>
+                  </div>
+                  {showProRata && (
+                    <div className="table-row sub-sub-row">
+                      <div className="label">    {isLast ? '└─' : '├─'} pro-rata</div>
+                      <div className="amount amount-positive">+{formatDollar(safe.proRataAmount)}</div>
+                      <div className="percent">{formatPercent(safe.proRataPercent || 0)}</div>
+                    </div>
+                  )}
                 </div>
-                <div className="percent">{formatPercent(safe.percent)}</div>
-              </div>
-            ))}
+              )
+            })}
           </>
         )}
         

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -109,7 +109,7 @@ export function createDefaultCompany(companyName = 'New Company') {
 
     // New multi-party structures
     priorInvestors: [
-      createPriorInvestor('Previous Investors', 15, true) // Default with pro-rata rights
+      createPriorInvestor('Previous Investors', 15, false)
     ],
     founders: [
       createFounder('Founder Team', 85) // Default founder ownership

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -174,7 +174,11 @@ export function migrateLegacyCompany(legacyCompany) {
   // Ensure arrays exist even if empty
   migrated.priorInvestors = migrated.priorInvestors || []
   migrated.founders = migrated.founders || [createFounder('Founder Team', 85)]
-  migrated.safes = migrated.safes || []
+  migrated.safes = (migrated.safes || []).map(safe => ({
+    proRata: false,
+    proRataOverride: null,
+    ...safe
+  }))
 
   // Ensure 2-step round fields exist
   if (migrated.twoStepEnabled === undefined) migrated.twoStepEnabled = false

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -77,12 +77,12 @@ function calculateSafeConversions(safes, preMoneyVal) {
   let totalSafePercent = 0
   let totalSafeAmount = 0
   let safeDetails = []
-  
+
   if (safes && safes.length > 0) {
     safes.forEach((safe, index) => {
       if (safe.amount > 0) {
         let conversionPrice = 0
-        
+
         if (safe.cap > 0 && safe.discount > 0) {
           const capPrice = safe.cap
           const discountPrice = preMoneyVal * (1 - safe.discount / 100)
@@ -94,14 +94,14 @@ function calculateSafeConversions(safes, preMoneyVal) {
         } else {
           conversionPrice = preMoneyVal
         }
-        
+
         if (conversionPrice > 0) {
           const safePercent = r2p(safe.amount / conversionPrice)
-          
+
           if (safePercent <= 95) {
             totalSafePercent += safePercent
             totalSafeAmount += safe.amount
-            
+
             safeDetails.push({
               id: safe.id,
               index: index + 1,
@@ -110,18 +110,72 @@ function calculateSafeConversions(safes, preMoneyVal) {
               discount: safe.discount,
               conversionPrice: r$(conversionPrice),
               percent: safePercent,
-              investorName: safe.investorName || ''
+              investorName: safe.investorName || '',
+              proRata: Boolean(safe.proRata),
+              proRataOverride: (safe.proRataOverride != null && safe.proRataOverride >= 0)
+                ? Number(safe.proRataOverride)
+                : null
             })
           }
         }
       }
     })
   }
-  
+
   return {
     totalSafePercent: rp(totalSafePercent),
     totalSafeAmount: r$(totalSafeAmount),
     safeDetails
+  }
+}
+
+/**
+ * Calculate pro-rata allocation for SAFEs flagged with proRata rights.
+ * Mirrors calculateProRataAllocations for prior investors.
+ * @param {Array} safeDetails - Output from calculateSafeConversions (already carries percent, proRata, proRataOverride, investorName)
+ * @param {number} roundSize - Total round size in which pro-rata is exercised
+ * @param {string} investorName - Lead investor name; matching SAFEs are skipped (handled via lead portion)
+ * @returns {Object} { safeProRataResults, totalSafeProRataAmount }
+ */
+function calculateSafeProRataAllocations(safeDetails, roundSize, investorName) {
+  const safeProRataResults = []
+  let totalSafeProRataAmount = 0
+
+  if (!Array.isArray(safeDetails)) {
+    return { safeProRataResults: [], totalSafeProRataAmount: 0 }
+  }
+
+  const leadName = (investorName || '').trim()
+
+  safeDetails.forEach(safe => {
+    if (!safe.proRata || !safe.percent || safe.percent <= 0 || !roundSize) {
+      return
+    }
+    // Lead-attributed SAFEs: pro-rata absorbed by lead's investor portion
+    const safeInvestor = (safe.investorName || '').trim()
+    if (safeInvestor && safeInvestor === leadName) {
+      return
+    }
+    const calculatedAmount = r$((safe.percent / 100) * roundSize)
+    const proRataAmount = (safe.proRataOverride != null && safe.proRataOverride >= 0)
+      ? r$(safe.proRataOverride)
+      : calculatedAmount
+    if (proRataAmount <= 0) return
+
+    safeProRataResults.push({
+      id: safe.id,
+      investorName: safe.investorName || '',
+      preRoundSafePercent: safe.percent,
+      proRataAmount,
+      calculatedProRataAmount: calculatedAmount,
+      isOverridden: safe.proRataOverride != null && safe.proRataOverride >= 0
+    })
+    totalSafeProRataAmount += proRataAmount
+  })
+
+  return {
+    safeProRataResults,
+    totalSafeProRataAmount: r$(totalSafeProRataAmount)
   }
 }
 
@@ -229,9 +283,24 @@ function calculateTwoStepScenario(inputs) {
   )
   const proRataCalc = calculateProRataAllocations(priorInvestorsForProRata, S2)
 
-  // Pro-rata comes from step 2 other portion
-  const actualProRataAmount = Math.min(proRataCalc.totalProRataAmount, s2Other)
-  const adjustedS2Other = r$(s2Other - actualProRataAmount)
+  // SAFE pro-rata also draws from step 2's other portion. Use pre-dilution SAFE percent
+  // relative to step 2 round (treat safeCalc.totalSafePercent as the step-1 post-money % of SAFE).
+  const safeProRataCalc = calculateSafeProRataAllocations(safeCalc.safeDetails, S2, investorName)
+
+  // Combined pro-rata clamped to available step 2 other portion
+  const combinedRequestedProRata = r$(proRataCalc.totalProRataAmount + safeProRataCalc.totalSafeProRataAmount)
+  const priorProRataShare = combinedRequestedProRata > 0
+    ? (proRataCalc.totalProRataAmount / combinedRequestedProRata)
+    : 0
+  const safeProRataShare = combinedRequestedProRata > 0
+    ? (safeProRataCalc.totalSafeProRataAmount / combinedRequestedProRata)
+    : 0
+  const totalProRataApplied = Math.min(combinedRequestedProRata, s2Other)
+  const actualProRataAmount = r$(totalProRataApplied * priorProRataShare)
+  const actualSafeProRataAmount = r$(totalProRataApplied * safeProRataShare)
+  const adjustedS2Other = r$(s2Other - actualProRataAmount - actualSafeProRataAmount)
+  // Scale factor applied per-investor/per-SAFE if combined pro-rata exceeded available s2Other
+  const clampRatio = combinedRequestedProRata > 0 ? (totalProRataApplied / combinedRequestedProRata) : 0
 
   // --- Step 1 ownership ---
   // Step 1 investors get S1/V1 of post-step-1 company
@@ -272,10 +341,13 @@ function calculateTwoStepScenario(inputs) {
     // Existing shareholders diluted by step 1 then step 2
     let postRoundPercent = rp(preRoundPercent * (100 - step1RoundPercent - safeCalc.totalSafePercent - esopCalc.esopIncreasePreClose) / 100 * step2DilutionFactor)
 
-    // Add pro-rata participation from step 2
+    // Add pro-rata participation from step 2 (scaled by clamp ratio when combined pro-rata exceeds s2Other)
     const proRataEntry = proRataCalc.proRataResults.find(pr => pr.id === investor.id)
-    if (proRataEntry && proRataEntry.proRataAmount > 0) {
-      const proRataOwnershipPercent = r2p(Math.min(proRataEntry.proRataAmount, actualProRataAmount > 0 ? proRataEntry.proRataAmount : 0) / V2)
+    const scaledProRataAmount = (proRataEntry && proRataEntry.proRataAmount > 0)
+      ? r$(proRataEntry.proRataAmount * clampRatio)
+      : 0
+    if (scaledProRataAmount > 0) {
+      const proRataOwnershipPercent = r2p(scaledProRataAmount / V2)
       postRoundPercent += proRataOwnershipPercent
     }
 
@@ -287,7 +359,7 @@ function calculateTwoStepScenario(inputs) {
     return {
       ...investor,
       postRoundPercent: rp(postRoundPercent),
-      proRataAmount: proRataEntry ? Math.min(proRataEntry.proRataAmount, actualProRataAmount > 0 ? proRataEntry.proRataAmount : 0) : 0,
+      proRataAmount: scaledProRataAmount,
       dilution: rp(preRoundPercent - postRoundPercent)
     }
   })
@@ -337,10 +409,22 @@ function calculateTwoStepScenario(inputs) {
   }
 
   // Compute diluted SAFE details once (reused in return and SAFE attribution)
-  const dilutedSafeDetails = safeCalc.safeDetails.map(d => ({
-    ...d,
-    percent: rp(d.percent * step2DilutionFactor)
-  }))
+  const esopPostCloseFactor2 = esopCalc.esopIncreasePostClose > 0
+    ? (100 - esopCalc.esopIncreasePostClose) / 100
+    : 1
+  const dilutedSafeDetails = safeCalc.safeDetails.map(d => {
+    const pr = safeProRataCalc.safeProRataResults.find(r => r.id === d.id)
+    const scaledProRataAmount = pr ? r$(pr.proRataAmount * clampRatio) : 0
+    const proRataPercent = rp(r2p(scaledProRataAmount / V2) * esopPostCloseFactor2)
+    const dilutedPercent = rp(d.percent * step2DilutionFactor * esopPostCloseFactor2)
+    return {
+      ...d,
+      percent: rp(d.percent * step2DilutionFactor),
+      proRataAmount: scaledProRataAmount,
+      proRataPercent,
+      totalPercent: rp(dilutedPercent + proRataPercent)
+    }
+  })
 
   // Calculate SAFE ownership attributed to the lead investor
   let investorSafePercent = 0
@@ -430,6 +514,11 @@ function calculateTwoStepScenario(inputs) {
     proRataAmount: actualProRataAmount,
     proRataPercent: r2p(actualProRataAmount / V2),
     proRataDetails: proRataCalc.proRataResults,
+
+    // SAFE pro-rata totals
+    totalSafeProRataAmount: actualSafeProRataAmount,
+    totalSafeProRataPercent: r2p(actualSafeProRataAmount / V2),
+    safeProRataDetails: safeProRataCalc.safeProRataResults,
 
     // SAFE details
     totalSafeAmount: safeCalc.totalSafeAmount,
@@ -576,30 +665,33 @@ export function calculateEnhancedScenario(inputs) {
     inv.name === investorName ? { ...inv, hasProRataRights: false } : inv
   )
   const proRataCalc = calculateProRataAllocations(priorInvestorsForProRata, roundSize)
-  
-  // Pro-rata comes from the "Other" portion, not from round size
-  // Validate that pro-rata doesn't exceed the "Other" portion
-  if (proRataCalc.totalProRataAmount > otherPortion) {
-    // Return an error object that can be handled by the UI
+
+  // Calculate SAFE conversions (needed before SAFE pro-rata)
+  const safeCalc = calculateSafeConversions(effectiveSafes, preMoneyVal)
+
+  // Calculate SAFE pro-rata on SAFEs flagged with pro-rata rights
+  const safeProRataCalc = calculateSafeProRataAllocations(safeCalc.safeDetails, roundSize, investorName)
+
+  // Pro-rata (prior + SAFE) comes from the "Other" portion, not from round size
+  const combinedProRataAmount = r$(proRataCalc.totalProRataAmount + safeProRataCalc.totalSafeProRataAmount)
+  if (combinedProRataAmount > otherPortion + 1e-9) {
     return {
       error: true,
-      errorMessage: `Total pro-rata amount ($${proRataCalc.totalProRataAmount.toFixed(2)}M) exceeds available "Other" portion ($${otherPortion.toFixed(2)}M). Please reduce pro-rata rights or increase "Other" portion.`,
-      proRataAmount: proRataCalc.totalProRataAmount,
+      errorMessage: `Total pro-rata amount ($${combinedProRataAmount.toFixed(2)}M) exceeds available "Other" portion ($${otherPortion.toFixed(2)}M). Please reduce pro-rata rights or increase "Other" portion.`,
+      proRataAmount: combinedProRataAmount,
       otherPortion,
       roundSize,
       postMoneyVal,
       preMoneyVal
     }
   }
-  
+
   const actualProRataAmount = proRataCalc.totalProRataAmount
-  
-  // Adjust investor portions - investor stays the same, other is reduced by pro-rata
+  const actualSafeProRataAmount = safeProRataCalc.totalSafeProRataAmount
+
+  // Adjust investor portions - investor stays the same, other is reduced by combined pro-rata
   const adjustedInvestorPortion = investorPortion
-  const adjustedOtherPortion = r$(otherPortion - actualProRataAmount)
-  
-  // Calculate SAFE conversions
-  const safeCalc = calculateSafeConversions(effectiveSafes, preMoneyVal)
+  const adjustedOtherPortion = r$(otherPortion - actualProRataAmount - actualSafeProRataAmount)
   
   // Calculate ownership percentages on post-money basis
   const roundPercent = r2p(roundSize / postMoneyVal)
@@ -749,13 +841,31 @@ export function calculateEnhancedScenario(inputs) {
     }
   }
 
+  // Enrich safeDetails with pro-rata attribution (post-close ESOP dilutes round percentages)
+  const esopPostCloseFactor = esopCalc.esopIncreasePostClose > 0
+    ? (100 - esopCalc.esopIncreasePostClose) / 100
+    : 1
+  const enrichedSafeDetails = (safeCalc.safeDetails || []).map(safe => {
+    const pr = safeProRataCalc.safeProRataResults.find(r => r.id === safe.id)
+    const proRataAmount = pr ? pr.proRataAmount : 0
+    const proRataPercentRaw = r2p(proRataAmount / postMoneyVal)
+    const proRataPercent = rp(proRataPercentRaw * esopPostCloseFactor)
+    const dilutedConversionPercent = rp(safe.percent * esopPostCloseFactor)
+    return {
+      ...safe,
+      proRataAmount,
+      proRataPercent,
+      totalPercent: rp(dilutedConversionPercent + proRataPercent)
+    }
+  })
+
   return {
     // Basic valuation info
     postMoneyVal: postMoneyVal || 13,
     roundSize: roundSize || 3,
     preMoneyVal: preMoneyVal || 10,
     investorName: investorName || 'US',
-    
+
     // Round composition - ensure no undefined values
     newMoneyAmount: roundSize || 0,
     investorAmount: adjustedInvestorPortion || 0,
@@ -764,22 +874,27 @@ export function calculateEnhancedScenario(inputs) {
     otherPercent: otherPercent || 0,
     otherAmountOriginal: otherPortion || 0, // Original other amount before pro-rata adjustment
     roundPercent: finalRoundPercent || 0,
-    
+
     // Total round details for legacy compatibility
     totalAmount: roundSize || 3,
     totalPercent: finalRoundPercent || 0,
-    
-    // Pro-rata details
+
+    // Pro-rata details (prior investors only — SAFE pro-rata surfaced via safeDetails)
     totalProRataAmount: actualProRataAmount || 0,
     totalProRataPercent: r2p(actualProRataAmount / postMoneyVal),
     proRataAmount: actualProRataAmount || 0,
     proRataPercent: r2p(actualProRataAmount / postMoneyVal),
     proRataDetails: proRataCalc.proRataResults || [],
-    
+
+    // SAFE pro-rata totals
+    totalSafeProRataAmount: actualSafeProRataAmount || 0,
+    totalSafeProRataPercent: r2p(actualSafeProRataAmount / postMoneyVal),
+    safeProRataDetails: safeProRataCalc.safeProRataResults || [],
+
     // SAFE details
     totalSafeAmount: safeCalc.totalSafeAmount || 0,
     totalSafePercent: safeCalc.totalSafePercent || 0,
-    safeDetails: safeCalc.safeDetails || [],
+    safeDetails: enrichedSafeDetails,
     safes: effectiveSafes || [],
     
     // ESOP details

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -105,6 +105,12 @@ export function encodeScenarioToURL(scenarioData) {
             if (safe.investorName && safe.investorName.trim()) {
               encoded.n = safe.investorName.trim()
             }
+            if (safe.proRata) {
+              encoded.p = 1
+              if (safe.proRataOverride != null && safe.proRataOverride >= 0) {
+                encoded.po = safe.proRataOverride
+              }
+            }
             return encoded
           }).filter(safe => safe.a > 0) // Only include SAFEs with amount > 0
 
@@ -238,7 +244,9 @@ export function decodeScenarioFromURL(urlParams) {
                 amount: safe.a || 0,
                 cap: safe.c || 0,
                 discount: safe.d || 0,
-                investorName: safe.n || ''
+                investorName: safe.n || '',
+                proRata: safe.p === 1 || safe.p === true,
+                proRataOverride: (typeof safe.po === 'number' && safe.po >= 0) ? safe.po : null
               }))
             }
           } catch (error) {

--- a/react-app/src/utils/safe-pro-rata.test.js
+++ b/react-app/src/utils/safe-pro-rata.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { calculateEnhancedScenario, calculateEnhancedScenarios } from './multiPartyCalculations'
+
+const baseInputs = {
+  postMoneyVal: 100,
+  roundSize: 20,
+  investorPortion: 15,
+  otherPortion: 5,
+  investorName: 'LSVP',
+  showAdvanced: true,
+  safes: [],
+  priorInvestors: [],
+  founders: [{ id: 99, name: 'Founders', ownershipPercent: 80 }],
+  currentEsopPercent: 0,
+  targetEsopPercent: 0,
+  esopTiming: 'pre-close',
+  twoStepEnabled: false,
+  step2PostMoney: 0,
+  step2Amount: 0,
+  step2InvestorPortion: 0,
+  step2OtherPortion: 0
+}
+
+describe('SAFE Pro-Rata', () => {
+  it('does not change results when no SAFE has proRata enabled', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 10, discount: 0, investorName: 'Acme', proRata: false }
+      ]
+    })
+    expect(result.totalSafeProRataAmount).toBe(0)
+    expect(result.otherAmount).toBeCloseTo(5, 2)
+  })
+
+  it('deducts SAFE pro-rata from "Other" portion and attributes to the SAFE row', () => {
+    // SAFE converts to 25% of company ($2M / $8M cap). Pro-rata = 25% * $20M = $5M,
+    // but only $5M available in Other. At boundary.
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 8, discount: 0, investorName: 'Acme', proRata: true }
+      ]
+    })
+    expect(result.error).toBeFalsy()
+    expect(result.totalSafeProRataAmount).toBeCloseTo(5, 2)
+    expect(result.otherAmount).toBeCloseTo(0, 2) // fully consumed
+    const safe = result.safeDetails[0]
+    expect(safe.proRata).toBe(true)
+    expect(safe.proRataAmount).toBeCloseTo(5, 2)
+    expect(safe.proRataPercent).toBeCloseTo(5, 2) // $5M / $100M
+  })
+
+  it('errors when prior + SAFE pro-rata combined exceed Other portion', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      otherPortion: 2, // Only $2M other
+      investorPortion: 18,
+      safes: [
+        { id: 1, amount: 1, cap: 10, discount: 0, investorName: 'Acme', proRata: true } // 10% → $2M pro-rata
+      ],
+      priorInvestors: [
+        { id: 10, name: 'Seed Co', ownershipPercent: 10, hasProRataRights: true, proRataOverride: null } // 10% × $20M = $2M
+      ],
+      founders: [{ id: 99, name: 'Founders', ownershipPercent: 70 }]
+    })
+    expect(result.error).toBe(true)
+    expect(result.errorMessage).toMatch(/exceeds available/)
+  })
+
+  it('respects proRataOverride on a SAFE', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 8, discount: 0, investorName: 'Acme', proRata: true, proRataOverride: 1 }
+      ]
+    })
+    expect(result.error).toBeFalsy()
+    expect(result.totalSafeProRataAmount).toBeCloseTo(1, 2)
+    expect(result.otherAmount).toBeCloseTo(4, 2)
+    expect(result.safeDetails[0].proRataAmount).toBeCloseTo(1, 2)
+  })
+
+  it('skips pro-rata for SAFE matching the lead investor name (handled via lead portion)', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 8, discount: 0, investorName: 'LSVP', proRata: true }
+      ]
+    })
+    expect(result.error).toBeFalsy()
+    expect(result.totalSafeProRataAmount).toBe(0)
+    expect(result.otherAmount).toBeCloseTo(5, 2) // Other untouched
+    expect(result.safeDetails[0].proRataAmount).toBe(0)
+  })
+
+  it('keeps total ownership close to 100% with SAFE pro-rata enabled', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 8, discount: 0, investorName: 'Acme', proRata: true, proRataOverride: 2 }
+      ]
+    })
+    expect(result.error).toBeFalsy()
+    expect(result.totalOwnership + result.unknownOwnership).toBeCloseTo(100, 1)
+  })
+
+  it('persists SAFE pro-rata fields in permalink round-trip', async () => {
+    const { encodeScenarioToURL, decodeScenarioFromURL } = await import('./permalink')
+    const encoded = encodeScenarioToURL({
+      ...baseInputs,
+      safes: [
+        { id: 1, amount: 2, cap: 8, discount: 0, investorName: 'Acme', proRata: true, proRataOverride: 1.5 }
+      ]
+    })
+    const decoded = decodeScenarioFromURL(encoded)
+    expect(decoded.safes).toHaveLength(1)
+    expect(decoded.safes[0].proRata).toBe(true)
+    expect(decoded.safes[0].proRataOverride).toBe(1.5)
+  })
+})
+
+describe('SAFE Pro-Rata in Two-Step Round', () => {
+  it('draws SAFE pro-rata from step 2 Other portion', () => {
+    const scenarios = calculateEnhancedScenarios({
+      ...baseInputs,
+      twoStepEnabled: true,
+      postMoneyVal: 50,
+      roundSize: 10,
+      investorPortion: 8,
+      otherPortion: 2,
+      step2PostMoney: 150,
+      step2Amount: 30,
+      step2InvestorPortion: 20,
+      step2OtherPortion: 10,
+      safes: [
+        { id: 1, amount: 1, cap: 10, discount: 0, investorName: 'Acme', proRata: true }
+        // Converts at $10M on $40M pre-money → ~10% pre-round, pro-rata on $30M step-2 = $3M (of $10M other)
+      ]
+    })
+    const base = scenarios[0]
+    expect(base.error).toBeFalsy()
+    expect(base.totalSafeProRataAmount).toBeGreaterThan(0)
+    expect(base.safeDetails[0].proRataAmount).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- SAFEs can now be individually marked with pro-rata rights via a checkbox on each SAFE row, with an optional allocation override mirroring the prior-investor UX.
- Calculation engine combines SAFE and prior-investor pro-rata against the "Other" portion budget; lead-attributed SAFEs skip pro-rata (handled via the lead's round portion), and the two-step path scales proportionally when combined pro-rata would exceed step-2 Other.
- ScenarioCard shows each SAFE's pro-rata as a sub-row under the SAFE and under the "Other" breakdown; permalink encodes the new \`p\` / \`po\` fields so state round-trips.
- The default "Previous Investors" seed now starts with pro-rata off so users opt in rather than out.

## Test plan
- [x] \`npx vitest run\` — 368 tests pass (8 new in \`safe-pro-rata.test.js\`)
- [ ] Manual: add a SAFE with cap/amount, toggle pro-rata, confirm "Other" is reduced and the SAFE row shows the pro-rata sub-row
- [ ] Manual: confirm lead-attributed SAFEs show the "handled via {lead} round portion" hint instead of an allocation input
- [ ] Permalink round-trip preserves \`proRata\` and \`proRataOverride\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)