### PR TITLE
Compact advanced section with table-row repeaters and wider panel

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -327,6 +327,14 @@ body {
   max-width: 1500px;
 }
 
+/* When Advanced Features is expanded, give the input panel extra room so the
+   repeater tables (SAFEs, Prior Investors, Founders) can breathe across
+   several inline columns. Base Case column stays readable at ~1fr. */
+.top-row.advanced-open {
+  grid-template-columns: 1.35fr 1fr;
+  max-width: 1400px;
+}
+
 .base-result {
   display: flex;
   justify-content: center;
@@ -553,8 +561,8 @@ body {
 
 /* 2-Step Round Section */
 .two-step-section {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
   border-top: 1px solid #e2e8f0;
 }
 
@@ -658,7 +666,7 @@ body {
   background: var(--color-bg-subtle);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-4);
+  padding: var(--space-3) var(--space-4);
   margin-top: var(--space-2);
 }
 
@@ -666,9 +674,25 @@ body {
   font-size: 0.85rem;
   color: #4a5568;
   font-weight: 600;
-  margin: 0 0 0.85rem 0;
+  margin: 0 0 0.75rem 0;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+/* Top row inside advanced: 2-Step Round + ESOP side-by-side.
+   Collapses to single column on narrow viewports. */
+.advanced-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.advanced-split > .two-step-section,
+.advanced-split > .esop-section {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
 }
 
 /* SAFE Conversion Info */
@@ -1505,7 +1529,9 @@ body {
 /* N SAFEs Section Styling */
 .safes-section {
   grid-column: 1 / -1;
-  margin-top: 1rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e2e8f0;
 }
 
 .safes-header {
@@ -1608,8 +1634,8 @@ body {
 
 /* Prior Investors Section Styles */
 .prior-investors-section {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
   border-top: 1px solid #e2e8f0;
 }
 
@@ -2097,15 +2123,15 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 /* Founders Section Styles */
 .founders-section {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
   border-top: 1px solid #e2e8f0;
 }
 
 /* ESOP Section Styles */
 .esop-section {
-  margin-top: var(--space-6);
-  padding-top: var(--space-6);
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
   border-top: 1px solid var(--color-border);
 }
 
@@ -2277,6 +2303,280 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     grid-template-columns: 1fr;
     gap: 0.75rem;
   }
+
+  .advanced-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Collapse advanced-split to single column on narrow-but-not-mobile viewports
+   where the two halves would squeeze their 3-col ESOP grid. */
+@media (max-width: 1080px) {
+  .advanced-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Section header shared between SAFEs / Prior Investors / Founders —
+   puts "total" pill + add-button next to the title so the header is one line. */
+.section-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.section-total-pill {
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  background: var(--color-bg-muted);
+  border-radius: var(--radius-pill);
+  padding: 2px 0.6rem;
+  font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+}
+
+.section-total-pill strong {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
+/* Compact title-row replaces the old column layout for tables; reuse the
+   existing .section-title-row / .section-label hooks. */
+.safes-section .section-title-row,
+.prior-investors-section .section-title-row,
+.founders-section .section-title-row {
+  margin-bottom: 0.5rem;
+}
+
+/* ---- Repeater tables (SAFEs, Prior Investors, Founders) ---- */
+.repeater-table {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.repeater-header,
+.repeater-row {
+  display: grid;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.35rem 0.5rem;
+}
+
+.repeater-header {
+  background: var(--color-bg-muted);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-fg-muted);
+  min-height: 28px;
+}
+
+.repeater-row {
+  border-bottom: 1px solid var(--color-border);
+  min-height: 40px;
+  position: relative;
+}
+
+.repeater-row:last-child {
+  border-bottom: 0;
+}
+
+.repeater-row:hover {
+  background: var(--color-bg-subtle);
+}
+
+/* Column track templates — each table tunes its own columns */
+.repeater-table--investors .repeater-header,
+.repeater-table--investors .repeater-row {
+  /* Name | Ownership | Pro-rata | Allocation | Actions */
+  grid-template-columns: minmax(120px, 1.6fr) 110px 64px 130px 56px;
+}
+
+.repeater-table--founders .repeater-header,
+.repeater-table--founders .repeater-row {
+  /* Name | Ownership | Actions */
+  grid-template-columns: minmax(140px, 1fr) 120px 56px;
+}
+
+.repeater-table--safes .repeater-header,
+.repeater-table--safes .repeater-row {
+  /* Investor | Amount | Cap | Discount | Pro-rata | Allocation | Actions */
+  grid-template-columns: minmax(110px, 1.4fr) 100px 110px 92px 64px 120px 56px;
+}
+
+.repeater-col {
+  min-width: 0;
+}
+
+.repeater-col--actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+}
+
+/* Pro-rata checkbox in tables — centered, no label (column header carries it) */
+.repeater-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.repeater-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+  margin: 0;
+}
+
+.repeater-alloc-placeholder {
+  display: block;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--color-fg-faint);
+  font-style: italic;
+  cursor: help;
+}
+
+/* Muted caption beneath a SAFE row for conversion info */
+.repeater-row--safe {
+  padding-bottom: 0.35rem;
+}
+
+.repeater-row-caption {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  color: var(--color-fg-subtle);
+  font-style: italic;
+  padding: 2px 0 2px 2px;
+  line-height: 1.3;
+}
+
+/* ---- Compact FormInput variant (used inside repeater tables) ---- */
+.form-input-wrapper.compact {
+  min-height: 30px;
+  min-width: 0;
+  border-radius: 4px;
+}
+
+.form-input-wrapper.compact .form-input-field {
+  padding-left: 6px;
+}
+
+.form-input-wrapper.compact .form-input-control {
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 4px 4px 4px 2px;
+  text-align: left;
+}
+
+.form-input-wrapper.compact .form-input-control[type="number"] {
+  text-align: right;
+}
+
+.form-input-wrapper.compact .form-input-prefix,
+.form-input-wrapper.compact .form-input-suffix {
+  font-size: 0.75rem;
+}
+
+.form-input-wrapper.compact .form-input-prefix {
+  padding-left: 4px;
+  padding-right: 2px;
+}
+
+.form-input-wrapper.compact .form-input-suffix {
+  padding-left: 2px;
+  padding-right: 6px;
+}
+
+.form-input-wrapper.compact .form-clear-btn {
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  font-size: 0.65rem;
+}
+
+/* Reset button (arrow) + remove (×) buttons in repeater action column */
+.repeater-col--actions .reset-pro-rata-btn {
+  background: transparent;
+  border: 0;
+  color: var(--color-fg-subtle);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 2px 4px;
+  line-height: 1;
+  border-radius: 3px;
+  text-decoration: none;
+}
+
+.repeater-col--actions .reset-pro-rata-btn:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.repeater-col--actions .remove-investor-btn,
+.repeater-col--actions .remove-founder-btn,
+.repeater-col--actions .remove-safe-btn {
+  width: 22px;
+  height: 22px;
+  font-size: 0.85rem;
+}
+
+/* ---- Shrink the educational notes (keep visible but denser) ---- */
+.founders-note--compact,
+.pro-rata-explanation--compact {
+  margin-top: var(--space-2);
+  padding: 0.4rem 0.6rem;
+  font-size: 0.75rem;
+  gap: 0.4rem;
+  line-height: 1.35;
+  border-left-width: 2px;
+}
+
+.founders-note--compact .note-icon,
+.pro-rata-explanation--compact .explanation-icon {
+  font-size: 0.85rem;
+}
+
+/* ESOP when paired with 2-Step: tighten subtitle + timing block spacing so
+   the block balances with the (often-collapsed) 2-Step side. */
+.advanced-split .esop-section .esop-subtitle {
+  margin-bottom: var(--space-2);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.advanced-split .esop-section .esop-timing-section {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+}
+
+.advanced-split .esop-section .esop-timing-explanation {
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+/* 2-Step Step 2 card — tighten gap between fields when paired in 2-col */
+.advanced-split .step2-input-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+/* When the input form has extra width (advanced-open), let ESOP's 3-col grid
+   stretch comfortably. */
+.top-row.advanced-open .esop-section .input-grid.esop-input-grid {
+  gap: var(--space-3);
 }
 
 /* Pro-rata row styling within scenario tables */

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -153,6 +153,7 @@ function App() {
   const isCompareMode = compareIds.length >= 2
   const cardIds = isCompareMode ? compareIds : [activeCompany]
   const showExitMath = !isCompareMode && companies[activeCompany]?.showExitMath
+  const advancedOpen = !isCompareMode && !showExitMath && Boolean(companies[activeCompany]?.showAdvanced)
 
   return (
     <div className="app">
@@ -177,7 +178,7 @@ function App() {
           onToggleCompareSelection={toggleCompareSelection}
         />
 
-        <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}`}>
+        <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}${advancedOpen ? ' advanced-open' : ''}`}>
           <InputForm
             company={companies[activeCompany]}
             onUpdate={(data) => updateCompany(activeCompany, data)}

--- a/react-app/src/components/FormInput.jsx
+++ b/react-app/src/components/FormInput.jsx
@@ -17,11 +17,12 @@ const FormInput = ({
   clearable = false,
   id,
   tooltip,
+  compact = false,
+  ariaLabel,
   ...props
 }) => {
   const [isFocused, setIsFocused] = useState(false)
-  
-  // Generate unique ID if not provided
+
   const inputId = id || `form-input-${label.toLowerCase().replace(/\s+/g, '-')}`
   
   const handleChange = (e) => {
@@ -45,12 +46,14 @@ const FormInput = ({
   const showClearButton = clearable && value && (type === 'number' ? value > 0 : value.length > 0)
 
   return (
-    <div className={`form-input-group ${className}`} title={tooltip || undefined}>
-      <div className={`form-input-wrapper ${isFocused ? 'focused' : ''} ${disabled ? 'disabled' : ''} ${showClearButton ? 'with-clear' : ''}`}>
-        <label htmlFor={inputId} className="form-input-label" title={tooltip || undefined}>
-          {label}
-        </label>
-        
+    <div className={`form-input-group ${compact ? 'compact' : ''} ${className}`} title={tooltip || undefined}>
+      <div className={`form-input-wrapper ${compact ? 'compact' : ''} ${isFocused ? 'focused' : ''} ${disabled ? 'disabled' : ''} ${showClearButton ? 'with-clear' : ''}`}>
+        {!compact && (
+          <label htmlFor={inputId} className="form-input-label" title={tooltip || undefined}>
+            {label}
+          </label>
+        )}
+
         <div className="form-input-field">
           {showClearButton && (
             <button
@@ -63,9 +66,9 @@ const FormInput = ({
               ×
             </button>
           )}
-          
+
           {prefix && <span className="form-input-prefix">{prefix}</span>}
-          
+
           <input
             id={inputId}
             type={type}
@@ -79,9 +82,10 @@ const FormInput = ({
             step={step}
             disabled={disabled}
             className="form-input-control"
+            aria-label={compact ? (ariaLabel || label) : undefined}
             {...props}
           />
-          
+
           {suffix && <span className="form-input-suffix">{suffix}</span>}
         </div>
       </div>

--- a/react-app/src/components/FoundersSection.jsx
+++ b/react-app/src/components/FoundersSection.jsx
@@ -4,10 +4,9 @@ import FormInput from './FormInput'
 function FoundersSection({ founders = [], onUpdate }) {
   const addFounder = () => {
     const newFounder = createFounder('New Founder', 0)
-    const updatedFounders = [...founders, newFounder]
-    onUpdate(updatedFounders)
+    onUpdate([...founders, newFounder])
   }
-  
+
   const updateFounder = (founderId, field, value) => {
     const updatedFounders = founders.map(founder => {
       if (founder.id === founderId) {
@@ -20,64 +19,59 @@ function FoundersSection({ founders = [], onUpdate }) {
     })
     onUpdate(updatedFounders)
   }
-  
+
   const removeFounder = (founderId) => {
-    const updatedFounders = founders.filter(founder => founder.id !== founderId)
-    onUpdate(updatedFounders)
+    onUpdate(founders.filter(founder => founder.id !== founderId))
   }
-  
+
   const totalOwnership = calculateTotalOwnership(founders)
-  
+
   return (
     <div className="founders-section">
       <div className="founders-investors-header">
         <div className="section-title-row">
           <h5 className="section-label">Founders</h5>
-          <button 
-            className="add-founder-btn"
-            onClick={addFounder}
-            type="button"
-          >
-            + Add Founder
-          </button>
-        </div>
-        
-        {totalOwnership > 0 && (
-          <div className="ownership-summary">
-            <span className="summary-label">Total Founder Ownership:</span>
-            <span className="summary-value">{totalOwnership.toFixed(1)}%</span>
+          <div className="section-header-actions">
+            {totalOwnership > 0 && (
+              <span className="section-total-pill">
+                Total: <strong>{totalOwnership.toFixed(1)}%</strong>
+              </span>
+            )}
+            <button
+              className="add-founder-btn"
+              onClick={addFounder}
+              type="button"
+            >
+              + Add Founder
+            </button>
           </div>
-        )}
+        </div>
       </div>
-      
+
       {founders.length === 0 ? (
         <div className="no-founders-message">
           No founders added. Click "Add Founder" to add founding team members.
         </div>
       ) : (
-        <div className="founders-list">
+        <div className="repeater-table repeater-table--founders">
+          <div className="repeater-header">
+            <span className="repeater-col repeater-col--name">Name</span>
+            <span className="repeater-col repeater-col--pct">Ownership</span>
+            <span className="repeater-col repeater-col--actions" aria-hidden="true" />
+          </div>
           {founders.map((founder, index) => (
-            <div key={founder.id} className="founder-row">
-              <div className="founder-row-header">
-                <span className="founder-label">Founder #{index + 1}</span>
-                <button
-                  className="remove-founder-btn"
-                  onClick={() => removeFounder(founder.id)}
-                  type="button"
-                  title="Remove founder"
-                >
-                  ×
-                </button>
-              </div>
-              
-              <div className="founder-inputs">
+            <div key={founder.id} className="repeater-row">
+              <div className="repeater-col repeater-col--name">
                 <FormInput
                   label="Name"
                   type="text"
                   value={founder.name}
                   onChange={(value) => updateFounder(founder.id, 'name', value)}
                   placeholder={`Founder ${index + 1}`}
+                  compact
                 />
+              </div>
+              <div className="repeater-col repeater-col--pct">
                 <FormInput
                   label="Ownership"
                   type="number"
@@ -87,18 +81,28 @@ function FoundersSection({ founders = [], onUpdate }) {
                   min="0"
                   max="100"
                   step="0.1"
+                  compact
                 />
+              </div>
+              <div className="repeater-col repeater-col--actions">
+                <button
+                  className="remove-founder-btn"
+                  onClick={() => removeFounder(founder.id)}
+                  type="button"
+                  title="Remove founder"
+                >
+                  ×
+                </button>
               </div>
             </div>
           ))}
         </div>
       )}
-      
-      <div className="founders-note">
+
+      <div className="founders-note founders-note--compact">
         <div className="note-icon">💡</div>
         <div className="note-text">
-          Founder ownership will be diluted by the new round, SAFEs, and ESOP according to the timing you specify.
-          Total pre-round ownership (founders + prior investors) should not exceed 100%.
+          Founders are diluted by the new round, SAFEs, and ESOP per the timing you pick. Pre-round (founders + prior investors) should total ≤ 100%.
         </div>
       </div>
     </div>

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -329,282 +329,366 @@ const InputForm = ({ company, onUpdate }) => {
         <div className="advanced-section">
           <h4>Cap Table Modeling</h4>
 
-          {/* 2-Step Round */}
-          <div className="two-step-section">
-            <div className="two-step-header">
-              <h5>2-Step Round</h5>
-              <label className="two-step-checkbox">
-                <input
-                  type="checkbox"
-                  checked={values.twoStepEnabled || false}
-                  onChange={(e) => handleChange('twoStepEnabled', e.target.checked)}
-                />
-                <span className="two-step-label">Enable</span>
-              </label>
+          <div className="advanced-split">
+            {/* 2-Step Round */}
+            <div className="two-step-section">
+              <div className="two-step-header">
+                <h5>2-Step Round</h5>
+                <label className="two-step-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={values.twoStepEnabled || false}
+                    onChange={(e) => handleChange('twoStepEnabled', e.target.checked)}
+                  />
+                  <span className="two-step-label">Enable</span>
+                </label>
+              </div>
+
+              {values.twoStepEnabled && (
+                <div className="step2-card">
+                  <div className="step2-card-header">
+                    <span className="step-label">Step 2</span>
+                    <span className="step-note">Step 1 uses main inputs above</span>
+                  </div>
+                  {values.step2PostMoney > 0 && values.step2PostMoney <= values.postMoneyVal && (
+                    <div className="warning">
+                      V2 (${values.step2PostMoney}M) should be greater than V1 (${values.postMoneyVal}M)
+                    </div>
+                  )}
+                  <div className="input-grid step2-input-grid">
+                    <FormInput
+                      label="Post-Money Valuation"
+                      type="number"
+                      value={values.step2PostMoney || 0}
+                      onChange={(value) => handleChange('step2PostMoney', value)}
+                      prefix="$"
+                      suffix="M"
+                      step="0.1"
+                      min="0"
+                    />
+
+                    <FormInput
+                      label="Amount"
+                      type="number"
+                      value={values.step2Amount || 0}
+                      onChange={(value) => handleChange('step2Amount', value)}
+                      prefix="$"
+                      suffix="M"
+                      step="0.1"
+                      min="0"
+                    />
+
+                    <FormInput
+                      label={`${values.investorName || 'US'} Portion`}
+                      type="number"
+                      value={values.step2InvestorPortion || 0}
+                      onChange={(value) => handleChange('step2InvestorPortion', value)}
+                      prefix="$"
+                      suffix="M"
+                      step="0.01"
+                      min="0"
+                      max={values.step2Amount || 0}
+                    />
+
+                    <FormInput
+                      label="Other Portion"
+                      type="number"
+                      value={values.step2OtherPortion || 0}
+                      onChange={(value) => handleChange('step2OtherPortion', value)}
+                      prefix="$"
+                      suffix="M"
+                      step="0.01"
+                      min="0"
+                      max={values.step2Amount || 0}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
 
-            {values.twoStepEnabled && (
-              <div className="step2-card">
-                <div className="step2-card-header">
-                  <span className="step-label">Step 2</span>
-                  <span className="step-note">Step 1 uses main inputs above</span>
-                </div>
-                {values.step2PostMoney > 0 && values.step2PostMoney <= values.postMoneyVal && (
-                  <div className="warning">
-                    V2 (${values.step2PostMoney}M) should be greater than V1 (${values.postMoneyVal}M)
-                  </div>
-                )}
-                <div className="input-grid">
-                  <FormInput
-                    label="Post-Money Valuation"
-                    type="number"
-                    value={values.step2PostMoney || 0}
-                    onChange={(value) => handleChange('step2PostMoney', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.1"
-                    min="0"
-                  />
+            <div className="esop-section">
+              <h5>Employee Stock Option Pool (ESOP)</h5>
+              <p className="esop-subtitle">
+                Total pool = Granted + Available. VCs typically negotiate the <em>available</em> slice post-close.
+              </p>
 
-                  <FormInput
-                    label="Amount"
-                    type="number"
-                    value={values.step2Amount || 0}
-                    onChange={(value) => handleChange('step2Amount', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.1"
-                    min="0"
-                  />
+              <div className="input-grid esop-input-grid">
+                <FormInput
+                  label="Current Pool"
+                  type="number"
+                  value={values.currentEsopPercent || ''}
+                  onChange={(value) => handleChange('currentEsopPercent', value)}
+                  suffix="%"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  placeholder="0"
+                  clearable={true}
+                  tooltip="Total ESOP pool today, including both granted and unallocated shares (as a % of fully-diluted shares)."
+                />
 
-                  <FormInput
-                    label={`${values.investorName || 'US'} Portion`}
-                    type="number"
-                    value={values.step2InvestorPortion || 0}
-                    onChange={(value) => handleChange('step2InvestorPortion', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.01"
-                    min="0"
-                    max={values.step2Amount || 0}
-                  />
+                <FormInput
+                  label="Already Granted"
+                  type="number"
+                  value={values.grantedEsopPercent || ''}
+                  onChange={(value) => handleChange('grantedEsopPercent', value)}
+                  suffix="%"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  placeholder="0"
+                  clearable={true}
+                  tooltip="Portion of the current pool that has already been issued to employees. The rest is the unallocated pool VCs negotiate over."
+                />
 
-                  <FormInput
-                    label="Other Portion"
-                    type="number"
-                    value={values.step2OtherPortion || 0}
-                    onChange={(value) => handleChange('step2OtherPortion', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.01"
-                    min="0"
-                    max={values.step2Amount || 0}
-                  />
-                </div>
+                <FormInput
+                  label="Target Available"
+                  type="number"
+                  value={values.targetEsopPercent || ''}
+                  onChange={(value) => handleChange('targetEsopPercent', value)}
+                  suffix="%"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  placeholder="0"
+                  clearable={true}
+                  tooltip="Desired unallocated pool post-round (as a % of post-money fully-diluted). Set to 0 to skip any top-up."
+                />
               </div>
-            )}
+
+              {Number(values.grantedEsopPercent || 0) > Number(values.currentEsopPercent || 0) && (
+                <div className="esop-validation-error">
+                  Already granted ({Number(values.grantedEsopPercent).toFixed(2)}%) exceeds current pool ({Number(values.currentEsopPercent).toFixed(2)}%).
+                </div>
+              )}
+
+              {values.targetEsopPercent > 0 && (
+                <div className="esop-timing-section">
+                  <label className="section-label">Top-up timing</label>
+                  <div className="esop-timing-toggle" role="tablist">
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={values.esopTiming === 'pre-close'}
+                      className={`esop-timing-option ${values.esopTiming === 'pre-close' ? 'active' : ''}`}
+                      onClick={() => handleChange('esopTiming', 'pre-close')}
+                    >
+                      Pre-Close
+                    </button>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={values.esopTiming === 'post-close'}
+                      className={`esop-timing-option ${values.esopTiming === 'post-close' ? 'active' : ''}`}
+                      onClick={() => handleChange('esopTiming', 'post-close')}
+                    >
+                      Post-Close
+                    </button>
+                  </div>
+
+                  <p className="esop-timing-explanation">
+                    {values.esopTiming === 'pre-close'
+                      ? 'Top-up happens before the round. Dilutes founders, prior investors, and granted ESOP — not new investors.'
+                      : 'Top-up happens after the round. Dilutes everyone proportionally, including new investors.'}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
 
           <div className="safes-section">
-            <div className="safes-header">
-              <h5>SAFE Notes</h5>
-              <button 
-                type="button"
-                className="add-safe-btn"
-                onClick={addSafe}
-                title="Add SAFE"
-              >
-                + Add SAFE
-              </button>
+            <div className="section-title-row">
+              <h5 className="section-label">SAFE Notes</h5>
+              <div className="section-header-actions">
+                <button
+                  type="button"
+                  className="add-safe-btn"
+                  onClick={addSafe}
+                  title="Add SAFE"
+                >
+                  + Add SAFE
+                </button>
+              </div>
             </div>
 
-            {(!values.safes || values.safes.length === 0) && (
+            {(!values.safes || values.safes.length === 0) ? (
               <div className="no-safes-message">
                 No SAFE notes added. Click "Add SAFE" to get started.
               </div>
-            )}
-
-            {values.safes && values.safes.map((safe, index) => (
-              <div key={safe.id} className="safe-row">
-                <div className="safe-row-header">
-                  <span className="safe-label">SAFE #{index + 1}</span>
-                  <button 
-                    type="button"
-                    className="remove-safe-btn"
-                    onClick={() => removeSafe(safe.id)}
-                    title="Remove SAFE"
-                  >
-                    ×
-                  </button>
+            ) : (
+              <div className="repeater-table repeater-table--safes">
+                <div className="repeater-header">
+                  <span className="repeater-col repeater-col--name">Investor</span>
+                  <span className="repeater-col repeater-col--amount">Amount</span>
+                  <span className="repeater-col repeater-col--cap">Cap</span>
+                  <span className="repeater-col repeater-col--discount">Discount</span>
+                  <span className="repeater-col repeater-col--prorata">Pro-rata</span>
+                  <span className="repeater-col repeater-col--alloc">Allocation</span>
+                  <span className="repeater-col repeater-col--actions" aria-hidden="true" />
                 </div>
-                
-                <div className="safe-inputs">
-                  <FormInput
-                    label="Amount"
-                    type="number"
-                    value={safe.amount}
-                    onChange={(value) => updateSafe(safe.id, 'amount', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.1"
-                    min="0"
-                    id={`safe-amount-${safe.id}`}
-                  />
+                {values.safes.map((safe) => {
+                  // Conversion valuation for the caption under the row
+                  const conversionInfo = (() => {
+                    if (!(safe.amount > 0 && (safe.cap > 0 || safe.discount > 0))) return null
+                    let val, note
+                    if (safe.cap > 0 && safe.discount > 0) {
+                      const capPrice = safe.cap
+                      const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
+                      if (capPrice < discountPrice) {
+                        val = capPrice
+                        note = `cap vs ${safe.discount}% discount`
+                      } else {
+                        val = discountPrice
+                        note = `discount vs $${capPrice.toFixed(1)}M cap`
+                      }
+                    } else if (safe.cap > 0) {
+                      val = Math.min(safe.cap, safePreMoneyVal)
+                      note = `cap $${safe.cap.toFixed(1)}M`
+                    } else {
+                      val = safePreMoneyVal * (1 - safe.discount / 100)
+                      note = `${safe.discount}% discount`
+                    }
+                    return `Converts at $${val.toFixed(1)}M (${note})`
+                  })()
 
-                  <FormInput
-                    label="Valuation"
-                    type="number"
-                    value={safe.cap}
-                    onChange={(value) => updateSafe(safe.id, 'cap', value)}
-                    prefix="$"
-                    suffix="M"
-                    step="0.5"
-                    min="0"
-                    placeholder="0 = uncapped"
-                    id={`safe-cap-${safe.id}`}
-                  />
-
-                  <FormInput
-                    label="Discount"
-                    type="number"
-                    value={safe.discount}
-                    onChange={(value) => updateSafe(safe.id, 'discount', value)}
-                    suffix="%"
-                    step="1"
-                    min="0"
-                    max="100"
-                    id={`safe-discount-${safe.id}`}
-                  />
-
-                  <FormInput
-                    label="Investor"
-                    type="text"
-                    value={safe.investorName || ''}
-                    onChange={(value) => updateSafe(safe.id, 'investorName', value)}
-                    placeholder="Optional"
-                    id={`safe-investor-${safe.id}`}
-                  />
-                </div>
-
-                {/* Individual SAFE Conversion Info */}
-                {safe.amount > 0 && (safe.cap > 0 || safe.discount > 0) && (
-                  <div className="safe-conversion-info">
-                    <div className="conversion-display">
-                      <span className="conversion-label">Conversion Valuation:</span>
-                      <span className="conversion-value">
-                        {(() => {
-                          if (safe.cap > 0 && safe.discount > 0) {
-                            const capPrice = safe.cap
-                            const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                            return capPrice < discountPrice
-                              ? `$${capPrice.toFixed(1)}M`
-                              : `$${discountPrice.toFixed(1)}M`
-                          } else if (safe.cap > 0) {
-                            return `$${Math.min(safe.cap, safePreMoneyVal).toFixed(1)}M`
-                          } else if (safe.discount > 0) {
-                            return `$${(safePreMoneyVal * (1 - safe.discount / 100)).toFixed(1)}M`
-                          }
-                          return '$0.0M'
-                        })()}
-                      </span>
-                      <span className="conversion-note">
-                        {(() => {
-                          if (safe.cap > 0 && safe.discount > 0) {
-                            const capPrice = safe.cap
-                            const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                            return capPrice < discountPrice
-                              ? `(Using cap vs ${safe.discount}% discount)`
-                              : `(Using discount vs $${capPrice.toFixed(1)}M cap)`
-                          } else if (safe.cap > 0) {
-                            return `(Cap: $${safe.cap.toFixed(1)}M)`
-                          } else if (safe.discount > 0) {
-                            return `(${safe.discount}% discount)`
-                          }
-                          return ''
-                        })()}
-                      </span>
-                    </div>
-                  </div>
-                )}
-
-                {/* Pro-rata rights for this SAFE */}
-                <div className="investor-pro-rata">
-                  <label className="pro-rata-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={Boolean(safe.proRata)}
-                      onChange={(e) => updateSafe(safe.id, 'proRata', e.target.checked)}
-                    />
-                    <span className="checkbox-label">Pro-rata rights</span>
-                  </label>
-                </div>
-
-                {safe.proRata && safe.amount > 0 && values.roundSize > 0 && (() => {
-                  // Compute conversion price matching calculateSafeConversions
-                  let conversionPrice = 0
-                  if (safe.cap > 0 && safe.discount > 0) {
-                    conversionPrice = Math.min(safe.cap, safePreMoneyVal * (1 - safe.discount / 100))
-                  } else if (safe.cap > 0) {
-                    conversionPrice = Math.min(safe.cap, safePreMoneyVal)
-                  } else if (safe.discount > 0) {
-                    conversionPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                  } else {
-                    conversionPrice = safePreMoneyVal
+                  // Pro-rata allocation calculation
+                  let proRataBlock = null
+                  if (safe.proRata && safe.amount > 0 && values.roundSize > 0) {
+                    let conversionPrice = 0
+                    if (safe.cap > 0 && safe.discount > 0) {
+                      conversionPrice = Math.min(safe.cap, safePreMoneyVal * (1 - safe.discount / 100))
+                    } else if (safe.cap > 0) {
+                      conversionPrice = Math.min(safe.cap, safePreMoneyVal)
+                    } else if (safe.discount > 0) {
+                      conversionPrice = safePreMoneyVal * (1 - safe.discount / 100)
+                    } else {
+                      conversionPrice = safePreMoneyVal
+                    }
+                    if (conversionPrice > 0) {
+                      const safeOwnership = (safe.amount / conversionPrice) * 100
+                      const calculatedProRata = (safeOwnership / 100) * values.roundSize
+                      const hasOverride = safe.proRataOverride != null
+                      const displayAmount = hasOverride ? safe.proRataOverride : calculatedProRata
+                      const matchesLead = (safe.investorName || '').trim() === (values.investorName || 'US').trim()
+                      proRataBlock = { calculatedProRata, hasOverride, displayAmount, matchesLead: matchesLead && !!safe.investorName }
+                    }
                   }
-                  if (conversionPrice <= 0) return null
-                  const safeOwnership = (safe.amount / conversionPrice) * 100
-                  const calculatedProRata = (safeOwnership / 100) * values.roundSize
-                  const hasOverride = safe.proRataOverride != null
-                  const displayAmount = hasOverride ? safe.proRataOverride : calculatedProRata
-                  const matchesLead = (safe.investorName || '').trim() === (values.investorName || 'US').trim()
-                  if (matchesLead && safe.investorName) {
-                    return (
-                      <div className="pro-rata-hint">
-                        <span className="hint-text">
-                          Pro-rata handled via {values.investorName || 'US'} round portion
-                        </span>
-                      </div>
-                    )
-                  }
+
                   return (
-                    <div className="pro-rata-allocation">
-                      <div className="pro-rata-allocation-row">
+                    <div key={safe.id} className="repeater-row repeater-row--safe">
+                      <div className="repeater-col repeater-col--name">
                         <FormInput
-                          label="Allocation"
-                          type="number"
-                          value={displayAmount}
-                          onChange={(value) => updateSafe(safe.id, 'proRataOverride', value)}
-                          prefix="$"
-                          suffix="M"
-                          step="0.01"
-                          min="0"
+                          label="Investor"
+                          type="text"
+                          value={safe.investorName || ''}
+                          onChange={(value) => updateSafe(safe.id, 'investorName', value)}
+                          placeholder="Optional"
+                          id={`safe-investor-${safe.id}`}
+                          compact
                         />
                       </div>
-                      {hasOverride && (
-                        <div className="pro-rata-hint">
-                          <span className="hint-text">
-                            Pro-rata right: ${parseFloat(calculatedProRata.toPrecision(10))}M
-                            {safe.proRataOverride < calculatedProRata
-                              ? ` (taking less)`
-                              : safe.proRataOverride > calculatedProRata
-                                ? ` (taking more)`
-                                : ''}
+                      <div className="repeater-col repeater-col--amount">
+                        <FormInput
+                          label="Amount"
+                          type="number"
+                          value={safe.amount}
+                          onChange={(value) => updateSafe(safe.id, 'amount', value)}
+                          prefix="$"
+                          suffix="M"
+                          step="0.1"
+                          min="0"
+                          id={`safe-amount-${safe.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--cap">
+                        <FormInput
+                          label="Cap"
+                          type="number"
+                          value={safe.cap}
+                          onChange={(value) => updateSafe(safe.id, 'cap', value)}
+                          prefix="$"
+                          suffix="M"
+                          step="0.5"
+                          min="0"
+                          placeholder="0 = uncapped"
+                          id={`safe-cap-${safe.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--discount">
+                        <FormInput
+                          label="Discount"
+                          type="number"
+                          value={safe.discount}
+                          onChange={(value) => updateSafe(safe.id, 'discount', value)}
+                          suffix="%"
+                          step="1"
+                          min="0"
+                          max="100"
+                          id={`safe-discount-${safe.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--prorata">
+                        <label className="repeater-checkbox" title="Pro-rata rights">
+                          <input
+                            type="checkbox"
+                            checked={Boolean(safe.proRata)}
+                            onChange={(e) => updateSafe(safe.id, 'proRata', e.target.checked)}
+                          />
+                        </label>
+                      </div>
+                      <div className="repeater-col repeater-col--alloc">
+                        {proRataBlock && !proRataBlock.matchesLead ? (
+                          <FormInput
+                            label="Allocation"
+                            type="number"
+                            value={proRataBlock.displayAmount}
+                            onChange={(value) => updateSafe(safe.id, 'proRataOverride', value)}
+                            prefix="$"
+                            suffix="M"
+                            step="0.01"
+                            min="0"
+                            compact
+                          />
+                        ) : (
+                          <span
+                            className="repeater-alloc-placeholder"
+                            title={proRataBlock?.matchesLead ? `Handled via ${values.investorName || 'US'} round portion` : 'Enable pro-rata to set allocation'}
+                          >
+                            {proRataBlock?.matchesLead ? 'via lead' : '—'}
                           </span>
+                        )}
+                      </div>
+                      <div className="repeater-col repeater-col--actions">
+                        {proRataBlock?.hasOverride && !proRataBlock.matchesLead && (
                           <button
                             type="button"
                             className="reset-pro-rata-btn"
                             onClick={() => updateSafe(safe.id, 'proRataOverride', null)}
-                            title="Reset to calculated pro-rata"
+                            title={`Reset to calculated ($${parseFloat(proRataBlock.calculatedProRata.toPrecision(10))}M)`}
                           >
-                            reset
+                            ↺
                           </button>
-                        </div>
+                        )}
+                        <button
+                          type="button"
+                          className="remove-safe-btn"
+                          onClick={() => removeSafe(safe.id)}
+                          title="Remove SAFE"
+                        >
+                          ×
+                        </button>
+                      </div>
+                      {conversionInfo && (
+                        <div className="repeater-row-caption">{conversionInfo}</div>
                       )}
                     </div>
                   )
-                })()}
+                })}
               </div>
-            ))}
+            )}
           </div>
 
           <PriorInvestorsSection
@@ -614,99 +698,10 @@ const InputForm = ({ company, onUpdate }) => {
             investorName={values.investorName || 'US'}
           />
 
-          <FoundersSection 
+          <FoundersSection
             founders={values.founders || []}
             onUpdate={handleFoundersUpdate}
           />
-
-          <div className="esop-section">
-            <h5>Employee Stock Option Pool (ESOP)</h5>
-            <p className="esop-subtitle">
-              Total pool = Granted + Available. VCs typically negotiate the <em>available</em> slice post-close.
-            </p>
-
-            <div className="input-grid esop-input-grid">
-              <FormInput
-                label="Current Pool"
-                type="number"
-                value={values.currentEsopPercent || ''}
-                onChange={(value) => handleChange('currentEsopPercent', value)}
-                suffix="%"
-                step="0.01"
-                min="0"
-                max="100"
-                placeholder="0"
-                clearable={true}
-                tooltip="Total ESOP pool today, including both granted and unallocated shares (as a % of fully-diluted shares)."
-              />
-
-              <FormInput
-                label="Already Granted"
-                type="number"
-                value={values.grantedEsopPercent || ''}
-                onChange={(value) => handleChange('grantedEsopPercent', value)}
-                suffix="%"
-                step="0.01"
-                min="0"
-                max="100"
-                placeholder="0"
-                clearable={true}
-                tooltip="Portion of the current pool that has already been issued to employees. The rest is the unallocated pool VCs negotiate over."
-              />
-
-              <FormInput
-                label="Target Available"
-                type="number"
-                value={values.targetEsopPercent || ''}
-                onChange={(value) => handleChange('targetEsopPercent', value)}
-                suffix="%"
-                step="0.01"
-                min="0"
-                max="100"
-                placeholder="0"
-                clearable={true}
-                tooltip="Desired unallocated pool post-round (as a % of post-money fully-diluted). Set to 0 to skip any top-up."
-              />
-            </div>
-
-            {Number(values.grantedEsopPercent || 0) > Number(values.currentEsopPercent || 0) && (
-              <div className="esop-validation-error">
-                Already granted ({Number(values.grantedEsopPercent).toFixed(2)}%) exceeds current pool ({Number(values.currentEsopPercent).toFixed(2)}%).
-              </div>
-            )}
-
-            {values.targetEsopPercent > 0 && (
-              <div className="esop-timing-section">
-                <label className="section-label">Top-up timing</label>
-                <div className="esop-timing-toggle" role="tablist">
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={values.esopTiming === 'pre-close'}
-                    className={`esop-timing-option ${values.esopTiming === 'pre-close' ? 'active' : ''}`}
-                    onClick={() => handleChange('esopTiming', 'pre-close')}
-                  >
-                    Pre-Close
-                  </button>
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={values.esopTiming === 'post-close'}
-                    className={`esop-timing-option ${values.esopTiming === 'post-close' ? 'active' : ''}`}
-                    onClick={() => handleChange('esopTiming', 'post-close')}
-                  >
-                    Post-Close
-                  </button>
-                </div>
-
-                <p className="esop-timing-explanation">
-                  {values.esopTiming === 'pre-close'
-                    ? 'Top-up happens before the round. Dilutes founders, prior investors, and granted ESOP — not new investors.'
-                    : 'Top-up happens after the round. Dilutes everyone proportionally, including new investors.'}
-                </p>
-              </div>
-            )}
-          </div>
 
         </div>
       )}

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -1,15 +1,10 @@
-import { useState } from 'react'
 import { createPriorInvestor, calculateTotalOwnership } from '../utils/dataStructures'
 import FormInput from './FormInput'
 
 function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, investorName = '' }) {
-  const [expandedInvestor, setExpandedInvestor] = useState(null)
-
   const addPriorInvestor = () => {
     const newInvestor = createPriorInvestor('New Investor', 0, false)
-    const updatedInvestors = [...priorInvestors, newInvestor]
-    onUpdate(updatedInvestors)
-    setExpandedInvestor(newInvestor.id)
+    onUpdate([...priorInvestors, newInvestor])
   }
 
   const updateInvestor = (investorId, field, value) => {
@@ -18,7 +13,6 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
         const updated = { ...investor }
         if (field === 'ownershipPercent') {
           updated.ownershipPercent = Math.max(0, Math.min(100, Number(value) || 0))
-          // Reset override when ownership changes so it recalculates
           if (updated.proRataOverride != null) {
             updated.proRataOverride = null
           }
@@ -27,7 +21,6 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
           updated.proRataOverride = (isNaN(numVal) || value === '' || value === null) ? null : Math.max(0, numVal)
         } else if (field === 'hasProRataRights') {
           updated.hasProRataRights = value
-          // Clear override when toggling pro-rata off
           if (!value) {
             updated.proRataOverride = null
           }
@@ -42,11 +35,7 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
   }
 
   const removeInvestor = (investorId) => {
-    const updatedInvestors = priorInvestors.filter(investor => investor.id !== investorId)
-    onUpdate(updatedInvestors)
-    if (expandedInvestor === investorId) {
-      setExpandedInvestor(null)
-    }
+    onUpdate(priorInvestors.filter(investor => investor.id !== investorId))
   }
 
   const getCalculatedProRata = (investor) => {
@@ -62,21 +51,21 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
       <div className="founders-investors-header">
         <div className="section-title-row">
           <h5 className="section-label">Prior Investors</h5>
-          <button
-            className="add-investor-btn"
-            onClick={addPriorInvestor}
-            type="button"
-          >
-            + Add Investor
-          </button>
-        </div>
-
-        {totalOwnership > 0 && (
-          <div className="ownership-summary">
-            <span className="summary-label">Total Prior Investor Ownership:</span>
-            <span className="summary-value">{totalOwnership.toFixed(1)}%</span>
+          <div className="section-header-actions">
+            {totalOwnership > 0 && (
+              <span className="section-total-pill">
+                Total: <strong>{totalOwnership.toFixed(1)}%</strong>
+              </span>
+            )}
+            <button
+              className="add-investor-btn"
+              onClick={addPriorInvestor}
+              type="button"
+            >
+              + Add Investor
+            </button>
           </div>
-        )}
+        </div>
       </div>
 
       {priorInvestors.length === 0 ? (
@@ -84,34 +73,33 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
           No prior investors added. Click "Add Investor" to include previous round participants.
         </div>
       ) : (
-        <div className="investors-list">
+        <div className="repeater-table repeater-table--investors">
+          <div className="repeater-header">
+            <span className="repeater-col repeater-col--name">Name</span>
+            <span className="repeater-col repeater-col--pct">Ownership</span>
+            <span className="repeater-col repeater-col--prorata">Pro-rata</span>
+            <span className="repeater-col repeater-col--alloc">Allocation</span>
+            <span className="repeater-col repeater-col--actions" aria-hidden="true" />
+          </div>
           {priorInvestors.map(investor => {
             const calculatedProRata = getCalculatedProRata(investor)
             const hasOverride = investor.proRataOverride != null
             const displayAmount = hasOverride ? investor.proRataOverride : calculatedProRata
-
+            const matchesLead = investor.name === investorName && investor.name
+            const allocActive = investor.hasProRataRights && investor.ownershipPercent > 0 && roundSize > 0
             return (
-              <div key={investor.id} className="investor-row">
-                <div className="investor-row-header">
-                  <span className="investor-label">Prior Investor</span>
-                  <button
-                    className="remove-investor-btn"
-                    onClick={() => removeInvestor(investor.id)}
-                    type="button"
-                    title="Remove investor"
-                  >
-                    ×
-                  </button>
-                </div>
-
-                <div className="investor-inputs">
+              <div key={investor.id} className="repeater-row">
+                <div className="repeater-col repeater-col--name">
                   <FormInput
                     label="Name"
                     type="text"
                     value={investor.name}
                     onChange={(value) => updateInvestor(investor.id, 'name', value)}
                     placeholder="Investor name"
+                    compact
                   />
+                </div>
+                <div className="repeater-col repeater-col--pct">
                   <FormInput
                     label="Ownership"
                     type="number"
@@ -121,66 +109,57 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
                     min="0"
                     max="100"
                     step="0.1"
+                    compact
                   />
                 </div>
-
-                <div className="investor-pro-rata">
-                  <label className="pro-rata-checkbox">
+                <div className="repeater-col repeater-col--prorata">
+                  <label className="repeater-checkbox" title="Pro-rata rights">
                     <input
                       type="checkbox"
                       checked={investor.hasProRataRights}
                       onChange={(e) => updateInvestor(investor.id, 'hasProRataRights', e.target.checked)}
                     />
-                    <span className="checkbox-label">Pro-rata rights</span>
                   </label>
                 </div>
-
-                {/* Show allocation field when pro-rata is enabled and they have ownership */}
-                {investor.hasProRataRights && investor.ownershipPercent > 0 && roundSize > 0 && (
-                  investor.name === investorName ? (
-                    <div className="pro-rata-hint">
-                      <span className="hint-text">
-                        Pro-rata handled via {investorName} round portion
-                      </span>
-                    </div>
+                <div className="repeater-col repeater-col--alloc">
+                  {allocActive && !matchesLead ? (
+                    <FormInput
+                      label="Allocation"
+                      type="number"
+                      value={displayAmount}
+                      onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
+                      prefix="$"
+                      suffix="M"
+                      step="0.01"
+                      min="0"
+                      compact
+                    />
                   ) : (
-                    <div className="pro-rata-allocation">
-                      <div className="pro-rata-allocation-row">
-                        <FormInput
-                          label="Allocation"
-                          type="number"
-                          value={displayAmount}
-                          onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
-                          prefix="$"
-                          suffix="M"
-                          step="0.01"
-                          min="0"
-                        />
-                      </div>
-                      {hasOverride && (
-                        <div className="pro-rata-hint">
-                          <span className="hint-text">
-                            Pro-rata right: ${parseFloat(calculatedProRata.toPrecision(10))}M
-                            {investor.proRataOverride < calculatedProRata
-                              ? ` (taking less)`
-                              : investor.proRataOverride > calculatedProRata
-                                ? ` (taking more)`
-                                : ''}
-                          </span>
-                          <button
-                            type="button"
-                            className="reset-pro-rata-btn"
-                            onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
-                            title="Reset to calculated pro-rata"
-                          >
-                            reset
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )
-                )}
-
+                    <span className="repeater-alloc-placeholder" title={matchesLead ? `Handled via ${investorName} round portion` : 'Enable pro-rata to set allocation'}>
+                      {matchesLead ? 'via lead' : '—'}
+                    </span>
+                  )}
+                </div>
+                <div className="repeater-col repeater-col--actions">
+                  {hasOverride && allocActive && !matchesLead && (
+                    <button
+                      type="button"
+                      className="reset-pro-rata-btn"
+                      onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
+                      title={`Reset to calculated ($${parseFloat(calculatedProRata.toPrecision(10))}M)`}
+                    >
+                      ↺
+                    </button>
+                  )}
+                  <button
+                    className="remove-investor-btn"
+                    onClick={() => removeInvestor(investor.id)}
+                    type="button"
+                    title="Remove investor"
+                  >
+                    ×
+                  </button>
+                </div>
               </div>
             )
           })}
@@ -188,11 +167,10 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
       )}
 
       {hasProRataInvestors && (
-        <div className="pro-rata-explanation">
+        <div className="pro-rata-explanation pro-rata-explanation--compact">
           <div className="explanation-icon">ℹ️</div>
           <div className="explanation-text">
-            Investors with pro-rata rights can participate in the new round proportional to their current ownership.
-            Their allocation is deducted from the "Other" portion. Edit the allocation to adjust.
+            Pro-rata participants buy in proportional to ownership; allocation is deducted from the "Other" portion. Edit inline to adjust.
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Widens Investment Parameters panel (1.35fr / 1fr, max 1400px) only when Advanced is open.
- Pairs 2-Step Round and ESOP side-by-side via a new `.advanced-split` grid.
- Converts SAFEs, Prior Investors, and Founders repeater cards into compact `.repeater-table` rows with labeled header rows; FormInput gets a `compact` variant.
- Shrinks educational notes (typography + margins) instead of removing; tightens subsection spacing throughout.

## Test plan
- [ ] Open Advanced Features and confirm panel widens, ESOP + 2-Step sit side-by-side, repeater tables render header rows
- [ ] Add/remove SAFEs, Prior Investors, Founders — inline rows, pro-rata toggle, allocation override all work
- [ ] Compare Mode and Exit Math layouts unchanged
- [ ] `npx vitest run` passes (338 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)