### PR TITLE
Base Case quick-tweaks, duplicate tabs, and compare mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .vercel
 *.log
 .gstack/
+.playwright-mcp/
+compare-mode.png

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -352,6 +352,17 @@ body {
   max-width: 460px;
 }
 
+.base-scenario.compare-active {
+  background: #ffffff;
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-md);
+}
+
+.base-scenario.compare-inactive {
+  background: var(--color-bg-subtle);
+  box-shadow: var(--shadow-sm);
+}
+
 /* Scenarios Rows Layout */
 .scenarios-rows {
   display: grid;

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -363,6 +363,23 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+.base-scenario.compare-inactive.compare-tint-0 {
+  background: hsl(210 35% 97%);
+  border-left: 3px solid hsl(210 45% 70%);
+}
+.base-scenario.compare-inactive.compare-tint-1 {
+  background: hsl(42 50% 96%);
+  border-left: 3px solid hsl(42 55% 65%);
+}
+.base-scenario.compare-inactive.compare-tint-2 {
+  background: hsl(142 30% 96%);
+  border-left: 3px solid hsl(142 35% 60%);
+}
+.base-scenario.compare-inactive.compare-tint-3 {
+  background: hsl(280 25% 97%);
+  border-left: 3px solid hsl(280 35% 70%);
+}
+
 /* Scenarios Rows Layout */
 .scenarios-rows {
   display: grid;

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -203,7 +203,7 @@ body {
   opacity: 1;
 }
 
-.tab-edit-btn, .tab-remove-btn {
+.tab-edit-btn, .tab-remove-btn, .tab-duplicate-btn {
   background: #6c757d;
   color: white;
   border: none;
@@ -216,14 +216,32 @@ body {
   cursor: pointer;
   transition: background-color 0.2s ease;
   font-size: 0.7rem;
+  line-height: 1;
 }
 
 .tab-edit-btn:hover {
   background: #0d6efd;
 }
 
+.tab-duplicate-btn {
+  font-size: 0.8rem;
+}
+
+.tab-duplicate-btn:hover {
+  background: var(--color-accent);
+}
+
 .tab-remove-btn:hover {
   background: #dc3545;
+}
+
+.tab-compare-checkbox {
+  width: 14px;
+  height: 14px;
+  margin: 0 6px 0 0;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+  flex-shrink: 0;
 }
 
 .tab-edit-input {
@@ -312,6 +330,26 @@ body {
 .base-result {
   display: flex;
   justify-content: center;
+}
+
+.top-row.compare-mode {
+  grid-template-columns: minmax(320px, 1fr) minmax(0, 2fr);
+  max-width: 1600px;
+}
+
+.base-result-compare {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  gap: var(--space-4);
+  overflow-x: auto;
+  padding-bottom: var(--space-2);
+  width: 100%;
+}
+
+.base-result-compare > .scenario-card {
+  flex: 0 0 420px;
+  max-width: 460px;
 }
 
 /* Scenarios Rows Layout */
@@ -1003,6 +1041,80 @@ body {
   background: var(--color-accent-soft);
   border-color: var(--color-accent);
   color: var(--color-accent);
+}
+
+/* Inline Base Case quick-edit row */
+.base-quick-edit {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  flex-wrap: wrap;
+}
+
+.base-quick-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 0;
+  min-width: 90px;
+}
+
+.base-quick-label {
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.base-quick-input-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.base-quick-input-wrap:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-focus);
+}
+
+.base-quick-prefix,
+.base-quick-suffix {
+  color: var(--color-fg-subtle);
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+}
+
+.base-quick-input {
+  flex: 1;
+  min-width: 40px;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-fg);
+  font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+  outline: none;
+  padding: 0 2px;
+  width: 100%;
+}
+
+.base-quick-input::-webkit-outer-spin-button,
+.base-quick-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.base-quick-input[type=number] {
+  -moz-appearance: textfield;
 }
 
 .valuation-footer {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -341,15 +341,65 @@ body {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  gap: var(--space-4);
+  gap: var(--space-2);
   overflow-x: auto;
   padding-bottom: var(--space-2);
   width: 100%;
 }
 
 .base-result-compare > .scenario-card {
-  flex: 0 0 420px;
-  max-width: 460px;
+  flex: 0 0 340px;
+  max-width: 380px;
+  padding: var(--space-3);
+}
+
+.base-result-compare .scenario-header {
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-2);
+}
+
+.base-result-compare .scenario-title {
+  font-size: var(--text-sm);
+}
+
+.base-result-compare .base-quick-edit {
+  gap: var(--space-1);
+  padding: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.base-result-compare .base-quick-field {
+  min-width: 0;
+}
+
+.base-result-compare .base-quick-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.03em;
+}
+
+.base-result-compare .base-quick-input-wrap {
+  padding: 2px 4px;
+}
+
+.base-result-compare .base-quick-input {
+  font-size: 0.85rem;
+  min-width: 28px;
+}
+
+.base-result-compare .base-quick-prefix,
+.base-result-compare .base-quick-suffix {
+  font-size: 0.7rem;
+}
+
+.base-result-compare .table-header,
+.base-result-compare .table-row {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  font-size: var(--text-xs);
+}
+
+.base-result-compare .valuation-footer {
+  padding-top: var(--space-2);
 }
 
 .base-scenario.compare-active {

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -12,7 +12,7 @@ import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
 import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink'
 import { updateSocialSharingMeta } from './utils/socialSharing'
-import { createDefaultCompany } from './utils/dataStructures'
+import { createDefaultCompany, nextUniqueName } from './utils/dataStructures'
 
 function App() {
   const [activeCompany, setActiveCompany] = useState('company1')
@@ -20,9 +20,11 @@ function App() {
     company1: createDefaultCompany('Startup Alpha')
   })
   const [nextCompanyId, setNextCompanyId] = useState(2)
+  const [selectedCompanyIds, setSelectedCompanyIds] = useLocalStorage('valuationFrameworkSelected', [])
   const [hasLoadedFromURL, setHasLoadedFromURL] = useState(false)
 
   const [scenarios, setScenarios] = useState([])
+  const [baseScenariosById, setBaseScenariosById] = useState({})
   const { notifications, removeNotification, showSuccess, showInfo, showError } = useNotifications()
 
   const updateCompany = useCallback((companyId, data) => {
@@ -44,26 +46,49 @@ function App() {
 
   const addCompany = () => {
     const newCompanyId = `company${nextCompanyId}`
-    const companyName = nextCompanyId <= 26 
+    const companyName = nextCompanyId <= 26
       ? `Startup ${String.fromCharCode(64 + nextCompanyId)}`
       : `Startup ${nextCompanyId}`
     const newCompany = createDefaultCompany(companyName)
-    
+
     setCompanies(prev => ({ ...prev, [newCompanyId]: newCompany }))
+    setActiveCompany(newCompanyId)
+    setNextCompanyId(prev => prev + 1)
+  }
+
+  const duplicateCompany = (companyId) => {
+    const source = companies[companyId]
+    if (!source) return
+    const newCompanyId = `company${nextCompanyId}`
+    const copy = typeof structuredClone === 'function'
+      ? structuredClone(source)
+      : JSON.parse(JSON.stringify(source))
+    copy.name = nextUniqueName(source.name, companies)
+    setCompanies(prev => ({ ...prev, [newCompanyId]: copy }))
     setActiveCompany(newCompanyId)
     setNextCompanyId(prev => prev + 1)
   }
 
   const removeCompany = (companyId) => {
     if (Object.keys(companies).length <= 1) return
-    
+
     const newCompanies = { ...companies }
     delete newCompanies[companyId]
     setCompanies(newCompanies)
-    
+
+    setSelectedCompanyIds(prev => prev.filter(id => id !== companyId))
+
     if (activeCompany === companyId) {
       setActiveCompany(Object.keys(newCompanies)[0])
     }
+  }
+
+  const toggleCompareSelection = (companyId) => {
+    setSelectedCompanyIds(prev => (
+      prev.includes(companyId)
+        ? prev.filter(id => id !== companyId)
+        : [...prev, companyId]
+    ))
   }
 
   // Load scenario from URL on mount (only once)
@@ -83,7 +108,7 @@ function App() {
     const currentCompany = companies[activeCompany]
     if (currentCompany) {
       const newScenarios = calculateEnhancedScenarios(currentCompany)
-      
+
       // Check if the result is an error object
       if (newScenarios && newScenarios.error) {
         showError(newScenarios.errorMessage)
@@ -93,7 +118,7 @@ function App() {
         const totalPriorOwnership = (currentCompany.priorInvestors || []).reduce((sum, inv) => sum + (inv.ownershipPercent || 0), 0)
         const totalFounderOwnership = (currentCompany.founders || []).reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)
         const totalOwnership = totalPriorOwnership + totalFounderOwnership
-        
+
         if (totalOwnership > 100) {
           showError(`Cannot calculate scenarios: Total pre-round ownership is ${totalOwnership.toFixed(1)}% (exceeds 100%). Please adjust prior investor and founder ownership percentages.`)
         }
@@ -101,13 +126,33 @@ function App() {
       } else {
         setScenarios(newScenarios)
       }
-      
+
       // Update page metadata for permalinks
       updateSocialSharingMeta()
     } else {
       setScenarios([]) // Clear scenarios if no valid company
     }
   }, [companies, activeCompany, showError])
+
+  useEffect(() => {
+    const validSelected = selectedCompanyIds.filter(id => companies[id])
+    const idsToCompute = validSelected.length >= 2 ? validSelected : [activeCompany]
+    const next = {}
+    for (const id of idsToCompute) {
+      const co = companies[id]
+      if (!co) continue
+      const s = calculateEnhancedScenarios(co)
+      if (Array.isArray(s) && s.length > 0) {
+        next[id] = s[0]
+      }
+    }
+    setBaseScenariosById(next)
+  }, [companies, activeCompany, selectedCompanyIds])
+
+  const compareIds = selectedCompanyIds.filter(id => companies[id])
+  const isCompareMode = compareIds.length >= 2
+  const cardIds = isCompareMode ? compareIds : [activeCompany]
+  const showExitMath = !isCompareMode && companies[activeCompany]?.showExitMath
 
   return (
     <div className="app">
@@ -120,38 +165,49 @@ function App() {
       </header>
 
       <main className="app-main">
-        <CompanyTabs 
+        <CompanyTabs
           companies={companies}
           activeCompany={activeCompany}
           onCompanyChange={setActiveCompany}
           onAddCompany={addCompany}
           onRemoveCompany={removeCompany}
           onUpdateCompany={updateCompany}
+          onDuplicateCompany={duplicateCompany}
+          selectedCompanyIds={selectedCompanyIds}
+          onToggleCompareSelection={toggleCompareSelection}
         />
-        
-        <div className={`top-row${companies[activeCompany]?.showExitMath ? ' with-exit-math' : ''}`}>
+
+        <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}`}>
           <InputForm
             company={companies[activeCompany]}
             onUpdate={(data) => updateCompany(activeCompany, data)}
           />
 
-          <div className="base-result">
-            {scenarios.length > 0 && (
-              <ScenarioCard
-                scenario={scenarios[0]}
-                index={0}
-                isBase={true}
-                onApplyScenario={applyScenario}
-                onCopyPermalink={handleCopyPermalink}
-                investorName={companies[activeCompany]?.investorName || 'US'}
-                showAdvanced={companies[activeCompany]?.showAdvanced || false}
-                percentPrecision={companies[activeCompany]?.percentPrecision || 2}
-                onPercentPrecisionChange={(pp) => updateCompany(activeCompany, { percentPrecision: pp })}
-              />
-            )}
+          <div className={`base-result${isCompareMode ? ' base-result-compare' : ''}`}>
+            {cardIds.map((cid) => {
+              const base = baseScenariosById[cid]
+              if (!base) return null
+              return (
+                <ScenarioCard
+                  key={cid}
+                  scenario={base}
+                  index={0}
+                  isBase={true}
+                  onApplyScenario={(data) => updateCompany(cid, data)}
+                  onCopyPermalink={handleCopyPermalink}
+                  investorName={companies[cid]?.investorName || 'US'}
+                  showAdvanced={companies[cid]?.showAdvanced || false}
+                  percentPrecision={companies[cid]?.percentPrecision || 2}
+                  onPercentPrecisionChange={(pp) => updateCompany(cid, { percentPrecision: pp })}
+                  company={companies[cid]}
+                  onUpdateBase={(patch) => updateCompany(cid, patch)}
+                  companyName={isCompareMode ? companies[cid]?.name : undefined}
+                />
+              )
+            })}
           </div>
 
-          {companies[activeCompany]?.showExitMath && (
+          {showExitMath && (
             <ExitMathModule
               baseScenario={scenarios[0]}
               investorName={companies[activeCompany]?.investorName || 'US'}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -184,7 +184,7 @@ function App() {
           />
 
           <div className={`base-result${isCompareMode ? ' base-result-compare' : ''}`}>
-            {cardIds.map((cid) => {
+            {cardIds.map((cid, idx) => {
               const base = baseScenariosById[cid]
               if (!base) return null
               return (
@@ -203,6 +203,7 @@ function App() {
                   onUpdateBase={(patch) => updateCompany(cid, patch)}
                   companyName={isCompareMode ? companies[cid]?.name : undefined}
                   compareActive={isCompareMode ? cid === activeCompany : undefined}
+                  compareIndex={isCompareMode ? idx : undefined}
                 />
               )
             })}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -202,6 +202,7 @@ function App() {
                   company={companies[cid]}
                   onUpdateBase={(patch) => updateCompany(cid, patch)}
                   companyName={isCompareMode ? companies[cid]?.name : undefined}
+                  compareActive={isCompareMode ? cid === activeCompany : undefined}
                 />
               )
             })}

--- a/react-app/src/components/CompanyTabs-dup-compare.test.jsx
+++ b/react-app/src/components/CompanyTabs-dup-compare.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CompanyTabs from './CompanyTabs'
+
+const companies = {
+  c1: { name: 'Startup Alpha' },
+  c2: { name: 'Startup Beta' },
+}
+
+const baseProps = () => ({
+  companies,
+  activeCompany: 'c1',
+  onCompanyChange: vi.fn(),
+  onAddCompany: vi.fn(),
+  onRemoveCompany: vi.fn(),
+  onUpdateCompany: vi.fn(),
+  onDuplicateCompany: vi.fn(),
+  selectedCompanyIds: [],
+  onToggleCompareSelection: vi.fn(),
+})
+
+describe('CompanyTabs duplicate + compare', () => {
+  let props
+  beforeEach(() => {
+    props = baseProps()
+  })
+
+  it('renders duplicate button and calls onDuplicateCompany on click', () => {
+    render(<CompanyTabs {...props} />)
+    const btns = screen.getAllByRole('button', { name: /duplicate company/i })
+    expect(btns).toHaveLength(2)
+    fireEvent.click(btns[0])
+    expect(props.onDuplicateCompany).toHaveBeenCalledWith('c1')
+  })
+
+  it('duplicate click does not change active tab (stopPropagation)', () => {
+    render(<CompanyTabs {...props} />)
+    const btns = screen.getAllByRole('button', { name: /duplicate company/i })
+    fireEvent.click(btns[1])
+    expect(props.onCompanyChange).not.toHaveBeenCalled()
+    expect(props.onDuplicateCompany).toHaveBeenCalledWith('c2')
+  })
+
+  it('renders compare checkboxes that reflect selectedCompanyIds', () => {
+    render(<CompanyTabs {...props} selectedCompanyIds={['c2']} />)
+    const boxes = screen.getAllByRole('checkbox', { name: /include .* in compare/i })
+    expect(boxes).toHaveLength(2)
+    expect(boxes[0].checked).toBe(false)
+    expect(boxes[1].checked).toBe(true)
+  })
+
+  it('toggling a checkbox calls onToggleCompareSelection with the id', () => {
+    render(<CompanyTabs {...props} />)
+    const boxes = screen.getAllByRole('checkbox', { name: /include .* in compare/i })
+    fireEvent.click(boxes[0])
+    expect(props.onToggleCompareSelection).toHaveBeenCalledWith('c1')
+  })
+
+  it('checkbox click does not activate the tab (stopPropagation)', () => {
+    render(<CompanyTabs {...props} />)
+    const boxes = screen.getAllByRole('checkbox', { name: /include .* in compare/i })
+    fireEvent.click(boxes[1])
+    expect(props.onCompanyChange).not.toHaveBeenCalled()
+  })
+})

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -1,6 +1,16 @@
 import { useState } from 'react'
 
-const CompanyTabs = ({ companies, activeCompany, onCompanyChange, onAddCompany, onRemoveCompany, onUpdateCompany }) => {
+const CompanyTabs = ({
+  companies,
+  activeCompany,
+  onCompanyChange,
+  onAddCompany,
+  onRemoveCompany,
+  onUpdateCompany,
+  onDuplicateCompany,
+  selectedCompanyIds = [],
+  onToggleCompareSelection,
+}) => {
   const [editingTab, setEditingTab] = useState(null)
   const [editName, setEditName] = useState('')
 
@@ -43,11 +53,22 @@ const CompanyTabs = ({ companies, activeCompany, onCompanyChange, onAddCompany, 
     <div className="company-tabs">
       <div className="tabs-container">
         {Object.entries(companies).map(([companyId, company]) => (
-          <div 
+          <div
             key={companyId}
             className={`tab ${activeCompany === companyId ? 'active' : ''}`}
             onClick={() => handleTabClick(companyId)}
           >
+            {onToggleCompareSelection && (
+              <input
+                type="checkbox"
+                className="tab-compare-checkbox"
+                checked={selectedCompanyIds.includes(companyId)}
+                onChange={() => onToggleCompareSelection(companyId)}
+                onClick={(e) => e.stopPropagation()}
+                title="Include in compare view"
+                aria-label={`Include ${company.name} in compare view`}
+              />
+            )}
             {editingTab === companyId ? (
               <input
                 type="text"
@@ -63,7 +84,7 @@ const CompanyTabs = ({ companies, activeCompany, onCompanyChange, onAddCompany, 
               <>
                 <span className="tab-name">{company.name}</span>
                 <div className="tab-actions">
-                  <button 
+                  <button
                     className="tab-edit-btn"
                     onClick={(e) => {
                       e.stopPropagation()
@@ -73,8 +94,21 @@ const CompanyTabs = ({ companies, activeCompany, onCompanyChange, onAddCompany, 
                   >
                     ✏️
                   </button>
+                  {onDuplicateCompany && (
+                    <button
+                      className="tab-duplicate-btn"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDuplicateCompany(companyId)
+                      }}
+                      title="Duplicate company"
+                      aria-label="Duplicate company"
+                    >
+                      ⧉
+                    </button>
+                  )}
                   {Object.keys(companies).length > 1 && (
-                    <button 
+                    <button
                       className="tab-remove-btn"
                       onClick={(e) => {
                         e.stopPropagation()

--- a/react-app/src/components/ScenarioCard-quickedit.test.jsx
+++ b/react-app/src/components/ScenarioCard-quickedit.test.jsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ScenarioCard from './ScenarioCard'
+
+const baseScenario = {
+  title: 'Base Case',
+  postMoneyVal: 13,
+  roundSize: 3,
+  investorAmount: 2.75,
+  investorPercent: 21.15,
+  otherAmount: 0.25,
+  otherPercent: 1.92,
+  roundPercent: 23.08,
+  totalAmount: 3,
+  totalPercent: 23.08,
+  preMoneyVal: 10,
+  proRataAmount: 0,
+  proRataPercent: 0,
+  safes: [],
+  safeDetails: [],
+  totalSafePercent: 0,
+  preRoundFounderPercent: 76.9,
+  finalEsopPercent: 0,
+  priorInvestors: [],
+  founders: [],
+  unknownOwnership: 0,
+}
+
+const baseCompany = {
+  name: 'Startup Alpha',
+  postMoneyVal: 13,
+  roundSize: 3,
+  investorPortion: 2.75,
+  otherPortion: 0.25,
+  investorName: 'LSVP',
+}
+
+describe('ScenarioCard Base quick-edit', () => {
+  let onUpdateBase
+
+  beforeEach(() => {
+    onUpdateBase = vi.fn()
+  })
+
+  it('renders quick-edit inputs only when isBase with company + onUpdateBase', () => {
+    const { rerender } = render(
+      <ScenarioCard scenario={baseScenario} index={1} isBase={false} />
+    )
+    expect(screen.queryByText(/Round$/i)).not.toBeInTheDocument()
+
+    rerender(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        investorName="LSVP"
+      />
+    )
+    expect(screen.getByText('Post-Money')).toBeInTheDocument()
+    expect(screen.getByText('Round')).toBeInTheDocument()
+    expect(screen.getByText('LSVP')).toBeInTheDocument()
+  })
+
+  it('updates postMoneyVal on valuation edit', () => {
+    render(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        investorName="LSVP"
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    // First input is Post-Money
+    fireEvent.change(inputs[0], { target: { value: '20' } })
+    expect(onUpdateBase).toHaveBeenCalledWith({ postMoneyVal: 20 })
+  })
+
+  it('auto-recomputes otherPortion when roundSize changes', () => {
+    render(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        investorName="LSVP"
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    // Second input is Round
+    fireEvent.change(inputs[1], { target: { value: '5' } })
+    expect(onUpdateBase).toHaveBeenCalledWith({
+      roundSize: 5,
+      otherPortion: 2.25, // 5 - investorPortion(2.75)
+    })
+  })
+
+  it('auto-recomputes otherPortion when investor portion changes', () => {
+    render(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        investorName="LSVP"
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    // Third input is investor portion
+    fireEvent.change(inputs[2], { target: { value: '2' } })
+    expect(onUpdateBase).toHaveBeenCalledWith({
+      investorPortion: 2,
+      otherPortion: 1, // roundSize(3) - 2
+    })
+  })
+
+  it('clamps negative values to 0', () => {
+    render(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        investorName="LSVP"
+      />
+    )
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '-5' } })
+    expect(onUpdateBase).toHaveBeenCalledWith({ postMoneyVal: 0 })
+  })
+
+  it('shows companyName in title when provided', () => {
+    render(
+      <ScenarioCard
+        scenario={baseScenario}
+        index={0}
+        isBase={true}
+        company={baseCompany}
+        onUpdateBase={onUpdateBase}
+        companyName="Startup Alpha 2"
+      />
+    )
+    expect(screen.getByText(/Base Case — Startup Alpha 2/)).toBeInTheDocument()
+  })
+})

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange }) => {
+const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName }) => {
   const [copyFeedback, setCopyFeedback] = useState('')
   const [collapsed, setCollapsed] = useState({
     newRound: false,
@@ -143,15 +143,36 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     : 0
     
 
+  const handleBaseFieldChange = (field, rawValue) => {
+    if (!onUpdateBase || !company) return
+    let num = parseFloat(rawValue)
+    if (isNaN(num) || rawValue === '' || rawValue === null) num = 0
+    if (num < 0) num = 0
+    const round = (v) => Math.round(v * 100) / 100
+    const patch = { [field]: num }
+    if (field === 'roundSize') {
+      const investor = Number(company.investorPortion) || 0
+      patch.otherPortion = round(Math.max(0, num - investor))
+    } else if (field === 'investorPortion') {
+      const roundSize = Number(company.roundSize) || 0
+      patch.otherPortion = round(Math.max(0, roundSize - num))
+    }
+    onUpdateBase(patch)
+  }
+
+  const baseTitle = companyName
+    ? `Base Case — ${companyName}`
+    : (scenario.title || (isBase ? 'Base Case' : `Scenario ${index}`))
+
   return (
     <div className={getCardClass()}>
       <div className="scenario-header">
         <h3 className="scenario-title">
-          {scenario.title || (isBase ? "Base Case" : `Scenario ${index}`)}
+          {isBase ? baseTitle : (scenario.title || `Scenario ${index}`)}
         </h3>
         {!isBase && (
-          <button 
-            className="apply-scenario-btn" 
+          <button
+            className="apply-scenario-btn"
             onClick={handleApplyScenario}
             title="Apply this scenario to inputs"
           >
@@ -159,7 +180,58 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
           </button>
         )}
       </div>
-      
+
+      {isBase && onUpdateBase && company && (
+        <div className="base-quick-edit">
+          <label className="base-quick-field">
+            <span className="base-quick-label">Post-Money</span>
+            <span className="base-quick-input-wrap">
+              <span className="base-quick-prefix">$</span>
+              <input
+                type="number"
+                className="base-quick-input"
+                value={Number(company.postMoneyVal) || 0}
+                onChange={(e) => handleBaseFieldChange('postMoneyVal', e.target.value)}
+                step="0.5"
+                min="0"
+              />
+              <span className="base-quick-suffix">M</span>
+            </span>
+          </label>
+          <label className="base-quick-field">
+            <span className="base-quick-label">Round</span>
+            <span className="base-quick-input-wrap">
+              <span className="base-quick-prefix">$</span>
+              <input
+                type="number"
+                className="base-quick-input"
+                value={Number(company.roundSize) || 0}
+                onChange={(e) => handleBaseFieldChange('roundSize', e.target.value)}
+                step="0.25"
+                min="0"
+              />
+              <span className="base-quick-suffix">M</span>
+            </span>
+          </label>
+          <label className="base-quick-field">
+            <span className="base-quick-label">{investorName}</span>
+            <span className="base-quick-input-wrap">
+              <span className="base-quick-prefix">$</span>
+              <input
+                type="number"
+                className="base-quick-input"
+                value={Number(company.investorPortion) || 0}
+                onChange={(e) => handleBaseFieldChange('investorPortion', e.target.value)}
+                step="0.25"
+                min="0"
+                max={Number(company.roundSize) || 0}
+              />
+              <span className="base-quick-suffix">M</span>
+            </span>
+          </label>
+        </div>
+      )}
+
       <div className="scenario-table">
         <div className="table-header">
           <div className="label">Party</div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName, compareActive }) => {
+const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName, compareActive, compareIndex }) => {
   const [copyFeedback, setCopyFeedback] = useState('')
   const [collapsed, setCollapsed] = useState({
     newRound: false,
@@ -20,7 +20,10 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     if (isBase) {
       let cls = 'scenario-card base-scenario'
       if (compareActive === true) cls += ' compare-active'
-      else if (compareActive === false) cls += ' compare-inactive'
+      else if (compareActive === false) {
+        cls += ' compare-inactive'
+        if (Number.isFinite(compareIndex)) cls += ` compare-tint-${compareIndex % 4}`
+      }
       return cls
     }
     return `scenario-card scenario-${index % 5}`

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName }) => {
+const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName, compareActive }) => {
   const [copyFeedback, setCopyFeedback] = useState('')
   const [collapsed, setCollapsed] = useState({
     newRound: false,
@@ -17,7 +17,12 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   }
   
   const getCardClass = () => {
-    if (isBase) return 'scenario-card base-scenario'
+    if (isBase) {
+      let cls = 'scenario-card base-scenario'
+      if (compareActive === true) cls += ' compare-active'
+      else if (compareActive === false) cls += ' compare-inactive'
+      return cls
+    }
     return `scenario-card scenario-${index % 5}`
   }
 

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -211,6 +211,22 @@ export function migrateLegacyCompany(legacyCompany) {
 }
 
 /**
+ * Generates the next unique name for a duplicated company.
+ * Appends or increments a trailing numeric suffix, skipping existing names.
+ * @param {string} baseName - Source company name
+ * @param {Object} companies - Map of existing companies keyed by id
+ * @returns {string} Unique name
+ */
+export function nextUniqueName(baseName, companies) {
+  const existing = new Set(Object.values(companies || {}).map(c => c && c.name))
+  const match = (baseName || '').match(/^(.*?)\s+(\d+)$/)
+  const stem = match ? match[1] : (baseName || 'Company')
+  let n = match ? parseInt(match[2], 10) + 1 : 2
+  while (existing.has(`${stem} ${n}`)) n++
+  return `${stem} ${n}`
+}
+
+/**
  * Validates complete company data structure
  * @param {Object} company - Company object
  * @returns {Object} Validation result with success boolean and errors array

--- a/react-app/src/utils/nextUniqueName.test.js
+++ b/react-app/src/utils/nextUniqueName.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { nextUniqueName } from './dataStructures'
+
+describe('nextUniqueName', () => {
+  it('appends " 2" to a fresh name', () => {
+    const companies = { a: { name: 'Startup Alpha' } }
+    expect(nextUniqueName('Startup Alpha', companies)).toBe('Startup Alpha 2')
+  })
+
+  it('increments an existing trailing digit', () => {
+    const companies = { a: { name: 'Startup Alpha 2' } }
+    expect(nextUniqueName('Startup Alpha 2', companies)).toBe('Startup Alpha 3')
+  })
+
+  it('skips over existing collisions', () => {
+    const companies = {
+      a: { name: 'Startup Alpha' },
+      b: { name: 'Startup Alpha 2' },
+      c: { name: 'Startup Alpha 3' },
+    }
+    expect(nextUniqueName('Startup Alpha', companies)).toBe('Startup Alpha 4')
+  })
+
+  it('handles empty/missing baseName gracefully', () => {
+    expect(nextUniqueName('', {})).toBe('Company 2')
+    expect(nextUniqueName(undefined, {})).toBe('Company 2')
+  })
+
+  it('preserves multi-word stems when incrementing', () => {
+    const companies = { a: { name: 'Acme Corp 5' } }
+    expect(nextUniqueName('Acme Corp 5', companies)).toBe('Acme Corp 6')
+  })
+
+  it('handles single-word names', () => {
+    expect(nextUniqueName('Acme', { a: { name: 'Acme' } })).toBe('Acme 2')
+  })
+})


### PR DESCRIPTION
## Summary
- Inline quick-edit row (post-money, round size, lead portion) inside the Base Case card; preserves the `investorPortion + otherPortion === roundSize` invariant.
- Duplicate-tab button (⧉) deep-clones via `structuredClone` and auto-increments names (`Startup Alpha` → `Startup Alpha 2`), skipping existing collisions.
- Compare mode: per-tab checkboxes (persisted to localStorage) render 2+ selected Base Cases in a horizontally-scrolling row; `InputForm` stays bound to the active tab and `ExitMathModule` hides.

## Test plan
- [x] `npx vitest run` green (added coverage for `nextUniqueName`, quick-edit invariant, duplicate/compare wiring)
- [x] Browser-verified: duplicate creates `Startup Alpha 2`; compare mode shows labeled cards; per-card edits update only that card; localStorage persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)