### PR TITLE
Exit Math module + Conductor per-workspace port + AGENTS.md

### DIFF
--- a/.conductor/run.sh
+++ b/.conductor/run.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-
 cd react-app
-exec npm run dev
+
+# Conductor assigns a unique port per workspace via $CONDUCTOR_PORT so multiple
+# workspaces can run side-by-side without fighting over Vite's default 5173.
+# Fall back to Vite's default when run outside Conductor.
+PORT="${CONDUCTOR_PORT:-5173}"
+
+exec npm run dev -- --port "$PORT" --strictPort --host

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repo. Keep it short, update it when something changes.
+
+## What this repo is
+
+**ValuFrame** — a React + Vite single-page app that helps VCs model term sheets. You enter a post-money valuation and round size, the app computes ownership/dilution for the new investor, founders, and prior investors, and spits out a base case plus alternative scenarios (half round, 2x valuation, etc.). Everything runs client-side with localStorage persistence. Scenarios can be shared via permalinks that encode state into URL params.
+
+Recent additions:
+- Multi-party prior investors and founders (each with their own ownership row).
+- SAFE conversion math with per-SAFE investor attribution.
+- 2-step rounds (round closes in two tranches at different valuations).
+- **Exit Math module** (3rd column, toggled from the footer): projects base-case LSVP check forward through N rounds of dilution to an exit valuation and shows MOIC.
+
+## Layout
+
+```
+phoenix/
+├── react-app/                 # The actual app — do most work here
+│   ├── src/
+│   │   ├── App.jsx                          # Top-level layout + company state
+│   │   ├── App.css                          # Single stylesheet for the whole app
+│   │   ├── components/
+│   │   │   ├── InputForm.jsx                # Left column: all inputs
+│   │   │   ├── ScenarioCard.jsx             # Base case + scenario tiles
+│   │   │   ├── PriorInvestorsSection.jsx
+│   │   │   ├── FoundersSection.jsx
+│   │   │   ├── ExitMathModule.jsx           # 3rd column (toggled in footer)
+│   │   │   ├── AppFooter.jsx                # Exit Math toggle lives here
+│   │   │   └── CompanyTabs.jsx
+│   │   ├── utils/
+│   │   │   ├── multiPartyCalculations.js    # ★ Primary calc engine
+│   │   │   ├── calculations.js              # Legacy engine (tests only)
+│   │   │   ├── exitMath.js                  # Pure exit/MOIC math
+│   │   │   ├── dataStructures.js            # createDefaultCompany, migrations
+│   │   │   └── permalink.js                 # URL encode/decode (whitelisted fields)
+│   │   └── hooks/
+│   │       ├── useLocalStorage.js
+│   │       └── useNotifications.js
+├── .conductor/                # Conductor workspace scripts
+│   ├── run.sh                 # Starts vite on $CONDUCTOR_PORT
+│   └── setup.sh               # `npm install`
+├── CLAUDE.md                  # Claude-specific notes (progress log)
+├── AGENTS.md                  # You are here
+└── readme.md                  # End-user / README
+```
+
+## Running it
+
+```bash
+cd react-app
+npm install
+npm run dev               # http://localhost:5173
+npx vitest run            # full test suite (370+ tests)
+npm run lint              # eslint
+npm run build             # production build
+```
+
+From a Conductor workspace, prefer `.conductor/run.sh` — it binds Vite to the workspace's unique `$CONDUCTOR_PORT` so parallel workspaces don't collide.
+
+## Working in Conductor
+
+Conductor runs many agents in parallel, one per workspace. Each workspace is a git worktree.
+
+Env vars you can rely on:
+| Var | Meaning |
+|---|---|
+| `CONDUCTOR_WORKSPACE_NAME` | e.g. `phoenix` |
+| `CONDUCTOR_WORKSPACE_PATH` | absolute path to this workspace |
+| `CONDUCTOR_ROOT_PATH` | the main repo clone (read-only from here) |
+| `CONDUCTOR_DEFAULT_BRANCH` | usually `main` — target for PRs |
+| `CONDUCTOR_PORT` | per-workspace port; wired into `.conductor/run.sh` |
+
+Rules of thumb:
+- Do all work inside `$CONDUCTOR_WORKSPACE_PATH`. Never touch `$CONDUCTOR_ROOT_PATH`.
+- The target branch is `$CONDUCTOR_DEFAULT_BRANCH` (`main`). Open PRs against it.
+- If something doesn't make sense in context, the user may have sent the message to the wrong workspace — ask.
+- `.context/` is gitignored and is the place to drop scratch files other agents might read.
+- Unrelated tasks should go in separate workspaces.
+
+## Code conventions (follow these, they're load-bearing)
+
+- **Single stylesheet** — `App.css` holds everything. No CSS modules, no styled-components. Match existing class naming (`.advanced-section`, `.analytics-row`, `.investor-summary`, `.scenario-card`).
+- **Calc engine is `multiPartyCalculations.js`.** `calculations.js` is legacy; only the tests import it. New features plug into the multi-party engine.
+- **Scenarios are derived, never stored.** `App.jsx` re-runs `calculateEnhancedScenarios(company)` on every state change. Don't cache scenario results into company state.
+- **Company state shape is the source of truth.** Defaults live in `createDefaultCompany()` in `dataStructures.js`. If you add a field, also add it to `migrateLegacyCompany()` so existing localStorage blobs don't break.
+- **Permalinks are whitelisted.** `permalink.js` encodes only the fields in `URL_PARAM_MAP`. Anything not in that map will *not* travel through share links — use this on purpose for local-only UI state (e.g. `showExitMath`, `exitMath`) rather than adding a suppression flag.
+- **Money is in $M, exit math is in $M.** Percentages are numbers like `21.15` (not `0.2115`). If you need decimals, convert at the boundary.
+- **No new frameworks.** React 18 (via 19 peer), Vite, vanilla CSS, Vitest. That's it.
+
+## Testing
+
+- Vitest + @testing-library/react. Tests live next to the source (`foo.js` + `foo.test.js`).
+- Calc utilities should have pure-function unit tests with concrete numbers (see `exitMath.test.js`, `calculations.test.js`).
+- UI components are tested via render + query + assertion; see `ScenarioCard.test.jsx` for the pattern.
+- Run the full suite before committing. The suite is fast (~30s).
+
+## UI changes — verify in a browser
+
+Type checks and unit tests don't prove the UI works. For visual/interaction changes:
+1. Start the dev server (`.conductor/run.sh` or `npm run dev`).
+2. Load the page, click through the feature, check console for errors.
+3. If you can't do this (headless-only environment), say so in the handoff instead of claiming success.
+
+## Git workflow
+
+- Default instruction from the user: **commit and push after completing work** — don't ask.
+- Branches per workspace; the current branch is set up to track `origin`.
+- PR target is `main`. Use `gh pr create` and follow the commit message style in recent history (short imperative summary, then context).
+
+## Common gotchas
+
+- `vite` defaults to port 5173 — override with `--port` when running multiple workspaces. `.conductor/run.sh` handles this.
+- Adding a field to `createDefaultCompany` without updating `migrateLegacyCompany` silently breaks users with old localStorage.
+- When a scenario displays LSVP's "total" ownership, prefer `scenario.combinedInvestor.totalOwnership` over `scenario.investorPercent` — the latter is just the new-round slice and ignores pro-rata + SAFE attribution.
+- Dollar values throughout the app are in millions; don't accidentally mix $M and $ raw (the Exit Math module's `exitValuation` input is in $M — e.g. `5000` means $5B).

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -250,6 +250,11 @@ body.geometric-background-active .app {
   margin-right: auto;
 }
 
+.top-row.with-exit-math {
+  grid-template-columns: 1fr 1fr 0.9fr;
+  max-width: 1500px;
+}
+
 .base-result {
   display: flex;
   justify-content: center;
@@ -2143,7 +2148,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     border-bottom: none;
   }
 
-  .top-row {
+  .top-row,
+  .top-row.with-exit-math {
     grid-template-columns: 1fr;
     gap: 1.5rem;
     margin-bottom: 1.5rem;
@@ -2394,4 +2400,227 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     padding: 0.4rem 0.6rem;
     font-size: 0.72rem;
   }
+}
+
+/* ============================================================
+   Exit Math Module
+   ============================================================ */
+.exit-math-module {
+  background: #ffffff;
+  border: 1px solid #e2e7ed;
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.exit-math-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.exit-math-subtitle {
+  display: block;
+  font-size: 0.75rem;
+  color: #718096;
+  margin-top: 0.15rem;
+}
+
+.exit-math-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.85rem;
+}
+
+.exit-math-inputs .input-group label {
+  font-weight: 600;
+  color: #4a5568;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.25rem;
+}
+
+.exit-math-inputs input[type="number"] {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #cbd5e0;
+  border-radius: 4px;
+  background: #ffffff;
+  font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+  font-size: 0.9rem;
+  color: #1e293b;
+  box-sizing: border-box;
+}
+
+.exit-math-inputs input[type="number"]:focus {
+  outline: none;
+  border-color: #635bff;
+  box-shadow: 0 0 0 2px rgba(99, 91, 255, 0.15);
+}
+
+.exit-math-input-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.exit-math-hint {
+  font-size: 0.72rem;
+  color: #94a3b8;
+  font-style: italic;
+  margin-top: 0.15rem;
+}
+
+.exit-math-overrides {
+  border-top: 1px dashed #e2e8f0;
+  padding-top: 0.6rem;
+}
+
+.exit-math-overrides-grid {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.exit-math-override-row {
+  display: grid;
+  grid-template-columns: 60px 1fr 20px;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.exit-math-override-row label {
+  font-size: 0.75rem;
+  color: #4a5568;
+  font-weight: 600;
+  margin: 0;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.exit-math-override-row input {
+  padding: 0.3rem 0.5rem !important;
+  font-size: 0.82rem !important;
+}
+
+.exit-math-override-unit {
+  font-size: 0.8rem;
+  color: #718096;
+}
+
+.exit-math-reset-btn {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #635bff;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-weight: 600;
+}
+
+.exit-math-reset-btn:hover {
+  text-decoration: underline;
+}
+
+.exit-math-summary {
+  margin-top: 0;
+}
+
+.exit-math-breakdown {
+  background: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+
+.exit-math-breakdown-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #4a5568;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+}
+
+.exit-math-breakdown table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+  font-size: 0.82rem;
+}
+
+.exit-math-breakdown th {
+  text-align: left;
+  font-weight: 600;
+  color: #718096;
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.exit-math-breakdown td {
+  padding: 0.3rem 0.4rem;
+  color: #1e293b;
+  border-bottom: 1px solid #edf2f7;
+}
+
+.exit-math-breakdown tr:last-child td {
+  border-bottom: none;
+}
+
+.exit-math-empty {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  font-style: italic;
+  text-align: center;
+  padding: 1rem 0.5rem;
+}
+
+/* ============================================================
+   App Footer (houses Exit Math toggle)
+   ============================================================ */
+.app-footer {
+  width: 100%;
+  padding: 1rem 1.5rem 1.25rem;
+  display: flex;
+  justify-content: center;
+  border-top: 1px solid #e2e8f0;
+  margin-top: 1.5rem;
+}
+
+.exit-math-toggle {
+  background: none;
+  border: 1px solid #e2e8f0;
+  color: #718096;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.exit-math-toggle:hover {
+  color: #4a5568;
+  border-color: #cbd5e0;
+  background: #f7fafc;
+}
+
+.exit-math-toggle[aria-pressed="true"] {
+  color: #635bff;
+  border-color: #c7c3ff;
+  background: #f5f4ff;
 }

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -6,6 +6,8 @@ import ScenarioCard from './components/ScenarioCard'
 import Logo from './components/Logo'
 import GeometricBackground from './components/GeometricBackground'
 import NotificationContainer from './components/NotificationContainer'
+import ExitMathModule from './components/ExitMathModule'
+import AppFooter from './components/AppFooter'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
@@ -171,12 +173,12 @@ function App() {
           onUpdateCompany={updateCompany}
         />
         
-        <div className="top-row">
-          <InputForm 
+        <div className={`top-row${companies[activeCompany]?.showExitMath ? ' with-exit-math' : ''}`}>
+          <InputForm
             company={companies[activeCompany]}
             onUpdate={(data) => updateCompany(activeCompany, data)}
           />
-          
+
           <div className="base-result">
             {scenarios.length > 0 && (
               <ScenarioCard
@@ -192,8 +194,17 @@ function App() {
               />
             )}
           </div>
+
+          {companies[activeCompany]?.showExitMath && (
+            <ExitMathModule
+              baseScenario={scenarios[0]}
+              investorName={companies[activeCompany]?.investorName || 'US'}
+              exitMath={companies[activeCompany]?.exitMath}
+              onUpdate={(exitMath) => updateCompany(activeCompany, { exitMath })}
+            />
+          )}
         </div>
-        
+
         <div className="scenarios-rows">
           {scenarios.slice(1).map((scenario, index) => (
             <ScenarioCard
@@ -210,6 +221,11 @@ function App() {
           ))}
         </div>
       </main>
+
+      <AppFooter
+        showExitMath={companies[activeCompany]?.showExitMath || false}
+        onToggleExitMath={(v) => updateCompany(activeCompany, { showExitMath: v })}
+      />
     </div>
   )
 }

--- a/react-app/src/components/AppFooter.jsx
+++ b/react-app/src/components/AppFooter.jsx
@@ -1,0 +1,16 @@
+const AppFooter = ({ showExitMath, onToggleExitMath }) => {
+  return (
+    <footer className="app-footer">
+      <button
+        type="button"
+        className="exit-math-toggle"
+        onClick={() => onToggleExitMath(!showExitMath)}
+        aria-pressed={showExitMath}
+      >
+        {showExitMath ? '▼' : '▶'} Exit Math
+      </button>
+    </footer>
+  )
+}
+
+export default AppFooter

--- a/react-app/src/components/ExitMathModule.jsx
+++ b/react-app/src/components/ExitMathModule.jsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from 'react'
+import { calculateExitReturn, resolveDilutions } from '../utils/exitMath'
+
+const DEFAULT_EXIT = {
+  exitValuation: 5000, // $5B in $M
+  numRounds: 3,
+  uniformDilution: 20,
+  perRoundOverrides: [],
+}
+
+function formatMoney(valueM) {
+  if (!Number.isFinite(valueM)) return '—'
+  if (Math.abs(valueM) >= 1000) {
+    return `$${(valueM / 1000).toFixed(2)}B`
+  }
+  return `$${valueM.toFixed(2)}M`
+}
+
+const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate }) => {
+  const [showOverrides, setShowOverrides] = useState(false)
+
+  const state = {
+    ...DEFAULT_EXIT,
+    ...(exitMath || {}),
+  }
+  const { exitValuation, numRounds, uniformDilution } = state
+  const perRoundOverrides = Array.isArray(state.perRoundOverrides) ? state.perRoundOverrides : []
+
+  const initialCheck = baseScenario?.combinedInvestor?.totalNewInvestment ?? baseScenario?.investorAmount ?? 0
+  const currentOwnership = baseScenario?.combinedInvestor?.totalOwnership ?? baseScenario?.investorPercent ?? 0
+
+  const dilutions = useMemo(
+    () => resolveDilutions(numRounds, uniformDilution, perRoundOverrides),
+    [numRounds, uniformDilution, perRoundOverrides]
+  )
+
+  const { finalOwnership, exitProceeds, moic, perRound } = useMemo(
+    () => calculateExitReturn({ initialCheck, currentOwnership, dilutions, exitValuation }),
+    [initialCheck, currentOwnership, dilutions, exitValuation]
+  )
+
+  const update = (patch) => {
+    if (onUpdate) onUpdate({ ...state, ...patch })
+  }
+
+  const handleNumRoundsChange = (raw) => {
+    const n = Math.max(0, Math.min(10, Math.floor(Number(raw) || 0)))
+    const trimmed = (perRoundOverrides || []).slice(0, n)
+    while (trimmed.length < n) trimmed.push(null)
+    update({ numRounds: n, perRoundOverrides: trimmed })
+  }
+
+  const handleOverrideChange = (i, raw) => {
+    const next = [...perRoundOverrides]
+    while (next.length <= i) next.push(null)
+    if (raw === '' || raw === null || raw === undefined) {
+      next[i] = null
+    } else {
+      const n = Number(raw)
+      next[i] = Number.isFinite(n) ? n : null
+    }
+    update({ perRoundOverrides: next })
+  }
+
+  const resetOverrides = () => {
+    update({ perRoundOverrides: [] })
+  }
+
+  const hasData = baseScenario && initialCheck > 0
+
+  return (
+    <div className="exit-math-module">
+      <div className="exit-math-header">
+        <h3>Exit Math</h3>
+        <span className="exit-math-subtitle">{investorName} returns at exit</span>
+      </div>
+
+      <div className="exit-math-inputs">
+        <div className="input-group">
+          <label>Exit Valuation ($M)</label>
+          <input
+            type="number"
+            min="0"
+            step="100"
+            value={exitValuation}
+            onChange={(e) => update({ exitValuation: Number(e.target.value) || 0 })}
+          />
+          <span className="exit-math-hint">{formatMoney(exitValuation)}</span>
+        </div>
+
+        <div className="exit-math-input-row">
+          <div className="input-group">
+            <label># Rounds</label>
+            <input
+              type="number"
+              min="0"
+              max="10"
+              step="1"
+              value={numRounds}
+              onChange={(e) => handleNumRoundsChange(e.target.value)}
+            />
+          </div>
+
+          <div className="input-group">
+            <label>Dilution / Round (%)</label>
+            <input
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              value={uniformDilution}
+              onChange={(e) => update({ uniformDilution: Number(e.target.value) || 0 })}
+            />
+          </div>
+        </div>
+
+        {numRounds > 0 && (
+          <div className="exit-math-overrides">
+            <button
+              type="button"
+              className="toggle-advanced-btn"
+              onClick={() => setShowOverrides((v) => !v)}
+            >
+              {showOverrides ? '▼' : '▶'} Per-round overrides
+            </button>
+            {showOverrides && (
+              <div className="exit-math-overrides-grid">
+                {Array.from({ length: numRounds }).map((_, i) => (
+                  <div key={i} className="exit-math-override-row">
+                    <label>Round {i + 1}</label>
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="1"
+                      placeholder={`${uniformDilution}`}
+                      value={perRoundOverrides[i] ?? ''}
+                      onChange={(e) => handleOverrideChange(i, e.target.value)}
+                    />
+                    <span className="exit-math-override-unit">%</span>
+                  </div>
+                ))}
+                <button type="button" className="exit-math-reset-btn" onClick={resetOverrides}>
+                  Reset to uniform
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {hasData ? (
+        <>
+          <div className="investor-summary exit-math-summary">
+            <div className="investor-summary-header">Projection</div>
+            <div className="analytics-row">
+              <span className="analytics-label">Initial check</span>
+              <span className="analytics-value">{formatMoney(initialCheck)}</span>
+            </div>
+            <div className="analytics-row">
+              <span className="analytics-label">Starting ownership</span>
+              <span className="analytics-value">{currentOwnership.toFixed(2)}%</span>
+            </div>
+            <div className="analytics-row">
+              <span className="analytics-label">Final ownership</span>
+              <span className="analytics-value">{finalOwnership.toFixed(2)}%</span>
+            </div>
+            <div className="analytics-row">
+              <span className="analytics-label">Exit proceeds</span>
+              <span className="analytics-value">{formatMoney(exitProceeds)}</span>
+            </div>
+            <div className="analytics-row investor-summary-total">
+              <span className="analytics-label">MOIC</span>
+              <span className="analytics-value">{moic.toFixed(2)}x</span>
+            </div>
+          </div>
+
+          {perRound.length > 0 && (
+            <div className="exit-math-breakdown">
+              <div className="exit-math-breakdown-header">Dilution path</div>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Round</th>
+                    <th>Dilution</th>
+                    <th>Ownership</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {perRound.map((r) => (
+                    <tr key={r.round}>
+                      <td>R{r.round}</td>
+                      <td>{(r.dilution * 100).toFixed(1)}%</td>
+                      <td>{r.ownership.toFixed(2)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="exit-math-empty">
+          Enter a valid base scenario to see exit math.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ExitMathModule

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -107,6 +107,15 @@ export function createDefaultCompany(companyName = 'New Company') {
     step2InvestorPortion: 0,
     step2OtherPortion: 0,
 
+    // Exit Math module (local exploration tool; not permalinked)
+    showExitMath: false,
+    exitMath: {
+      exitValuation: 5000,
+      numRounds: 3,
+      uniformDilution: 20,
+      perRoundOverrides: []
+    },
+
     // New multi-party structures
     priorInvestors: [
       createPriorInvestor('Previous Investors', 15, true) // Default with pro-rata rights
@@ -182,6 +191,17 @@ export function migrateLegacyCompany(legacyCompany) {
   if (migrated.step2Amount === undefined) migrated.step2Amount = 0
   if (migrated.step2InvestorPortion === undefined) migrated.step2InvestorPortion = 0
   if (migrated.step2OtherPortion === undefined) migrated.step2OtherPortion = 0
+
+  // Ensure Exit Math fields exist
+  if (migrated.showExitMath === undefined) migrated.showExitMath = false
+  if (!migrated.exitMath || typeof migrated.exitMath !== 'object') {
+    migrated.exitMath = {
+      exitValuation: 5000,
+      numRounds: 3,
+      uniformDilution: 20,
+      perRoundOverrides: []
+    }
+  }
 
   return migrated
 }

--- a/react-app/src/utils/exitMath.js
+++ b/react-app/src/utils/exitMath.js
@@ -1,0 +1,66 @@
+/**
+ * Exit math: project an investor's current check and ownership forward through
+ * N rounds of dilution to a final exit valuation, and compute MOIC.
+ *
+ * All dollar values are in millions ($M) to match the rest of the app.
+ */
+
+/**
+ * Resolve per-round dilution decimals from a uniform default and optional overrides.
+ * @param {number} numRounds - integer >= 0
+ * @param {number} uniformDilutionPercent - e.g. 20 for 20%
+ * @param {Array<number|null>} overridesPercent - per-round % overrides; null/undefined = use uniform
+ * @returns {Array<number>} array of length numRounds, decimals in [0, 1]
+ */
+export function resolveDilutions(numRounds, uniformDilutionPercent, overridesPercent = []) {
+  const n = Math.max(0, Math.floor(Number(numRounds) || 0))
+  const uniform = clampPercent(uniformDilutionPercent)
+  const result = []
+  for (let i = 0; i < n; i++) {
+    const raw = overridesPercent[i]
+    const hasOverride = raw !== null && raw !== undefined && raw !== '' && !Number.isNaN(Number(raw))
+    const pct = hasOverride ? clampPercent(raw) : uniform
+    result.push(pct / 100)
+  }
+  return result
+}
+
+function clampPercent(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 0
+  return Math.max(0, Math.min(100, n))
+}
+
+/**
+ * Compute exit economics for a given investor position.
+ * @param {Object} args
+ * @param {number} args.initialCheck - initial investment in $M
+ * @param {number} args.currentOwnership - current ownership as a percentage (e.g. 21.15)
+ * @param {Array<number>} args.dilutions - per-round dilutions as decimals (e.g. [0.2, 0.2, 0.2])
+ * @param {number} args.exitValuation - exit valuation in $M
+ * @returns {{finalOwnership:number, exitProceeds:number, moic:number, perRound:Array<{round:number, dilution:number, ownership:number}>}}
+ */
+export function calculateExitReturn({ initialCheck, currentOwnership, dilutions, exitValuation }) {
+  const check = Number(initialCheck) || 0
+  const startOwnershipPct = Number(currentOwnership) || 0
+  const exitVal = Number(exitValuation) || 0
+  const safeDilutions = Array.isArray(dilutions) ? dilutions : []
+
+  let ownershipPct = startOwnershipPct
+  const perRound = []
+  safeDilutions.forEach((d, i) => {
+    const dec = Math.max(0, Math.min(1, Number(d) || 0))
+    ownershipPct = ownershipPct * (1 - dec)
+    perRound.push({
+      round: i + 1,
+      dilution: dec,
+      ownership: ownershipPct,
+    })
+  })
+
+  const finalOwnership = ownershipPct
+  const exitProceeds = (finalOwnership / 100) * exitVal
+  const moic = check > 0 ? exitProceeds / check : 0
+
+  return { finalOwnership, exitProceeds, moic, perRound }
+}

--- a/react-app/src/utils/exitMath.test.js
+++ b/react-app/src/utils/exitMath.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { calculateExitReturn, resolveDilutions } from './exitMath'
+
+describe('resolveDilutions', () => {
+  it('produces uniform decimals when no overrides', () => {
+    expect(resolveDilutions(3, 20, [])).toEqual([0.2, 0.2, 0.2])
+  })
+
+  it('applies per-round overrides where present', () => {
+    expect(resolveDilutions(3, 20, [null, 30, null])).toEqual([0.2, 0.3, 0.2])
+  })
+
+  it('treats empty string as no override', () => {
+    expect(resolveDilutions(2, 15, ['', 25])).toEqual([0.15, 0.25])
+  })
+
+  it('clamps out-of-range values', () => {
+    expect(resolveDilutions(2, 150, [-5, null])).toEqual([0, 1])
+  })
+
+  it('returns empty array when numRounds <= 0', () => {
+    expect(resolveDilutions(0, 20, [])).toEqual([])
+    expect(resolveDilutions(-2, 20, [])).toEqual([])
+  })
+})
+
+describe('calculateExitReturn', () => {
+  it('3 rounds of 20% dilution on a $5B exit', () => {
+    const result = calculateExitReturn({
+      initialCheck: 2.75, // $2.75M
+      currentOwnership: 21.15, // 21.15%
+      dilutions: [0.2, 0.2, 0.2],
+      exitValuation: 5000, // $5B in $M
+    })
+    // 21.15 * 0.8^3 = 21.15 * 0.512 = 10.8288
+    expect(result.finalOwnership).toBeCloseTo(10.8288, 4)
+    // exitProceeds = 10.8288% * $5000M = $541.44M
+    expect(result.exitProceeds).toBeCloseTo(541.44, 2)
+    // moic = 541.44 / 2.75 ≈ 196.88x
+    expect(result.moic).toBeCloseTo(196.8873, 3)
+    expect(result.perRound).toHaveLength(3)
+    expect(result.perRound[2].ownership).toBeCloseTo(10.8288, 4)
+  })
+
+  it('zero dilution preserves ownership', () => {
+    const result = calculateExitReturn({
+      initialCheck: 1,
+      currentOwnership: 10,
+      dilutions: [0, 0],
+      exitValuation: 1000,
+    })
+    expect(result.finalOwnership).toBe(10)
+    expect(result.exitProceeds).toBe(100)
+    expect(result.moic).toBe(100)
+  })
+
+  it('uneven dilutions chain correctly', () => {
+    const result = calculateExitReturn({
+      initialCheck: 5,
+      currentOwnership: 20,
+      dilutions: [0.1, 0.25, 0.5],
+      exitValuation: 2000,
+    })
+    // 20 * 0.9 * 0.75 * 0.5 = 6.75
+    expect(result.finalOwnership).toBeCloseTo(6.75, 4)
+    // exitProceeds = 6.75% * 2000 = 135
+    expect(result.exitProceeds).toBeCloseTo(135, 4)
+    // moic = 135 / 5 = 27
+    expect(result.moic).toBeCloseTo(27, 4)
+  })
+
+  it('zero initial check returns MOIC = 0 without divide-by-zero', () => {
+    const result = calculateExitReturn({
+      initialCheck: 0,
+      currentOwnership: 10,
+      dilutions: [0.2],
+      exitValuation: 1000,
+    })
+    expect(result.moic).toBe(0)
+    expect(Number.isFinite(result.moic)).toBe(true)
+  })
+
+  it('empty dilutions means no rounds applied', () => {
+    const result = calculateExitReturn({
+      initialCheck: 2,
+      currentOwnership: 15,
+      dilutions: [],
+      exitValuation: 1000,
+    })
+    expect(result.finalOwnership).toBe(15)
+    expect(result.exitProceeds).toBe(150)
+    expect(result.moic).toBe(75)
+    expect(result.perRound).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- **Exit Math module**: new third column (toggled from a page footer) that projects the base-case investor check and ownership forward through N rounds of dilution at a given exit valuation and shows final ownership, exit proceeds, and MOIC, with an optional per-round override grid. State is intentionally excluded from share permalinks (local exploration only). Pure calc in `utils/exitMath.js` with full test coverage.
- **Conductor run script**: `.conductor/run.sh` now forwards `\$CONDUCTOR_PORT` to Vite with `--strictPort --host` so parallel workspaces don't collide on 5173, and falls back to 5173 outside Conductor.
- **AGENTS.md**: documents repo layout, the multi-party calc engine, code conventions (single stylesheet, whitelisted permalinks, \$M units), Conductor env vars, and the commit-and-push default so future agents skip the same discovery.

## Test plan
- [x] `npx vitest run` — 370+ tests pass (including 10 new exitMath tests)
- [x] Dev server bound to \$CONDUCTOR_PORT returns HTTP 200
- [x] Toggling Exit Math renders the 3rd column; defaults (\$5B × 3 rounds × 20%) yield MOIC 196.92x in-browser
- [ ] Verify module stays closed and off-URL after loading a shared permalink

🤖 Generated with [Claude Code](https://claude.com/claude-code)