### PR TITLE
ESOP: model granted vs available pool, polish input section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .vercel
 *.log
 .gstack/
+.claude/
+.playwright-mcp/
+/esop-*.png

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1569,14 +1569,6 @@ body {
   padding-left: 80px;
 }
 
-.esop-section .input-grid .form-input-label {
-  max-width: 80px;
-}
-
-.esop-section .input-grid .form-input-field {
-  padding-left: 95px;
-}
-
 .pro-rata-allocation .form-input-label {
   max-width: 75px;
 }
@@ -1909,21 +1901,45 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 /* ESOP Section Styles */
 .esop-section {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid #e2e8f0;
+  margin-top: var(--space-6);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
 }
 
 .esop-section h5 {
-  font-size: 1rem;
+  font-size: var(--text-md);
   font-weight: 600;
-  color: #2d3748;
-  margin-bottom: 1rem;
+  color: var(--color-fg);
+  margin: 0 0 var(--space-2);
 }
 
-.esop-section .input-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
+.esop-subtitle {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-fg-subtle);
+  line-height: 1.5;
+}
+
+.esop-subtitle em {
+  color: var(--color-fg-muted);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.esop-input-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-4);
+}
+
+.esop-validation-error {
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: #fff5f5;
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-sm);
+  color: var(--color-danger-hover);
+  font-size: var(--text-sm);
+  line-height: 1.4;
 }
 
 .esop-timing-section {
@@ -1943,53 +1959,47 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   letter-spacing: 0.01em;
 }
 
-.esop-timing-options {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.radio-option {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 4px;
-  transition: background-color 0.2s ease;
-}
-
-.radio-option:hover {
-  background: #edf2f7;
-}
-
-.radio-option input[type="radio"] {
-  margin-top: 0.15rem;
-  cursor: pointer;
-}
-
-.radio-label {
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.radio-label strong {
-  color: #2d3748;
-}
-
-.esop-timing-info {
-  margin-top: var(--space-3);
-  padding: var(--space-3);
-  background: var(--color-accent-soft);
+.esop-timing-toggle {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  border-left: 3px solid var(--color-accent);
+  padding: 2px;
+  gap: 2px;
 }
 
-.timing-explanation {
-  margin: 0;
+.esop-timing-option {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: var(--space-2) var(--space-4);
   font-size: var(--text-sm);
-  color: var(--color-accent-hover);
-  line-height: 1.4;
+  font-weight: 500;
+  color: var(--color-fg-muted);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.esop-timing-option:hover {
+  color: var(--color-fg);
+}
+
+.esop-timing-option.active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.esop-timing-option:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.esop-timing-explanation {
+  margin: var(--space-3) 0 0;
+  font-size: var(--text-sm);
+  color: var(--color-fg-muted);
+  line-height: 1.5;
 }
 
 @media (max-width: 768px) {

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -621,10 +621,13 @@ const InputForm = ({ company, onUpdate }) => {
 
           <div className="esop-section">
             <h5>Employee Stock Option Pool (ESOP)</h5>
-            
-            <div className="input-grid">
+            <p className="esop-subtitle">
+              Total pool = Granted + Available. VCs typically negotiate the <em>available</em> slice post-close.
+            </p>
+
+            <div className="input-grid esop-input-grid">
               <FormInput
-                label="Current ESOP"
+                label="Current Pool"
                 type="number"
                 value={values.currentEsopPercent}
                 onChange={(value) => handleChange('currentEsopPercent', value)}
@@ -636,7 +639,19 @@ const InputForm = ({ company, onUpdate }) => {
               />
 
               <FormInput
-                label="Target ESOP"
+                label="Already Granted"
+                type="number"
+                value={values.grantedEsopPercent || 0}
+                onChange={(value) => handleChange('grantedEsopPercent', value)}
+                suffix="%"
+                step="0.01"
+                min="0"
+                max="100"
+                clearable={true}
+              />
+
+              <FormInput
+                label="Target Available"
                 type="number"
                 value={values.targetEsopPercent}
                 onChange={(value) => handleChange('targetEsopPercent', value)}
@@ -648,51 +663,41 @@ const InputForm = ({ company, onUpdate }) => {
               />
             </div>
 
-            {/* ESOP Timing Selection */}
-            {values.targetEsopPercent > 0 && values.currentEsopPercent >= 0 && (
+            {Number(values.grantedEsopPercent || 0) > Number(values.currentEsopPercent || 0) && (
+              <div className="esop-validation-error">
+                Already granted ({Number(values.grantedEsopPercent).toFixed(2)}%) exceeds current pool ({Number(values.currentEsopPercent).toFixed(2)}%).
+              </div>
+            )}
+
+            {values.targetEsopPercent > 0 && (
               <div className="esop-timing-section">
-                <label className="section-label">ESOP Pool Timing</label>
-                <div className="esop-timing-options">
-                  <label className="radio-option">
-                    <input
-                      type="radio"
-                      name="esop-timing"
-                      value="pre-close"
-                      checked={values.esopTiming === 'pre-close'}
-                      onChange={(e) => handleChange('esopTiming', e.target.value)}
-                    />
-                    <span className="radio-label">
-                      <strong>Pre-Close</strong> - Dilutes existing shareholders only
-                    </span>
-                  </label>
-                  <label className="radio-option">
-                    <input
-                      type="radio"
-                      name="esop-timing"
-                      value="post-close"
-                      checked={values.esopTiming === 'post-close'}
-                      onChange={(e) => handleChange('esopTiming', e.target.value)}
-                    />
-                    <span className="radio-label">
-                      <strong>Post-Close</strong> - Dilutes all shareholders including new investors
-                    </span>
-                  </label>
+                <label className="section-label">Top-up timing</label>
+                <div className="esop-timing-toggle" role="tablist">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={values.esopTiming === 'pre-close'}
+                    className={`esop-timing-option ${values.esopTiming === 'pre-close' ? 'active' : ''}`}
+                    onClick={() => handleChange('esopTiming', 'pre-close')}
+                  >
+                    Pre-Close
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={values.esopTiming === 'post-close'}
+                    className={`esop-timing-option ${values.esopTiming === 'post-close' ? 'active' : ''}`}
+                    onClick={() => handleChange('esopTiming', 'post-close')}
+                  >
+                    Post-Close
+                  </button>
                 </div>
-                
-                {/* Info about the difference */}
-                <div className="esop-timing-info">
-                  {values.esopTiming === 'pre-close' ? (
-                    <p className="timing-explanation">
-                      💡 ESOP shares are allocated before the investment. This affects only existing shareholders 
-                      (founders, employees, previous investors) and uses iterative dilution calculations.
-                    </p>
-                  ) : (
-                    <p className="timing-explanation">
-                      💡 ESOP shares are allocated after the investment. All shareholders including 
-                      the new investors share the dilution proportionally.
-                    </p>
-                  )}
-                </div>
+
+                <p className="esop-timing-explanation">
+                  {values.esopTiming === 'pre-close'
+                    ? 'Top-up happens before the round. Dilutes founders, prior investors, and granted ESOP — not new investors.'
+                    : 'Top-up happens after the round. Dilutes everyone proportionally, including new investors.'}
+                </p>
               </div>
             )}
           </div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -440,31 +440,47 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
         
         {/* ESOP */}
         {showAdvanced && scenario.finalEsopPercent > 0 && (
-          <div className="table-row">
-            <div className="label">ESOP Pool</div>
-            <div className="amount">
-              {(() => {
-                // Calculate ESOP dilution if there was a pre-existing ESOP
-                if (scenario.currentEsopPercent > 0) {
-                  const esopDilution = scenario.currentEsopPercent - scenario.finalEsopPercent
-                  if (Math.abs(esopDilution) > 0.01) {
-                    return (
-                      <span className={esopDilution > 0 ? 'amount-negative' : 'amount-positive'}>
-                        {esopDilution > 0 ? `-${esopDilution.toFixed(1)}%` : `+${Math.abs(esopDilution).toFixed(1)}%`}
-                      </span>
-                    )
+          <>
+            <div className="table-row">
+              <div className="label">ESOP Pool</div>
+              <div className="amount">
+                {(() => {
+                  // Calculate ESOP dilution if there was a pre-existing ESOP
+                  if (scenario.currentEsopPercent > 0) {
+                    const esopDilution = scenario.currentEsopPercent - scenario.finalEsopPercent
+                    if (Math.abs(esopDilution) > 0.01) {
+                      return (
+                        <span className={esopDilution > 0 ? 'amount-negative' : 'amount-positive'}>
+                          {esopDilution > 0 ? `-${esopDilution.toFixed(1)}%` : `+${Math.abs(esopDilution).toFixed(1)}%`}
+                        </span>
+                      )
+                    }
                   }
-                }
-                // If ESOP increase, show positive change
-                if (scenario.esopIncrease > 0) {
-                  return <span className='amount-positive'>+{scenario.esopIncrease.toFixed(1)}%</span>
-                }
-                // Otherwise show neutral
-                return <span className='amount-neutral'>—</span>
-              })()}
+                  // If ESOP increase, show positive change
+                  if (scenario.esopIncrease > 0) {
+                    return <span className='amount-positive'>+{scenario.esopIncrease.toFixed(1)}%</span>
+                  }
+                  // Otherwise show neutral
+                  return <span className='amount-neutral'>—</span>
+                })()}
+              </div>
+              <div className="percent percent-bold">{formatPercent(scenario.finalEsopPercent)}</div>
             </div>
-            <div className="percent percent-bold">{formatPercent(scenario.finalEsopPercent)}</div>
-          </div>
+            {(scenario.grantedEsopPercent || 0) > 0 && (
+              <>
+                <div className="table-row sub-row">
+                  <div className="label">├─ Available</div>
+                  <div className="amount amount-neutral">unallocated</div>
+                  <div className="percent">{formatPercent(scenario.finalEsopAvailablePercent || 0)}</div>
+                </div>
+                <div className="table-row sub-row">
+                  <div className="label">└─ Granted</div>
+                  <div className="amount amount-neutral">issued</div>
+                  <div className="percent">{formatPercent(scenario.finalEsopGrantedPercent || 0)}</div>
+                </div>
+              </>
+            )}
+          </>
         )}
         
         {/* Total row */}

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -124,9 +124,10 @@ export function createDefaultCompany(companyName = 'New Company') {
       createFounder('Founder Team', 85) // Default founder ownership
     ],
     
-    // SAFE and ESOP support (unchanged)
+    // SAFE and ESOP support
     safes: [],
     currentEsopPercent: 0,
+    grantedEsopPercent: 0,
     targetEsopPercent: 0,
     esopTiming: 'pre-close',
     
@@ -195,6 +196,9 @@ export function migrateLegacyCompany(legacyCompany) {
   if (migrated.step2Amount === undefined) migrated.step2Amount = 0
   if (migrated.step2InvestorPortion === undefined) migrated.step2InvestorPortion = 0
   if (migrated.step2OtherPortion === undefined) migrated.step2OtherPortion = 0
+
+  // Ensure ESOP fields exist (grantedEsopPercent added after initial release)
+  if (migrated.grantedEsopPercent === undefined) migrated.grantedEsopPercent = 0
 
   // Ensure Exit Math fields exist
   if (migrated.showExitMath === undefined) migrated.showExitMath = false

--- a/react-app/src/utils/multiParty-calculations.test.js
+++ b/react-app/src/utils/multiParty-calculations.test.js
@@ -1229,4 +1229,148 @@ describe('Hand-computed scenario verification', () => {
       expect(r.totalOwnership + r.unknownOwnership).toBeCloseTo(100, 0)
     })
   })
+
+  describe('Scenario 13: Granted ESOP + pre-close top-up (user negotiation case)', () => {
+    // Company has 10% authorized pool, 2.5% already granted (7.5% available).
+    // New $3M round at $15M post = 20% dilution. Target 7% AVAILABLE post-close.
+    //
+    // available = 10 - 2.5 = 7.5
+    // naturalDilutedAvailable = 7.5 * (100-20)/100 = 6
+    // rawIncrease = 7 - 6 = 1
+    // denom = 1 - 7.5/100 = 0.925
+    // esopIncreasePreClose = 1 / 0.925 ≈ 1.08
+    //
+    // totalNewOwnership = 20 + 0 + 1.08 = 21.08
+    // Founders 90% → 90 * (100-21.08)/100 ≈ 71.03
+    // Granted 2.5% → 2.5 * (100-21.08)/100 ≈ 1.97
+    // Available = 7.5 * (100-21.08)/100 + 1.08 ≈ 5.92 + 1.08 = 7.00
+    // Round = 20% (unchanged, pre-close doesn't touch new investors)
+    const inputs = {
+      postMoneyVal: 15, roundSize: 3,
+      investorPortion: 2.5, otherPortion: 0.5,
+      showAdvanced: true,
+      priorInvestors: [],
+      founders: [{ id: 1, name: 'Founders', ownershipPercent: 90 }],
+      safes: [],
+      currentEsopPercent: 10, grantedEsopPercent: 2.5, targetEsopPercent: 7,
+      esopTiming: 'pre-close'
+    }
+
+    it('should compute pre-close top-up from available pool only', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.esopIncreasePreClose).toBeCloseTo(1.08, 1)
+      expect(r.esopIncreasePostClose).toBe(0)
+    })
+
+    it('should land at 7% available post-close', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.finalEsopAvailablePercent).toBeCloseTo(7, 1)
+    })
+
+    it('should preserve granted portion through natural dilution and top-up', () => {
+      const r = calculateEnhancedScenario(inputs)
+      // Granted diluted by round (20%) AND pre-close top-up (1.08%)
+      expect(r.finalEsopGrantedPercent).toBeCloseTo(1.97, 1)
+    })
+
+    it('should dilute founders by ~18.97% (round 18% + ~0.97% top-up cost)', () => {
+      const r = calculateEnhancedScenario(inputs)
+      const founders = r.founders[0]
+      expect(founders.postRoundPercent).toBeCloseTo(71.03, 1)
+      expect(founders.dilution).toBeCloseTo(18.97, 1)
+    })
+
+    it('should leave new investors at full 20% (pre-close doesn\'t touch round)', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.roundPercent).toBeCloseTo(20, 1)
+    })
+
+    it('should have finalEsopPercent = available + granted', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.finalEsopPercent).toBeCloseTo(
+        r.finalEsopAvailablePercent + r.finalEsopGrantedPercent,
+        1
+      )
+    })
+
+    it('should have all percentages summing to 100', () => {
+      const r = calculateEnhancedScenario(inputs)
+      const total = r.roundPercent + r.founders[0].postRoundPercent + r.finalEsopPercent
+      expect(total).toBeCloseTo(100, 1)
+    })
+  })
+
+  describe('Scenario 14: granted=0 backwards-compat matches legacy math', () => {
+    // With granted=0, everything should behave identically to the old engine.
+    const inputs = {
+      postMoneyVal: 15, roundSize: 3,
+      investorPortion: 2.5, otherPortion: 0.5,
+      showAdvanced: true,
+      priorInvestors: [],
+      founders: [{ id: 1, name: 'Founders', ownershipPercent: 90 }],
+      safes: [],
+      currentEsopPercent: 10, grantedEsopPercent: 0, targetEsopPercent: 15,
+      esopTiming: 'pre-close'
+    }
+
+    it('should behave identically whether granted is 0 or undefined', () => {
+      const withZero = calculateEnhancedScenario(inputs)
+      const withoutField = calculateEnhancedScenario({ ...inputs, grantedEsopPercent: undefined })
+      expect(withZero.finalEsopPercent).toBe(withoutField.finalEsopPercent)
+      expect(withZero.esopIncreasePreClose).toBe(withoutField.esopIncreasePreClose)
+      expect(withZero.founders[0].postRoundPercent).toBe(withoutField.founders[0].postRoundPercent)
+    })
+
+    it('should route entire current pool as available when granted=0', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.finalEsopGrantedPercent).toBe(0)
+      expect(r.finalEsopAvailablePercent).toBe(r.finalEsopPercent)
+    })
+  })
+
+  describe('Scenario 15: Granted ESOP with post-close top-up', () => {
+    // Same inputs as scenario 13 but post-close timing.
+    //
+    // available = 7.5, naturalDilutedAvailable = 6
+    // rawIncrease = 7 - 6 = 1
+    // denom = 1 - 6/100 = 0.94
+    // esopIncreasePostClose = 1 / 0.94 ≈ 1.064
+    //
+    // Everyone gets diluted by (100-1.064)/100 ≈ 0.9894:
+    //   Founders: (90*0.8) * 0.9894 ≈ 72 * 0.9894 ≈ 71.23
+    //   Granted: (2.5*0.8) * 0.9894 ≈ 2 * 0.9894 ≈ 1.98
+    //   Available: 6 * 0.9894 + 1.064 ≈ 5.94 + 1.064 = 7.00
+    //   Round: 20 * 0.9894 ≈ 19.79
+    const inputs = {
+      postMoneyVal: 15, roundSize: 3,
+      investorPortion: 2.5, otherPortion: 0.5,
+      showAdvanced: true,
+      priorInvestors: [],
+      founders: [{ id: 1, name: 'Founders', ownershipPercent: 90 }],
+      safes: [],
+      currentEsopPercent: 10, grantedEsopPercent: 2.5, targetEsopPercent: 7,
+      esopTiming: 'post-close'
+    }
+
+    it('should dilute new investors on post-close top-up', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.roundPercent).toBeCloseTo(19.79, 1)
+      expect(r.esopIncreasePostClose).toBeCloseTo(1.06, 1)
+    })
+
+    it('should land at 7% available post-close', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.finalEsopAvailablePercent).toBeCloseTo(7, 1)
+    })
+
+    it('should dilute granted by round then post-close top-up', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.finalEsopGrantedPercent).toBeCloseTo(1.98, 1)
+    })
+
+    it('should dilute founders less than pre-close (since round absorbs some)', () => {
+      const r = calculateEnhancedScenario(inputs)
+      expect(r.founders[0].postRoundPercent).toBeCloseTo(71.23, 1)
+    })
+  })
 })

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -181,35 +181,45 @@ function calculateSafeProRataAllocations(safeDetails, roundSize, investorName) {
 
 /**
  * Calculate ESOP dilution and timing effects
- * @param {number} currentEsopPercent - Current ESOP pool percentage
- * @param {number} targetEsopPercent - Target ESOP pool percentage after round
+ *
+ * The pool is split into two buckets: already-granted options (persist through
+ * the round as individual shareholders would) and available/unallocated pool
+ * (what VCs negotiate). The top-up formula only applies to the available bucket;
+ * target represents the target AVAILABLE pool post-round.
+ *
+ * @param {number} currentEsopPercent - Total current pool (granted + available), pre-round
+ * @param {number} grantedEsopPercent - Already-issued portion of the pool, pre-round
+ * @param {number} targetEsopPercent - Target AVAILABLE pool percentage post-round
  * @param {string} esopTiming - 'pre-close' or 'post-close'
- * @param {number} baseDilutionPercent - Total dilution from round + SAFEs (not including ESOP)
+ * @param {number} baseDilutionPercent - Total dilution from round + SAFEs (not including ESOP top-up)
  */
-function calculateEsopEffects(currentEsopPercent, targetEsopPercent, esopTiming, baseDilutionPercent) {
+function calculateEsopEffects(currentEsopPercent, grantedEsopPercent, targetEsopPercent, esopTiming, baseDilutionPercent) {
+  const availablePercent = Math.max(0, rp(currentEsopPercent - grantedEsopPercent))
+  const naturalDilutedAvailable = rp(availablePercent * (100 - baseDilutionPercent) / 100)
+  const naturalDilutedGranted = rp(grantedEsopPercent * (100 - baseDilutionPercent) / 100)
+
   let esopIncrease = 0
   let esopIncreasePreClose = 0
   let esopIncreasePostClose = 0
-  let finalEsopPercent = targetEsopPercent
+  let finalEsopAvailablePercent = targetEsopPercent
+  let finalEsopGrantedPercent = naturalDilutedGranted
 
   if (targetEsopPercent > 0) {
-    const naturalDilutedEsop = rp(currentEsopPercent * (100 - baseDilutionPercent) / 100)
-
-    if (targetEsopPercent > naturalDilutedEsop) {
-      const rawIncrease = targetEsopPercent - naturalDilutedEsop
+    if (targetEsopPercent > naturalDilutedAvailable) {
+      const rawIncrease = targetEsopPercent - naturalDilutedAvailable
 
       if (esopTiming === 'pre-close') {
-        // Pre-close: ESOP increase dilutes existing ESOP pool too
-        // Solve: currentEsop * (100 - baseDilution - X) / 100 + X = target
-        const denominator = 1 - currentEsopPercent / 100
+        // Pre-close: top-up dilutes the available pool, granted, founders, priors — not new investors
+        // Solve: available * (100 - baseDilution - X) / 100 + X = target
+        const denominator = 1 - availablePercent / 100
         esopIncrease = denominator > 0.01
           ? rp(rawIncrease / denominator)
           : rawIncrease
         esopIncreasePreClose = esopIncrease
       } else {
-        // Post-close: ESOP increase dilutes everyone including already-diluted ESOP
-        // Solve: naturalDiluted * (100 - X) / 100 + X = target
-        const denominator = 1 - naturalDilutedEsop / 100
+        // Post-close: top-up dilutes everyone including already-diluted pool
+        // Solve: naturalDilutedAvailable * (100 - X) / 100 + X = target
+        const denominator = 1 - naturalDilutedAvailable / 100
         esopIncrease = denominator > 0.01
           ? rp(rawIncrease / denominator)
           : rawIncrease
@@ -221,16 +231,29 @@ function calculateEsopEffects(currentEsopPercent, targetEsopPercent, esopTiming,
       esopIncrease = Math.min(esopIncrease, maxIncrease)
       esopIncreasePreClose = Math.min(esopIncreasePreClose, maxIncrease)
       esopIncreasePostClose = Math.min(esopIncreasePostClose, maxIncrease)
+
+      // Granted portion dilutes like a pre-round shareholder
+      if (esopTiming === 'pre-close') {
+        finalEsopGrantedPercent = rp(grantedEsopPercent * (100 - baseDilutionPercent - esopIncreasePreClose) / 100)
+      } else {
+        finalEsopGrantedPercent = rp(naturalDilutedGranted * (100 - esopIncreasePostClose) / 100)
+      }
     }
-  } else if (targetEsopPercent === 0 && currentEsopPercent > 0) {
-    finalEsopPercent = rp(currentEsopPercent * (100 - baseDilutionPercent) / 100)
+    // else: natural dilution already reaches/exceeds target — treat final available as target
+  } else {
+    // No target specified: available pool just dilutes naturally
+    finalEsopAvailablePercent = naturalDilutedAvailable
   }
+
+  const finalEsopPercent = rp(finalEsopAvailablePercent + finalEsopGrantedPercent)
 
   return {
     esopIncrease,
     esopIncreasePreClose,
     esopIncreasePostClose,
-    finalEsopPercent
+    finalEsopPercent,
+    finalEsopAvailablePercent,
+    finalEsopGrantedPercent
   }
 }
 
@@ -257,6 +280,7 @@ function calculateTwoStepScenario(inputs) {
     founders = [],
     safes = [],
     currentEsopPercent = 0,
+    grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close'
   } = migratedInputs
@@ -272,6 +296,7 @@ function calculateTwoStepScenario(inputs) {
   const effectiveFounders = showAdvanced ? founders : []
   const effectiveSafes = showAdvanced ? safes : []
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
+  const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
 
   // --- SAFE conversions at step 1 pre-money ---
@@ -333,7 +358,7 @@ function calculateTwoStepScenario(inputs) {
 
   // --- ESOP ---
   const baseDilutionPercent = totalRoundPercent + safeFinalPercent
-  const esopCalc = calculateEsopEffects(effectiveCurrentEsopPercent, effectiveTargetEsopPercent, esopTiming, baseDilutionPercent)
+  const esopCalc = calculateEsopEffects(effectiveCurrentEsopPercent, effectiveGrantedEsopPercent, effectiveTargetEsopPercent, esopTiming, baseDilutionPercent)
 
   // --- Prior investors ---
   const postRoundPriorInvestors = effectivePriorInvestors.map(investor => {
@@ -528,8 +553,11 @@ function calculateTwoStepScenario(inputs) {
 
     // ESOP details
     currentEsopPercent: effectiveCurrentEsopPercent,
+    grantedEsopPercent: effectiveGrantedEsopPercent,
     targetEsopPercent: effectiveTargetEsopPercent,
     finalEsopPercent: esopCalc.finalEsopPercent,
+    finalEsopAvailablePercent: esopCalc.finalEsopAvailablePercent,
+    finalEsopGrantedPercent: esopCalc.finalEsopGrantedPercent,
     esopIncrease: esopCalc.esopIncrease,
     esopIncreasePreClose: esopCalc.esopIncreasePreClose,
     esopIncreasePostClose: esopCalc.esopIncreasePostClose,
@@ -624,18 +652,20 @@ export function calculateEnhancedScenario(inputs) {
     // New multi-party structures
     priorInvestors = [],
     founders = [],
-    // SAFE and ESOP (unchanged)
+    // SAFE and ESOP
     safes = [],
     currentEsopPercent = 0,
+    grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close'
   } = migratedInputs
-  
+
   // When showAdvanced is false, ignore all advanced inputs
   const effectivePriorInvestors = showAdvanced ? priorInvestors : []
   const effectiveFounders = showAdvanced ? founders : []
   const effectiveSafes = showAdvanced ? safes : []
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
+  const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
   
   // Check if pre-round ownership exceeds 100% and return error if so
@@ -700,7 +730,7 @@ export function calculateEnhancedScenario(inputs) {
 
   // Calculate ESOP effects — pass round + SAFEs as the base dilution
   const baseDilutionPercent = roundPercent + safeCalc.totalSafePercent
-  const esopCalc = calculateEsopEffects(effectiveCurrentEsopPercent, effectiveTargetEsopPercent, esopTiming, baseDilutionPercent)
+  const esopCalc = calculateEsopEffects(effectiveCurrentEsopPercent, effectiveGrantedEsopPercent, effectiveTargetEsopPercent, esopTiming, baseDilutionPercent)
 
   // Adjust round percentage for post-close ESOP dilution
   let finalRoundPercent = roundPercent
@@ -899,8 +929,11 @@ export function calculateEnhancedScenario(inputs) {
     
     // ESOP details
     currentEsopPercent: effectiveCurrentEsopPercent || 0,
+    grantedEsopPercent: effectiveGrantedEsopPercent || 0,
     targetEsopPercent: effectiveTargetEsopPercent || 0,
     finalEsopPercent: esopCalc.finalEsopPercent || 0,
+    finalEsopAvailablePercent: esopCalc.finalEsopAvailablePercent || 0,
+    finalEsopGrantedPercent: esopCalc.finalEsopGrantedPercent || 0,
     esopIncrease: esopCalc.esopIncrease || 0,
     esopIncreasePreClose: esopCalc.esopIncreasePreClose || 0,
     esopIncreasePostClose: esopCalc.esopIncreasePostClose || 0,

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -20,6 +20,7 @@ const URL_PARAM_MAP = {
   founders: 'f',
   // ESOP modeling
   currentEsopPercent: 'ce',
+  grantedEsopPercent: 'ge',
   targetEsopPercent: 'te',
   esopTiming: 'et',
   percentPrecision: 'pp',
@@ -156,7 +157,7 @@ export function encodeScenarioToURL(scenarioData) {
       }
       
       // Only include non-zero values for optional fields
-      if (['proRataPercent', 'currentEsopPercent', 'targetEsopPercent',
+      if (['proRataPercent', 'currentEsopPercent', 'grantedEsopPercent', 'targetEsopPercent',
            'step2PostMoney', 'step2Amount', 'step2InvestorPortion', 'step2OtherPortion'].includes(field) && value === 0) {
         return
       }
@@ -209,6 +210,7 @@ export function decodeScenarioFromURL(urlParams) {
       founders: [],
       // ESOP defaults
       currentEsopPercent: 0,
+      grantedEsopPercent: 0,
       targetEsopPercent: 0,
       esopTiming: 'pre-close',
       percentPrecision: 2,
@@ -303,7 +305,8 @@ export function decodeScenarioFromURL(urlParams) {
 
     // Set showAdvanced to true if any advanced features are present (but don't override explicit setting)
     if (!params.has('adv') && (scenarioData.proRataPercent > 0 || scenarioData.preRoundFounderOwnership > 0 ||
-        (scenarioData.safes && scenarioData.safes.length > 0) || scenarioData.currentEsopPercent > 0 || 
+        (scenarioData.safes && scenarioData.safes.length > 0) || scenarioData.currentEsopPercent > 0 ||
+        scenarioData.grantedEsopPercent > 0 ||
         scenarioData.targetEsopPercent > 0 || (scenarioData.priorInvestors && scenarioData.priorInvestors.length > 0) ||
         (scenarioData.founders && scenarioData.founders.length > 0))) {
       scenarioData.showAdvanced = true


### PR DESCRIPTION
## Summary
Splits the ESOP pool into **granted** (persists through the round like a pre-round shareholder) and **available** (what VCs actually negotiate). `targetEsopPercent` now means target available post-close; `grantedEsopPercent` is new (default 0, fully backwards-compatible). The old model treated the whole pool as one bucket, which artificially boosted founder equity in any scenario with issued grants.

Also reworks the ESOP input section: three clearer inputs with subtitle and help text, segmented Pre-Close / Post-Close toggle replacing stacked radios, tightened explanation copy, inline validation when granted > current, and removed cramped label overrides so the section matches the rest of the advanced form.

## Test plan
- [x] Unit tests: 13 new cases, 321 total passing (scenarios 13–15 cover user's negotiation case pre/post-close plus granted=0 backwards-compat)
- [x] Browser verified: with current=10, granted=2.5, target=7, pre-close, 20% round → founders 71.03%, available 7.00%, granted 1.97%, new investors 20%
- [x] Post-close variant verified: new investors diluted to 19.79%, granted 1.98%, available 7.00%
- [x] Validation error shows when granted > current

🤖 Generated with [Claude Code](https://claude.com/claude-code)