### PR TITLE
Fix form input overlap and label crowding in advanced-section

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1295,7 +1295,7 @@ body {
 
 /* Advanced Features Styling */
 .advanced-section .input-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
 }
 
@@ -1390,7 +1390,7 @@ body {
 
 .safe-inputs {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
@@ -1525,7 +1525,7 @@ body {
 
 .investor-inputs, .founder-inputs {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
@@ -1922,7 +1922,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 }
 
 .esop-section .input-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
 }
 

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1560,7 +1560,7 @@ body {
 
 /* Adjust form input spacing for different contexts */
 .input-grid .form-input-field {
-  padding-left: 140px;
+  padding-left: 155px;
 }
 
 .safe-inputs .form-input-field,


### PR DESCRIPTION
## Summary
- Bump four `minmax(180px, 1fr)` grid declarations (`.advanced-section .input-grid`, `.safe-inputs`, `.investor-inputs`/`.founder-inputs`, `.esop-section .input-grid`) to `minmax(200px, 1fr)` so grid columns match `.form-input-wrapper { min-width: 200px }` — fixes a 20px overflow where wrappers escaped their grid cells (most visible in the ESOP Current/Target fields at desktop widths).
- Bump `.input-grid .form-input-field` padding-left from 140px → 155px so long labels like "Post-Money Valuation" get a clean ~17px gap before the `$` prefix instead of butting up against it.

## Test plan
- [x] `npx vitest run` — 308 tests pass
- [x] Visual pass at 1440px: ESOP, SAFE, Prior Investors, Founders, 2-Step Round — no overlap, labels have breathing room
- [x] Overflow scan in DevTools — zero form-input wrappers escape their parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)