### PR TITLE
Fix share links and compare state

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -183,7 +183,7 @@ body {
   border: none;
   border-right: 1px solid #e2e8f0;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   color: #4a5568;
   font-weight: 500;
   font-size: 0.9rem;
@@ -204,10 +204,14 @@ body {
 }
 
 .tab.active {
-  background: var(--color-bg);
-  color: var(--color-accent);
-  font-weight: 600;
-  box-shadow: inset 0 -2px 0 var(--color-accent);
+  background: linear-gradient(180deg, rgba(13, 110, 253, 0.16) 0%, rgba(13, 110, 253, 0.06) 100%);
+  color: #0b5ed7;
+  font-weight: 700;
+  box-shadow: inset 0 0 0 1px rgba(13, 110, 253, 0.28), inset 0 -3px 0 var(--color-accent);
+}
+
+.tab.active:hover {
+  background: linear-gradient(180deg, rgba(13, 110, 253, 0.2) 0%, rgba(13, 110, 253, 0.08) 100%);
 }
 
 .tab-name {
@@ -228,6 +232,10 @@ body {
 }
 
 .tab:hover .tab-actions {
+  opacity: 1;
+}
+
+.tab.active .tab-actions {
   opacity: 1;
 }
 
@@ -290,7 +298,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  height: 2px;
+  height: 3px;
   background: #0d6efd;
   opacity: 0;
   transition: opacity 0.2s ease;

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -368,6 +368,8 @@ body {
 .base-result-compare {
   display: flex;
   flex-direction: row;
+  width: fit-content;
+  max-width: 100%;
   /* `safe center` keeps cards centered in the rail until they exceed it, then
      falls back to flex-start so the leftmost card stays reachable via scroll. */
   justify-content: safe center;
@@ -375,7 +377,6 @@ body {
   gap: clamp(var(--space-2), 1.2vw, var(--space-5));
   overflow-x: auto;
   padding-bottom: var(--space-2);
-  width: 100%;
 }
 
 .base-result-compare > .scenario-card {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -350,10 +350,13 @@ body {
 
 .top-row.compare-mode {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: flex-start;
   gap: 2rem;
-  max-width: none;
+  width: fit-content;
+  max-width: min(1600px, 100%);
+  padding-inline: clamp(var(--space-3), 1.5vw, var(--space-5));
+  box-sizing: border-box;
 }
 
 .top-row.compare-mode > .input-form {
@@ -361,14 +364,14 @@ body {
 }
 
 .top-row.compare-mode > .base-result-compare {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
 .base-result-compare {
   display: flex;
   flex-direction: row;
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
   /* `safe center` keeps cards centered in the rail until they exceed it, then
      falls back to flex-start so the leftmost card stays reachable via scroll. */
@@ -2911,6 +2914,9 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   .top-row.compare-mode {
     flex-direction: column;
     gap: 1.5rem;
+    width: 100%;
+    max-width: none;
+    padding-inline: 0;
   }
 
   .top-row.compare-mode > .input-form {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -153,13 +153,27 @@ body {
 
 .tabs-container {
   display: flex;
-  gap: 2px;
-  align-items: center;
+  align-items: stretch;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
+}
+
+.tabs-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.tabs-list {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-width: 100%;
 }
 
 .tab {
@@ -176,7 +190,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  min-width: 140px;
+  flex: 1 1 0;
+  min-width: clamp(170px, 12vw, 210px);
   justify-content: space-between;
 }
 
@@ -198,6 +213,10 @@ body {
 .tab-name {
   font-size: 0.9rem;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .tab-actions {
@@ -205,6 +224,7 @@ body {
   gap: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s ease;
+  flex-shrink: 0;
 }
 
 .tab:hover .tab-actions {
@@ -261,7 +281,8 @@ body {
   font-weight: 500;
   color: #333;
   outline: none;
-  min-width: 100px;
+  min-width: 0;
+  width: 100%;
 }
 
 .tab-indicator {
@@ -303,6 +324,14 @@ body {
 
 .add-company-btn {
   margin-left: var(--space-2);
+}
+
+.tabs-container > .add-company-btn {
+  flex: 0 0 auto;
+  margin-left: 0;
+  border-left: 1px solid var(--color-border);
+  border-radius: 0;
+  align-self: stretch;
 }
 
 .add-company-btn:hover,
@@ -2893,6 +2922,16 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     flex-direction: column;
   }
 
+  .tabs-scroll {
+    width: 100%;
+  }
+
+  .tabs-list {
+    width: 100%;
+    min-width: 0;
+    flex-direction: column;
+  }
+
   .tab {
     width: 100%;
     border-right: none;
@@ -2902,6 +2941,13 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
   .tab:last-of-type {
     border-bottom: none;
+  }
+
+  .tabs-container > .add-company-btn {
+    width: 100%;
+    justify-content: center;
+    border-left: none;
+    border-top: 1px solid var(--color-border);
   }
 
   .top-row,

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -14,12 +14,24 @@ import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink
 import { updateSocialSharingMeta } from './utils/socialSharing'
 import { createDefaultCompany, nextUniqueName } from './utils/dataStructures'
 
+function getFirstCompanyId(companies) {
+  return Object.keys(companies || {})[0] || 'company1'
+}
+
+function getNextCompanyNumber(companies) {
+  const maxExisting = Object.keys(companies || {}).reduce((max, id) => {
+    const match = /^company(\d+)$/.exec(id)
+    return match ? Math.max(max, Number(match[1])) : max
+  }, 0)
+  return Math.max(2, maxExisting + 1)
+}
+
 function App() {
-  const [activeCompany, setActiveCompany] = useState('company1')
   const [companies, setCompanies] = useLocalStorage('valuationFramework', {
     company1: createDefaultCompany('Startup Alpha')
   })
-  const [nextCompanyId, setNextCompanyId] = useState(2)
+  const [activeCompany, setActiveCompany] = useState(() => getFirstCompanyId(companies))
+  const [nextCompanyId, setNextCompanyId] = useState(() => getNextCompanyNumber(companies))
   const [selectedCompanyIds, setSelectedCompanyIds] = useLocalStorage('valuationFrameworkSelected', [])
   const [hasLoadedFromURL, setHasLoadedFromURL] = useState(false)
 
@@ -92,6 +104,27 @@ function App() {
   }
 
   // Load scenario from URL on mount (only once)
+  useEffect(() => {
+    const companyIds = Object.keys(companies || {})
+
+    if (companyIds.length === 0) {
+      const fallback = { company1: createDefaultCompany('Startup Alpha') }
+      setCompanies(fallback)
+      setActiveCompany('company1')
+      setNextCompanyId(2)
+      return
+    }
+
+    if (!companies[activeCompany]) {
+      setActiveCompany(companyIds[0])
+    }
+
+    const derivedNextCompanyId = getNextCompanyNumber(companies)
+    if (nextCompanyId !== derivedNextCompanyId) {
+      setNextCompanyId(derivedNextCompanyId)
+    }
+  }, [companies, activeCompany, nextCompanyId, setCompanies])
+
   useEffect(() => {
     if (!hasLoadedFromURL) {
       const urlScenario = loadScenarioFromURL()
@@ -237,22 +270,25 @@ function App() {
           />
         )}
 
-        <div className="scenarios-rows">
-          {scenarios.slice(1).map((scenario, index) => (
-            <ScenarioCard
-              key={scenario.offsetPercent ?? index + 1}
-              scenario={scenario}
-              index={index + 1}
-              isBase={false}
-              onApplyScenario={applyScenario}
-              investorName={companies[activeCompany]?.investorName || 'US'}
-              showAdvanced={companies[activeCompany]?.showAdvanced || false}
-              percentPrecision={companies[activeCompany]?.percentPrecision || 2}
-              onPercentPrecisionChange={(pp) => updateCompany(activeCompany, { percentPrecision: pp })}
-              baseScenario={scenarios[0]}
-            />
-          ))}
-        </div>
+        {!isCompareMode && (
+          <div className="scenarios-rows">
+            {scenarios.slice(1).map((scenario, index) => (
+              <ScenarioCard
+                key={scenario.offsetPercent ?? index + 1}
+                scenario={scenario}
+                index={index + 1}
+                isBase={false}
+                onApplyScenario={applyScenario}
+                investorName={companies[activeCompany]?.investorName || 'US'}
+                showAdvanced={companies[activeCompany]?.showAdvanced || false}
+                percentPrecision={companies[activeCompany]?.percentPrecision || 2}
+                onPercentPrecisionChange={(pp) => updateCompany(activeCompany, { percentPrecision: pp })}
+                baseScenario={scenarios[0]}
+                company={companies[activeCompany]}
+              />
+            ))}
+          </div>
+        )}
       </main>
     </div>
   )

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import './App.css'
 import CompanyTabs from './components/CompanyTabs'
 import InputForm from './components/InputForm'
@@ -12,7 +12,7 @@ import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
 import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink'
 import { updateSocialSharingMeta } from './utils/socialSharing'
-import { createDefaultCompany, nextUniqueName } from './utils/dataStructures'
+import { createDefaultCompany, nextUniqueName, normalizeStoredCompanies } from './utils/dataStructures'
 
 function getFirstCompanyId(companies) {
   return Object.keys(companies || {})[0] || 'company1'
@@ -27,9 +27,10 @@ function getNextCompanyNumber(companies) {
 }
 
 function App() {
-  const [companies, setCompanies] = useLocalStorage('valuationFramework', {
+  const [storedCompanies, setStoredCompanies] = useLocalStorage('valuationFramework', {
     company1: createDefaultCompany('Startup Alpha')
   })
+  const companies = useMemo(() => normalizeStoredCompanies(storedCompanies), [storedCompanies])
   const [activeCompany, setActiveCompany] = useState(() => getFirstCompanyId(companies))
   const [nextCompanyId, setNextCompanyId] = useState(() => getNextCompanyNumber(companies))
   const [selectedCompanyIds, setSelectedCompanyIds] = useLocalStorage('valuationFrameworkSelected', [])
@@ -40,11 +41,14 @@ function App() {
   const { notifications, removeNotification, showSuccess, showInfo, showError } = useNotifications()
 
   const updateCompany = useCallback((companyId, data) => {
-    setCompanies(prev => ({
-      ...prev,
-      [companyId]: { ...prev[companyId], ...data }
-    }))
-  }, [setCompanies])
+    setStoredCompanies((prev) => {
+      const normalizedPrev = normalizeStoredCompanies(prev)
+      return {
+        ...normalizedPrev,
+        [companyId]: { ...normalizedPrev[companyId], ...data }
+      }
+    })
+  }, [setStoredCompanies])
 
   const applyScenario = (scenarioData) => {
     updateCompany(activeCompany, scenarioData)
@@ -63,7 +67,7 @@ function App() {
       : `Startup ${nextCompanyId}`
     const newCompany = createDefaultCompany(companyName)
 
-    setCompanies(prev => ({ ...prev, [newCompanyId]: newCompany }))
+    setStoredCompanies(prev => ({ ...normalizeStoredCompanies(prev), [newCompanyId]: newCompany }))
     setActiveCompany(newCompanyId)
     setNextCompanyId(prev => prev + 1)
   }
@@ -76,7 +80,7 @@ function App() {
       ? structuredClone(source)
       : JSON.parse(JSON.stringify(source))
     copy.name = nextUniqueName(source.name, companies)
-    setCompanies(prev => ({ ...prev, [newCompanyId]: copy }))
+    setStoredCompanies(prev => ({ ...normalizeStoredCompanies(prev), [newCompanyId]: copy }))
     setActiveCompany(newCompanyId)
     setNextCompanyId(prev => prev + 1)
   }
@@ -86,7 +90,7 @@ function App() {
 
     const newCompanies = { ...companies }
     delete newCompanies[companyId]
-    setCompanies(newCompanies)
+    setStoredCompanies(newCompanies)
 
     setSelectedCompanyIds(prev => prev.filter(id => id !== companyId))
 
@@ -103,13 +107,22 @@ function App() {
     ))
   }
 
+  useEffect(() => {
+    const raw = JSON.stringify(storedCompanies)
+    const normalized = JSON.stringify(companies)
+
+    if (raw !== normalized) {
+      setStoredCompanies(companies)
+    }
+  }, [storedCompanies, companies, setStoredCompanies])
+
   // Load scenario from URL on mount (only once)
   useEffect(() => {
     const companyIds = Object.keys(companies || {})
 
     if (companyIds.length === 0) {
       const fallback = { company1: createDefaultCompany('Startup Alpha') }
-      setCompanies(fallback)
+      setStoredCompanies(fallback)
       setActiveCompany('company1')
       setNextCompanyId(2)
       return
@@ -123,7 +136,7 @@ function App() {
     if (nextCompanyId !== derivedNextCompanyId) {
       setNextCompanyId(derivedNextCompanyId)
     }
-  }, [companies, activeCompany, nextCompanyId, setCompanies])
+  }, [companies, activeCompany, nextCompanyId, setStoredCompanies])
 
   useEffect(() => {
     if (!hasLoadedFromURL) {

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import App from './App'
 
 describe('App Component - Local Storage Integration', () => {
@@ -171,6 +171,32 @@ describe('App Component - Local Storage Integration', () => {
   })
 
   describe('Data Migration Scenarios', () => {
+    it('should migrate old single-company browser storage into the multi-company format', async () => {
+      const legacySingleCompany = {
+        name: 'Legacy Browser Company',
+        postMoney: 15,
+        round: 3,
+        investor: 2
+      }
+
+      localStorage.setItem('valuationFramework', JSON.stringify(legacySingleCompany))
+
+      render(<App />)
+
+      expect(screen.getByText('Legacy Browser Company')).toBeInTheDocument()
+
+      await waitFor(() => {
+        const migrated = JSON.parse(localStorage.getItem('valuationFramework'))
+        expect(migrated).toHaveProperty('company1')
+        expect(migrated.company1.postMoneyVal).toBe(15)
+        expect(migrated.company1.roundSize).toBe(3)
+        expect(migrated.company1.investorPortion).toBe(2)
+        expect(migrated.company1.otherPortion).toBe(1)
+        expect(Array.isArray(migrated.company1.priorInvestors)).toBe(true)
+        expect(Array.isArray(migrated.company1.founders)).toBe(true)
+      })
+    })
+
     it('should handle old data format gracefully', () => {
       // Simulate data from an older version of the app
       const oldFormatData = {

--- a/react-app/src/App.multicompany.test.jsx
+++ b/react-app/src/App.multicompany.test.jsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import App from './App'
+
+vi.mock('./components/CompanyTabs', () => ({
+  default: ({ companies, activeCompany, onCompanyChange, onAddCompany, selectedCompanyIds, onToggleCompareSelection }) => (
+    <div data-testid="company-tabs">
+      {Object.entries(companies).map(([id, company]) => (
+        <div key={id}>
+          <button data-testid={`tab-${id}`} onClick={() => onCompanyChange(id)}>
+            {company.name}{activeCompany === id ? ' (active)' : ''}
+          </button>
+          <button data-testid={`compare-${id}`} onClick={() => onToggleCompareSelection(id)}>
+            {selectedCompanyIds.includes(id) ? `Uncompare ${company.name}` : `Compare ${company.name}`}
+          </button>
+        </div>
+      ))}
+      <button data-testid="add-company" onClick={onAddCompany}>Add Company</button>
+    </div>
+  )
+}))
+
+vi.mock('./components/InputForm', () => ({
+  default: ({ company }) => (
+    <div data-testid="input-form">{company?.name || 'no-company'}</div>
+  )
+}))
+
+vi.mock('./components/ScenarioCard', () => ({
+  default: ({ isBase, companyName, scenario }) => (
+    <div data-testid={isBase ? 'base-scenario' : 'alt-scenario'}>
+      {isBase ? (companyName || scenario?.title || 'Base Case') : (scenario?.title || 'Scenario')}
+    </div>
+  )
+}))
+
+vi.mock('./components/ScenarioControls', () => ({
+  default: () => <div data-testid="scenario-controls">Scenario Controls</div>
+}))
+
+vi.mock('./components/Logo', () => ({
+  default: () => <div data-testid="logo">Logo</div>
+}))
+
+vi.mock('./components/NotificationContainer', () => ({
+  default: () => null
+}))
+
+vi.mock('./components/ExitMathModule', () => ({
+  default: () => <div data-testid="exit-math">Exit Math</div>
+}))
+
+describe('App multi-company state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://localhost:3000',
+        origin: 'http://localhost:3000',
+        pathname: '/',
+        search: '',
+        hash: '',
+      },
+      writable: true,
+    })
+  })
+
+  it('hydrates the active company from persisted data and appends new company ids after the max existing id', async () => {
+    window.localStorage.setItem('valuationFramework', JSON.stringify({
+      company2: {
+        name: 'Persisted Beta',
+        postMoneyVal: 20,
+        roundSize: 4,
+        investorPortion: 3,
+        otherPortion: 1,
+        investorName: 'US',
+        showAdvanced: false,
+        safes: [],
+        priorInvestors: [],
+        founders: [],
+        currentEsopPercent: 0,
+        grantedEsopPercent: 0,
+        targetEsopPercent: 0,
+        esopTiming: 'pre-close',
+        scenarioOffsets: [-30, -20, -10, 10, 20, 30],
+        showExitMath: false,
+        exitMath: { exitValuation: 5000, numRounds: 3, uniformDilution: 20, perRoundOverrides: [] }
+      }
+    }))
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('input-form')).toHaveTextContent('Persisted Beta')
+    })
+
+    fireEvent.click(screen.getByTestId('add-company'))
+
+    const stored = JSON.parse(window.localStorage.getItem('valuationFramework'))
+    expect(Object.keys(stored).sort()).toEqual(['company2', 'company3'])
+    expect(stored.company2.name).toBe('Persisted Beta')
+    expect(stored.company3.name).toBe('Startup C')
+  })
+
+  it('hides non-base scenarios while compare mode is active', async () => {
+    render(<App />)
+
+    fireEvent.click(screen.getByTestId('add-company'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-company2')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('compare-company1'))
+    fireEvent.click(screen.getByTestId('compare-company2'))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('base-scenario')).toHaveLength(2)
+    })
+
+    expect(screen.queryByTestId('alt-scenario')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('scenario-controls')).not.toBeInTheDocument()
+  })
+})

--- a/react-app/src/components/CompanyTabs-dup-compare.test.jsx
+++ b/react-app/src/components/CompanyTabs-dup-compare.test.jsx
@@ -71,6 +71,13 @@ describe('CompanyTabs duplicate + compare', () => {
     expect(props.onCompanyChange).not.toHaveBeenCalled()
   })
 
+  it('marks the active tab as current', () => {
+    render(<CompanyTabs {...props} />)
+
+    expect(screen.getByText('Startup Alpha').closest('.tab')).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByText('Startup Beta').closest('.tab')).not.toHaveAttribute('aria-current')
+  })
+
   it('scrolls the active tab into view when selection changes', () => {
     const { rerender } = render(<CompanyTabs {...props} />)
     expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1)

--- a/react-app/src/components/CompanyTabs-dup-compare.test.jsx
+++ b/react-app/src/components/CompanyTabs-dup-compare.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import CompanyTabs from './CompanyTabs'
 
@@ -21,8 +21,16 @@ const baseProps = () => ({
 
 describe('CompanyTabs duplicate + compare', () => {
   let props
+  let originalScrollIntoView
+
   beforeEach(() => {
     props = baseProps()
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView
   })
 
   it('renders duplicate button and calls onDuplicateCompany on click', () => {
@@ -61,5 +69,13 @@ describe('CompanyTabs duplicate + compare', () => {
     const boxes = screen.getAllByRole('checkbox', { name: /include .* in compare/i })
     fireEvent.click(boxes[1])
     expect(props.onCompanyChange).not.toHaveBeenCalled()
+  })
+
+  it('scrolls the active tab into view when selection changes', () => {
+    const { rerender } = render(<CompanyTabs {...props} />)
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1)
+
+    rerender(<CompanyTabs {...props} activeCompany="c2" />)
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(2)
   })
 })

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -72,6 +72,7 @@ const CompanyTabs = ({
                 key={companyId}
                 data-company-id={companyId}
                 className={`tab ${activeCompany === companyId ? 'active' : ''}`}
+                aria-current={activeCompany === companyId ? 'page' : undefined}
                 onClick={() => handleTabClick(companyId)}
               >
                 {onToggleCompareSelection && (

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const CompanyTabs = ({
   companies,
@@ -13,6 +13,19 @@ const CompanyTabs = ({
 }) => {
   const [editingTab, setEditingTab] = useState(null)
   const [editName, setEditName] = useState('')
+  const tabsScrollRef = useRef(null)
+  const companyEntries = Object.entries(companies)
+  const companyCount = companyEntries.length
+
+  useEffect(() => {
+    const tabsScroll = tabsScrollRef.current
+    if (!tabsScroll) return
+
+    const activeTab = tabsScroll.querySelector(`[data-company-id="${activeCompany}"]`)
+    if (typeof activeTab?.scrollIntoView === 'function') {
+      activeTab.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    }
+  }, [activeCompany, companyCount])
 
   const handleTabClick = (companyId) => {
     if (editingTab !== companyId) {
@@ -52,84 +65,89 @@ const CompanyTabs = ({
   return (
     <div className="company-tabs">
       <div className="tabs-container">
-        {Object.entries(companies).map(([companyId, company]) => (
-          <div
-            key={companyId}
-            className={`tab ${activeCompany === companyId ? 'active' : ''}`}
-            onClick={() => handleTabClick(companyId)}
-          >
-            {onToggleCompareSelection && (
-              <input
-                type="checkbox"
-                className="tab-compare-checkbox"
-                checked={selectedCompanyIds.includes(companyId)}
-                onChange={() => onToggleCompareSelection(companyId)}
-                onClick={(e) => e.stopPropagation()}
-                title="Include in compare view"
-                aria-label={`Include ${company.name} in compare view`}
-              />
-            )}
-            {editingTab === companyId ? (
-              <input
-                type="text"
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                onBlur={() => saveEdit(companyId)}
-                onKeyDown={(e) => handleKeyPress(e, companyId)}
-                className="tab-edit-input"
-                autoFocus
-                onClick={(e) => e.stopPropagation()}
-              />
-            ) : (
-              <>
-                <span className="tab-name">{company.name}</span>
-                <div className="tab-actions">
-                  <button
-                    className="tab-edit-btn"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      startEditing(companyId, company.name)
-                    }}
-                    title="Edit name"
-                  >
-                    ✏️
-                  </button>
-                  {onDuplicateCompany && (
-                    <button
-                      className="tab-duplicate-btn"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onDuplicateCompany(companyId)
-                      }}
-                      title="Duplicate company"
-                      aria-label="Duplicate company"
-                    >
-                      ⧉
-                    </button>
-                  )}
-                  {Object.keys(companies).length > 1 && (
-                    <button
-                      className="tab-remove-btn"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        const name = company.name || 'this scenario'
-                        if (window.confirm(`Delete "${name}"? This cannot be undone.`)) {
-                          onRemoveCompany(companyId)
-                        }
-                      }}
-                      title="Remove company"
-                    >
-                      ×
-                    </button>
-                  )}
-                </div>
-              </>
-            )}
-            <div className="tab-indicator" />
-            <div className="tab-stripe-pattern" />
+        <div className="tabs-scroll" ref={tabsScrollRef}>
+          <div className="tabs-list">
+            {companyEntries.map(([companyId, company]) => (
+              <div
+                key={companyId}
+                data-company-id={companyId}
+                className={`tab ${activeCompany === companyId ? 'active' : ''}`}
+                onClick={() => handleTabClick(companyId)}
+              >
+                {onToggleCompareSelection && (
+                  <input
+                    type="checkbox"
+                    className="tab-compare-checkbox"
+                    checked={selectedCompanyIds.includes(companyId)}
+                    onChange={() => onToggleCompareSelection(companyId)}
+                    onClick={(e) => e.stopPropagation()}
+                    title="Include in compare view"
+                    aria-label={`Include ${company.name} in compare view`}
+                  />
+                )}
+                {editingTab === companyId ? (
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onBlur={() => saveEdit(companyId)}
+                    onKeyDown={(e) => handleKeyPress(e, companyId)}
+                    className="tab-edit-input"
+                    autoFocus
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                ) : (
+                  <>
+                    <span className="tab-name">{company.name}</span>
+                    <div className="tab-actions">
+                      <button
+                        className="tab-edit-btn"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          startEditing(companyId, company.name)
+                        }}
+                        title="Edit name"
+                      >
+                        ✏️
+                      </button>
+                      {onDuplicateCompany && (
+                        <button
+                          className="tab-duplicate-btn"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onDuplicateCompany(companyId)
+                          }}
+                          title="Duplicate company"
+                          aria-label="Duplicate company"
+                        >
+                          ⧉
+                        </button>
+                      )}
+                      {companyCount > 1 && (
+                        <button
+                          className="tab-remove-btn"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            const name = company.name || 'this scenario'
+                            if (window.confirm(`Delete "${name}"? This cannot be undone.`)) {
+                              onRemoveCompany(companyId)
+                            }
+                          }}
+                          title="Remove company"
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
+                  </>
+                )}
+                <div className="tab-indicator" />
+                <div className="tab-stripe-pattern" />
+              </div>
+            ))}
           </div>
-        ))}
-        
+        </div>
+
         <button className="add-company-btn" onClick={onAddCompany} title="Add new company">
           <span className="add-icon">+</span>
           <span className="add-text">Add Company</span>

--- a/react-app/src/components/InputForm-twostep.test.jsx
+++ b/react-app/src/components/InputForm-twostep.test.jsx
@@ -163,4 +163,48 @@ describe('InputForm - Two-Step Round', () => {
     const investorLabels = screen.getAllByText(/Acme VC Portion/)
     expect(investorLabels.length).toBe(2)
   })
+
+  it('should clamp step 2 investor portion to step 2 amount', () => {
+    render(<InputForm company={{
+      ...defaultCompany,
+      twoStepEnabled: true,
+      step2PostMoney: 1000,
+      step2Amount: 200,
+      step2InvestorPortion: 100,
+      step2OtherPortion: 100
+    }} onUpdate={mockOnUpdate} />)
+
+    const inputs = screen.getAllByRole('spinbutton')
+    const step2InvestorInput = inputs[6]
+    fireEvent.change(step2InvestorInput, { target: { value: '250' } })
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step2InvestorPortion: 200,
+        step2OtherPortion: 0
+      })
+    )
+  })
+
+  it('should clamp step 2 investor portion when step 2 amount shrinks', () => {
+    render(<InputForm company={{
+      ...defaultCompany,
+      twoStepEnabled: true,
+      step2PostMoney: 1000,
+      step2Amount: 200,
+      step2InvestorPortion: 150,
+      step2OtherPortion: 50
+    }} onUpdate={mockOnUpdate} />)
+
+    const amountInput = screen.getByLabelText('Amount')
+    fireEvent.change(amountInput, { target: { value: '120' } })
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        step2Amount: 120,
+        step2InvestorPortion: 120,
+        step2OtherPortion: 0
+      })
+    )
+  })
 })

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -5,6 +5,7 @@ import FormInput from './FormInput'
 import { migrateLegacyCompany } from '../utils/dataStructures'
 
 const InputForm = ({ company, onUpdate }) => {
+  const roundToCents = (value) => Math.round(Math.max(0, value) * 100) / 100
   const [values, setValues] = useState({
     postMoneyVal: 13,
     roundSize: 3,
@@ -72,28 +73,36 @@ const InputForm = ({ company, onUpdate }) => {
     // Auto-calculate step 2 other portion
     if (field === 'step2Amount' || field === 'step2InvestorPortion') {
       if (field === 'step2Amount') {
-        newValues.step2OtherPortion = Math.round(Math.max(0, numValue - (values.step2InvestorPortion || 0)) * 100) / 100
+        const clampedInvestor = Math.min(values.step2InvestorPortion || 0, numValue)
+        newValues.step2InvestorPortion = roundToCents(clampedInvestor)
+        newValues.step2OtherPortion = roundToCents(numValue - clampedInvestor)
       } else if (field === 'step2InvestorPortion') {
-        newValues.step2OtherPortion = Math.round(Math.max(0, (values.step2Amount || 0) - numValue) * 100) / 100
+        const clampedInvestor = Math.min(numValue, values.step2Amount || 0)
+        newValues.step2InvestorPortion = roundToCents(clampedInvestor)
+        newValues.step2OtherPortion = roundToCents((values.step2Amount || 0) - clampedInvestor)
       }
     }
     if (field === 'step2OtherPortion') {
       const clampedOther = Math.min(numValue, values.step2Amount || 0)
-      newValues.step2OtherPortion = Math.round(Math.max(0, clampedOther) * 100) / 100
-      newValues.step2InvestorPortion = Math.round(Math.max(0, (values.step2Amount || 0) - newValues.step2OtherPortion) * 100) / 100
+      newValues.step2OtherPortion = roundToCents(clampedOther)
+      newValues.step2InvestorPortion = roundToCents((values.step2Amount || 0) - newValues.step2OtherPortion)
     }
 
     // Auto-calculate other portion when round size or investor portion changes
     if (field === 'roundSize' || field === 'investorPortion') {
       if (field === 'roundSize') {
-        newValues.otherPortion = Math.round(Math.max(0, numValue - values.investorPortion) * 100) / 100
+        const clampedInvestor = Math.min(values.investorPortion || 0, numValue)
+        newValues.investorPortion = roundToCents(clampedInvestor)
+        newValues.otherPortion = roundToCents(numValue - clampedInvestor)
         // Update post-money if in pre-money mode
         if (inputMode === 'pre-money') {
           const currentPreMoney = values.postMoneyVal - values.roundSize
-          newValues.postMoneyVal = Math.round((currentPreMoney + numValue) * 100) / 100
+          newValues.postMoneyVal = roundToCents(currentPreMoney + numValue)
         }
       } else if (field === 'investorPortion') {
-        newValues.otherPortion = Math.round(Math.max(0, values.roundSize - numValue) * 100) / 100
+        const clampedInvestor = Math.min(numValue, values.roundSize || 0)
+        newValues.investorPortion = roundToCents(clampedInvestor)
+        newValues.otherPortion = roundToCents((values.roundSize || 0) - clampedInvestor)
       }
     }
 
@@ -101,8 +110,8 @@ const InputForm = ({ company, onUpdate }) => {
     if (field === 'otherPortion') {
       // Clamp to round size
       const clampedOther = Math.min(numValue, values.roundSize)
-      newValues.otherPortion = Math.round(Math.max(0, clampedOther) * 100) / 100
-      newValues.investorPortion = Math.round(Math.max(0, values.roundSize - newValues.otherPortion) * 100) / 100
+      newValues.otherPortion = roundToCents(clampedOther)
+      newValues.investorPortion = roundToCents((values.roundSize || 0) - newValues.otherPortion)
     }
     
     

--- a/react-app/src/components/InputForm.test.jsx
+++ b/react-app/src/components/InputForm.test.jsx
@@ -92,8 +92,7 @@ describe('InputForm with Pre-Money Toggle', () => {
     
     // Change round size
     const roundSizeInput = screen.getByLabelText('Round Size')
-    await user.clear(roundSizeInput)
-    await user.type(roundSizeInput, '4')
+    fireEvent.change(roundSizeInput, { target: { value: '4' } })
 
     // Post-money should be recalculated: current pre-money (10) + new round size (4) = 14
     expect(mockOnUpdate).toHaveBeenCalledWith(
@@ -161,5 +160,32 @@ describe('InputForm with Pre-Money Toggle', () => {
     
     // Should have reduced padding for compact layout
     expect(inputForm).toHaveClass('input-form')
+  })
+
+  it('should clamp investor portion to round size', () => {
+    render(<InputForm company={defaultCompany} onUpdate={mockOnUpdate} />)
+
+    fireEvent.change(screen.getByLabelText('US Portion'), { target: { value: '5' } })
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        investorPortion: 3,
+        otherPortion: 0
+      })
+    )
+  })
+
+  it('should clamp investor portion when round size drops below it', () => {
+    render(<InputForm company={defaultCompany} onUpdate={mockOnUpdate} />)
+
+    fireEvent.change(screen.getByLabelText('Round Size'), { target: { value: '2' } })
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roundSize: 2,
+        investorPortion: 2,
+        otherPortion: 0
+      })
+    )
   })
 })

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -38,24 +38,30 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   const isTwoStep = !!(scenario.twoStepEnabled && scenario.step1 && scenario.step2)
 
   const buildScenarioData = () => {
+    const sourceCompany = company || {}
+    const useCompanyInputs = Boolean(company)
+
     const data = {
       postMoneyVal: isTwoStep ? scenario.step1.postMoney : scenario.postMoneyVal,
-      roundSize: isTwoStep ? scenario.step1.amount : scenario.roundSize,
-      investorPortion: isTwoStep ? scenario.step1.investorAmount : scenario.investorAmount,
-      otherPortion: isTwoStep ? scenario.step1.otherAmount : (scenario.otherAmountOriginal || scenario.otherAmount),
-      proRataPercent: scenario.proRataPercentInput || 0,
-      safes: scenario.safes || [],
-      preRoundFounderOwnership: scenario.preRoundFounderPercent ?? 0,
-      priorInvestors: scenario.priorInvestors || [],
-      founders: scenario.founders || [],
-      currentEsopPercent: scenario.currentEsopPercent || 0,
-      targetEsopPercent: scenario.targetEsopPercent || 0,
-      esopTiming: scenario.esopTiming || 'pre-close',
-      twoStepEnabled: isTwoStep,
-      step2PostMoney: isTwoStep ? scenario.step2.postMoney : 0,
-      step2Amount: isTwoStep ? scenario.step2.amount : 0,
-      step2InvestorPortion: isTwoStep ? scenario.step2.investorAmount : 0,
-      step2OtherPortion: isTwoStep ? scenario.step2.otherAmount : 0
+      roundSize: useCompanyInputs ? (sourceCompany.roundSize || 0) : (isTwoStep ? scenario.step1.amount : scenario.roundSize),
+      investorPortion: useCompanyInputs ? (sourceCompany.investorPortion || 0) : (isTwoStep ? scenario.step1.investorAmount : scenario.investorAmount),
+      otherPortion: useCompanyInputs ? (sourceCompany.otherPortion || 0) : (isTwoStep ? scenario.step1.otherAmount : (scenario.otherAmountOriginal || scenario.otherAmount)),
+      investorName: sourceCompany.investorName || investorName,
+      showAdvanced: sourceCompany.showAdvanced ?? showAdvanced,
+      proRataPercent: useCompanyInputs ? (sourceCompany.proRataPercent || 0) : (scenario.proRataPercentInput || 0),
+      safes: useCompanyInputs ? (sourceCompany.safes || []) : (scenario.safes || []),
+      preRoundFounderOwnership: useCompanyInputs ? (sourceCompany.preRoundFounderOwnership || 0) : (scenario.preRoundFounderPercent ?? 0),
+      priorInvestors: useCompanyInputs ? (sourceCompany.priorInvestors || []) : (scenario.priorInvestors || []),
+      founders: useCompanyInputs ? (sourceCompany.founders || []) : (scenario.founders || []),
+      currentEsopPercent: useCompanyInputs ? (sourceCompany.currentEsopPercent || 0) : (scenario.currentEsopPercent || 0),
+      grantedEsopPercent: useCompanyInputs ? (sourceCompany.grantedEsopPercent || 0) : (scenario.grantedEsopPercent || 0),
+      targetEsopPercent: useCompanyInputs ? (sourceCompany.targetEsopPercent || 0) : (scenario.targetEsopPercent || 0),
+      esopTiming: sourceCompany.esopTiming || scenario.esopTiming || 'pre-close',
+      twoStepEnabled: useCompanyInputs ? Boolean(sourceCompany.twoStepEnabled) : isTwoStep,
+      step2PostMoney: isTwoStep ? scenario.step2.postMoney : (sourceCompany.step2PostMoney || 0),
+      step2Amount: useCompanyInputs ? (sourceCompany.step2Amount || 0) : (isTwoStep ? scenario.step2.amount : 0),
+      step2InvestorPortion: useCompanyInputs ? (sourceCompany.step2InvestorPortion || 0) : (isTwoStep ? scenario.step2.investorAmount : 0),
+      step2OtherPortion: useCompanyInputs ? (sourceCompany.step2OtherPortion || 0) : (isTwoStep ? scenario.step2.otherAmount : 0)
     }
     return data
   }
@@ -70,13 +76,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     if (!onCopyPermalink) return
 
     try {
-      const scenarioData = {
-        ...buildScenarioData(),
-        investorName,
-        showAdvanced
-      }
-
-      const result = await onCopyPermalink(scenarioData)
+      const result = await onCopyPermalink(buildScenarioData())
       
       if (result.success) {
         setCopyFeedback('Copied!')

--- a/react-app/src/components/ScenarioCard.test.jsx
+++ b/react-app/src/components/ScenarioCard.test.jsx
@@ -21,7 +21,9 @@ describe('ScenarioCard with Permalink', () => {
     safes: [],
     totalSafePercent: 0,
     postRoundFounderPercent: 76.9,
-    founderDilution: 23.1
+    founderDilution: 23.1,
+    priorInvestors: [],
+    founders: []
   }
 
   const mockOnApplyScenario = vi.fn()
@@ -240,6 +242,183 @@ describe('ScenarioCard with Permalink', () => {
             dilution: 6.9
           }
         ]
+      })
+    )
+  })
+
+  it('should prefer company input state for permalink payloads when company is provided', async () => {
+    const company = {
+      name: 'Startup Alpha',
+      postMoneyVal: 13,
+      roundSize: 3,
+      investorPortion: 2,
+      otherPortion: 1,
+      investorName: 'US',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 1,
+          name: 'Previous Investors',
+          ownershipPercent: 15,
+          hasProRataRights: true,
+          proRataOverride: 0.8
+        }
+      ],
+      founders: [
+        {
+          id: 1,
+          name: 'Founder Team',
+          ownershipPercent: 85
+        }
+      ],
+      safes: [],
+      currentEsopPercent: 10,
+      grantedEsopPercent: 2.5,
+      targetEsopPercent: 7,
+      esopTiming: 'pre-close'
+    }
+
+    const derivedScenario = {
+      ...mockScenario,
+      priorInvestors: [
+        {
+          id: 1,
+          name: 'Previous Investors',
+          ownershipPercent: 13.5,
+          hasProRataRights: true,
+          proRataAmount: 0.8,
+          postRoundPercent: 11.5,
+          dilution: 2
+        }
+      ],
+      founders: [
+        {
+          id: 1,
+          name: 'Founder Team',
+          ownershipPercent: 76.5,
+          postRoundPercent: 58.8,
+          dilution: 17.7
+        }
+      ],
+      currentEsopPercent: 10,
+      grantedEsopPercent: 2.5,
+      targetEsopPercent: 7
+    }
+
+    mockOnCopyPermalink.mockResolvedValue({ success: true })
+    const user = userEvent.setup()
+
+    render(
+      <ScenarioCard
+        scenario={derivedScenario}
+        index={0}
+        isBase={true}
+        company={company}
+        onCopyPermalink={mockOnCopyPermalink}
+        investorName="US"
+        showAdvanced={true}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /🔗/ }))
+
+    expect(mockOnCopyPermalink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        investorPortion: 2,
+        otherPortion: 1,
+        priorInvestors: company.priorInvestors,
+        founders: company.founders,
+        currentEsopPercent: 10,
+        grantedEsopPercent: 2.5,
+        targetEsopPercent: 7
+      })
+    )
+  })
+
+  it('should prefer company input state when applying a non-base scenario', async () => {
+    const company = {
+      postMoneyVal: 13,
+      roundSize: 3,
+      investorPortion: 2,
+      otherPortion: 1,
+      investorName: 'US',
+      showAdvanced: true,
+      priorInvestors: [
+        {
+          id: 1,
+          name: 'Previous Investors',
+          ownershipPercent: 15,
+          hasProRataRights: true,
+          proRataOverride: 0.8
+        }
+      ],
+      founders: [
+        {
+          id: 1,
+          name: 'Founder Team',
+          ownershipPercent: 85
+        }
+      ],
+      safes: [],
+      currentEsopPercent: 10,
+      grantedEsopPercent: 2.5,
+      targetEsopPercent: 7,
+      esopTiming: 'pre-close'
+    }
+
+    const altScenario = {
+      ...mockScenario,
+      title: '−25%',
+      postMoneyVal: 9.75,
+      priorInvestors: [
+        {
+          id: 1,
+          name: 'Previous Investors',
+          ownershipPercent: 13.5,
+          hasProRataRights: true,
+          proRataAmount: 0.8,
+          postRoundPercent: 11.5,
+          dilution: 2
+        }
+      ],
+      founders: [
+        {
+          id: 1,
+          name: 'Founder Team',
+          ownershipPercent: 76.5,
+          postRoundPercent: 58.8,
+          dilution: 17.7
+        }
+      ],
+      currentEsopPercent: 10,
+      grantedEsopPercent: 2.5,
+      targetEsopPercent: 7
+    }
+
+    const user = userEvent.setup()
+
+    render(
+      <ScenarioCard
+        scenario={altScenario}
+        index={1}
+        isBase={false}
+        company={company}
+        onApplyScenario={mockOnApplyScenario}
+        investorName="US"
+        showAdvanced={true}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /apply this scenario/i }))
+
+    expect(mockOnApplyScenario).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postMoneyVal: 9.75,
+        investorPortion: 2,
+        otherPortion: 1,
+        priorInvestors: company.priorInvestors,
+        founders: company.founders,
+        grantedEsopPercent: 2.5
       })
     )
   })

--- a/react-app/src/components/ScenarioControls.jsx
+++ b/react-app/src/components/ScenarioControls.jsx
@@ -1,45 +1,36 @@
 import { useState } from 'react'
+import { buildScenarioOffsets, formatScenarioOffsetValue, normalizeScenarioOffsets } from '../utils/scenarioOffsets'
 
 const PRESETS = [
-  { label: '±10', offsets: [-10, 10] },
-  { label: '±20', offsets: [-20, -10, 10, 20] },
-  { label: '±30', offsets: [-30, -20, -10, 10, 20, 30] }
+  { label: '±10', max: 10 },
+  { label: '±20', max: 20 },
+  { label: '±30', max: 30 }
 ]
 
 const formatOffset = (n) => {
-  if (n > 0) return `+${n}%`
-  return `−${Math.abs(n)}%`
+  const value = formatScenarioOffsetValue(Math.abs(n))
+  if (n > 0) return `+${value}%`
+  return `−${value}%`
 }
 
-const arraysEqual = (a, b) => {
-  if (a.length !== b.length) return false
-  const sa = [...a].sort((x, y) => x - y)
-  const sb = [...b].sort((x, y) => x - y)
-  return sa.every((v, i) => v === sb[i])
-}
+const isSameBand = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 
 const ScenarioControls = ({ offsets = [], onChange }) => {
   const [adding, setAdding] = useState(false)
   const [draft, setDraft] = useState('')
 
-  const sorted = [...offsets].sort((a, b) => a - b)
-  const allKnown = Array.from(new Set([...sorted, -30, -20, -10, 10, 20, 30])).sort((a, b) => a - b)
+  const currentBand = normalizeScenarioOffsets(offsets)
 
-  const toggle = (n) => {
-    const next = sorted.includes(n) ? sorted.filter(x => x !== n) : [...sorted, n]
-    onChange(next.sort((a, b) => a - b))
-  }
-
-  const applyPreset = (presetOffsets) => {
-    onChange([...presetOffsets])
+  const applyPreset = (max) => {
+    onChange(buildScenarioOffsets(max))
   }
 
   const commitDraft = () => {
     const parsed = Number(draft)
     if (Number.isFinite(parsed)) {
-      const rounded = Math.round(parsed)
-      if (rounded !== 0 && rounded > -100 && !sorted.includes(rounded)) {
-        onChange([...sorted, rounded].sort((a, b) => a - b))
+      const max = Math.abs(parsed)
+      if (max > 0 && max < 100) {
+        onChange(buildScenarioOffsets(max))
       }
     }
     setDraft('')
@@ -55,19 +46,15 @@ const ScenarioControls = ({ offsets = [], onChange }) => {
     <div className="scenario-controls" role="group" aria-label="Sensitivity scenarios">
       <span className="scenario-controls-label">Sensitivity</span>
       <div className="scenario-pills">
-        {allKnown.map(n => {
-          const active = sorted.includes(n)
+        {currentBand.map(n => {
           const direction = n < 0 ? 'down' : 'up'
           return (
-            <button
+            <span
               key={n}
-              type="button"
-              className={`scenario-pill scenario-pill-${direction}${active ? ' active' : ''}`}
-              onClick={() => toggle(n)}
-              aria-pressed={active}
+              className={`scenario-pill scenario-pill-${direction} active`}
             >
               {formatOffset(n)}
-            </button>
+            </span>
           )
         })}
         {adding ? (
@@ -82,8 +69,8 @@ const ScenarioControls = ({ offsets = [], onChange }) => {
                 if (e.key === 'Enter') { e.preventDefault(); commitDraft() }
                 if (e.key === 'Escape') { e.preventDefault(); cancelDraft() }
               }}
-              placeholder="±%"
-              step="5"
+              placeholder="max %"
+              step="2.5"
             />
           </span>
         ) : (
@@ -91,7 +78,7 @@ const ScenarioControls = ({ offsets = [], onChange }) => {
             type="button"
             className="scenario-pill scenario-pill-add"
             onClick={() => setAdding(true)}
-            aria-label="Add custom offset"
+            aria-label="Set custom max delta"
           >
             +
           </button>
@@ -99,13 +86,13 @@ const ScenarioControls = ({ offsets = [], onChange }) => {
       </div>
       <div className="scenario-presets" aria-label="Range presets">
         {PRESETS.map(p => {
-          const active = arraysEqual(sorted, p.offsets)
+          const active = isSameBand(currentBand, buildScenarioOffsets(p.max))
           return (
             <button
               key={p.label}
               type="button"
               className={`scenario-preset${active ? ' active' : ''}`}
-              onClick={() => applyPreset(p.offsets)}
+              onClick={() => applyPreset(p.max)}
             >
               {p.label}
             </button>

--- a/react-app/src/components/ScenarioControls.test.jsx
+++ b/react-app/src/components/ScenarioControls.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ScenarioControls from './ScenarioControls'
+
+describe('ScenarioControls', () => {
+  it('renders a normalized 3-down / 3-up band from offsets', () => {
+    render(<ScenarioControls offsets={[-30, -20, -10, 10, 20, 30]} onChange={vi.fn()} />)
+
+    expect(screen.getByText('−30%')).toBeInTheDocument()
+    expect(screen.getByText('−15%')).toBeInTheDocument()
+    expect(screen.getByText('−7.5%')).toBeInTheDocument()
+    expect(screen.getByText('+7.5%')).toBeInTheDocument()
+    expect(screen.getByText('+15%')).toBeInTheDocument()
+    expect(screen.getByText('+30%')).toBeInTheDocument()
+  })
+
+  it('applies preset ranges as quarter / half / full bands', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ScenarioControls offsets={[-30, -15, -7.5, 7.5, 15, 30]} onChange={onChange} />)
+
+    await user.click(screen.getByRole('button', { name: '±10' }))
+
+    expect(onChange).toHaveBeenCalledWith([-10, -5, -2.5, 2.5, 5, 10])
+  })
+
+  it('accepts a custom max delta and expands it to six scenarios', () => {
+    const onChange = vi.fn()
+
+    render(<ScenarioControls offsets={[-30, -15, -7.5, 7.5, 15, 30]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /set custom max delta/i }))
+    const input = screen.getByPlaceholderText('max %')
+    fireEvent.change(input, { target: { value: '25' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith([-25, -12.5, -6.25, 6.25, 12.5, 25])
+  })
+})

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -86,6 +86,101 @@ export function calculateTotalOwnership(stakeholders) {
   }, 0)
 }
 
+function getOptionalNumber(...values) {
+  for (const value of values) {
+    if (value === '' || value === null || value === undefined) continue
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function normalizePriorInvestor(investor = {}) {
+  const {
+    proRataAmount: _legacyProRataAmount,
+    ...restInvestor
+  } = investor
+  const base = createPriorInvestor(
+    typeof restInvestor.name === 'string' ? restInvestor.name : '',
+    clamp(getOptionalNumber(restInvestor.ownershipPercent) ?? 0, 0, 100),
+    Boolean(restInvestor.hasProRataRights)
+  )
+  const proRataOverride = getOptionalNumber(restInvestor.proRataOverride, investor.proRataAmount)
+
+  return {
+    ...base,
+    ...restInvestor,
+    name: typeof restInvestor.name === 'string' ? restInvestor.name.trim() : '',
+    ownershipPercent: clamp(getOptionalNumber(restInvestor.ownershipPercent) ?? 0, 0, 100),
+    hasProRataRights: Boolean(restInvestor.hasProRataRights),
+    proRataOverride: proRataOverride === undefined ? null : Math.max(0, proRataOverride)
+  }
+}
+
+function normalizeFounder(founder = {}) {
+  const base = createFounder(
+    typeof founder.name === 'string' ? founder.name : '',
+    clamp(getOptionalNumber(founder.ownershipPercent) ?? 0, 0, 100)
+  )
+
+  return {
+    ...base,
+    ...founder,
+    name: typeof founder.name === 'string' ? founder.name.trim() : '',
+    ownershipPercent: clamp(getOptionalNumber(founder.ownershipPercent) ?? 0, 0, 100)
+  }
+}
+
+function normalizeSafe(safe = {}) {
+  const {
+    proRataAmount: _legacyProRataAmount,
+    ...restSafe
+  } = safe
+  const proRataOverride = getOptionalNumber(restSafe.proRataOverride, safe.proRataAmount)
+  const base = {
+    proRata: false,
+    proRataOverride: null
+  }
+
+  return {
+    ...base,
+    ...restSafe,
+    proRata: Boolean(restSafe.proRata),
+    proRataOverride: proRataOverride === undefined ? null : Math.max(0, proRataOverride)
+  }
+}
+
+function looksLikeSingleStoredCompany(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  return [
+    'postMoneyVal',
+    'postMoney',
+    'roundSize',
+    'round',
+    'investorPortion',
+    'investor',
+    'otherPortion',
+    'other',
+    'investorName',
+    'showAdvanced',
+    'proRataPercent',
+    'preRoundFounderOwnership',
+    'priorInvestors',
+    'founders',
+    'safes',
+    'currentEsopPercent',
+    'targetEsopPercent',
+    'twoStepEnabled',
+    'showExitMath',
+    'exitMath'
+  ].some((key) => Object.prototype.hasOwnProperty.call(value, key))
+}
+
 /**
  * Creates default company data structure with new multi-party support
  * @param {string} companyName - Company name
@@ -147,15 +242,45 @@ export function createDefaultCompany(companyName = 'New Company') {
  * @param {Object} legacyCompany - Company object with legacy fields
  * @returns {Object} Migrated company object
  */
-export function migrateLegacyCompany(legacyCompany) {
-  if (!legacyCompany) {
-    return createDefaultCompany()
+export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company') {
+  if (!legacyCompany || typeof legacyCompany !== 'object' || Array.isArray(legacyCompany)) {
+    return createDefaultCompany(fallbackName)
   }
-  
-  const migrated = { ...legacyCompany }
-  
+
+  const resolvedName = typeof legacyCompany.name === 'string' && legacyCompany.name.trim()
+    ? legacyCompany.name.trim()
+    : fallbackName
+  const defaults = createDefaultCompany(resolvedName)
+  const migrated = {
+    ...defaults,
+    ...legacyCompany,
+    name: resolvedName
+  }
+
+  migrated.postMoneyVal = Math.max(0, getOptionalNumber(legacyCompany.postMoneyVal, legacyCompany.postMoney) ?? defaults.postMoneyVal)
+  migrated.roundSize = Math.max(0, getOptionalNumber(legacyCompany.roundSize, legacyCompany.round) ?? defaults.roundSize)
+  migrated.investorPortion = clamp(
+    Math.max(0, getOptionalNumber(legacyCompany.investorPortion, legacyCompany.investor) ?? defaults.investorPortion),
+    0,
+    migrated.roundSize
+  )
+
+  const explicitOtherPortion = getOptionalNumber(legacyCompany.otherPortion, legacyCompany.other)
+  migrated.otherPortion = explicitOtherPortion === undefined
+    ? Math.max(0, migrated.roundSize - migrated.investorPortion)
+    : clamp(Math.max(0, explicitOtherPortion), 0, Math.max(0, migrated.roundSize - migrated.investorPortion))
+  migrated.investorName = typeof migrated.investorName === 'string' && migrated.investorName.trim()
+    ? migrated.investorName.trim()
+    : defaults.investorName
+  migrated.showAdvanced = Boolean(migrated.showAdvanced)
+  migrated.esopTiming = migrated.esopTiming === 'post-close' ? 'post-close' : defaults.esopTiming
+  delete migrated.postMoney
+  delete migrated.round
+  delete migrated.investor
+  delete migrated.other
+
   // Migrate legacy proRataPercent and preRoundFounderOwnership
-  if (!migrated.priorInvestors || !migrated.founders) {
+  if (!Array.isArray(legacyCompany.priorInvestors) && !Array.isArray(legacyCompany.founders)) {
     const legacyProRata = Number(legacyCompany.proRataPercent) || 0
     const legacyFounderOwnership = Number(legacyCompany.preRoundFounderOwnership) || 85
     
@@ -187,39 +312,83 @@ export function migrateLegacyCompany(legacyCompany) {
   }
   
   // Ensure arrays exist even if empty
-  migrated.priorInvestors = migrated.priorInvestors || []
-  migrated.founders = migrated.founders || [createFounder('Founder Team', 85)]
-  migrated.safes = (migrated.safes || []).map(safe => ({
-    proRata: false,
-    proRataOverride: null,
-    ...safe
-  }))
+  migrated.priorInvestors = Array.isArray(migrated.priorInvestors)
+    ? migrated.priorInvestors.map((investor) => normalizePriorInvestor(investor))
+    : []
+  migrated.founders = Array.isArray(migrated.founders)
+    ? migrated.founders.map((founder) => normalizeFounder(founder))
+    : [createFounder('Founder Team', 85)]
+  migrated.safes = Array.isArray(migrated.safes)
+    ? migrated.safes.map((safe) => normalizeSafe(safe))
+    : []
 
   // Ensure 2-step round fields exist
-  if (migrated.twoStepEnabled === undefined) migrated.twoStepEnabled = false
-  if (migrated.step2PostMoney === undefined) migrated.step2PostMoney = 0
-  if (migrated.step2Amount === undefined) migrated.step2Amount = 0
-  if (migrated.step2InvestorPortion === undefined) migrated.step2InvestorPortion = 0
-  if (migrated.step2OtherPortion === undefined) migrated.step2OtherPortion = 0
+  migrated.twoStepEnabled = Boolean(migrated.twoStepEnabled)
+  migrated.step2PostMoney = Math.max(0, getOptionalNumber(migrated.step2PostMoney) ?? 0)
+  migrated.step2Amount = Math.max(0, getOptionalNumber(migrated.step2Amount) ?? 0)
+  migrated.step2InvestorPortion = clamp(
+    Math.max(0, getOptionalNumber(migrated.step2InvestorPortion) ?? 0),
+    0,
+    migrated.step2Amount
+  )
+  migrated.step2OtherPortion = clamp(
+    Math.max(0, getOptionalNumber(migrated.step2OtherPortion) ?? Math.max(0, migrated.step2Amount - migrated.step2InvestorPortion)),
+    0,
+    Math.max(0, migrated.step2Amount - migrated.step2InvestorPortion)
+  )
 
   // Ensure ESOP fields exist (grantedEsopPercent added after initial release)
-  if (migrated.grantedEsopPercent === undefined) migrated.grantedEsopPercent = 0
+  migrated.currentEsopPercent = Math.max(0, getOptionalNumber(migrated.currentEsopPercent) ?? defaults.currentEsopPercent)
+  migrated.grantedEsopPercent = Math.max(0, getOptionalNumber(migrated.grantedEsopPercent) ?? defaults.grantedEsopPercent)
+  migrated.targetEsopPercent = Math.max(0, getOptionalNumber(migrated.targetEsopPercent) ?? defaults.targetEsopPercent)
+  migrated.percentPrecision = clamp(getOptionalNumber(migrated.percentPrecision) ?? defaults.percentPrecision, 0, 6)
 
   // Ensure scenarioOffsets exist
   migrated.scenarioOffsets = normalizeScenarioOffsets(migrated.scenarioOffsets)
 
   // Ensure Exit Math fields exist
-  if (migrated.showExitMath === undefined) migrated.showExitMath = false
-  if (!migrated.exitMath || typeof migrated.exitMath !== 'object') {
-    migrated.exitMath = {
-      exitValuation: 5000,
-      numRounds: 3,
-      uniformDilution: 20,
-      perRoundOverrides: []
+  migrated.showExitMath = Boolean(migrated.showExitMath)
+  migrated.exitMath = migrated.exitMath && typeof migrated.exitMath === 'object' && !Array.isArray(migrated.exitMath)
+    ? {
+        ...defaults.exitMath,
+        ...migrated.exitMath,
+        perRoundOverrides: Array.isArray(migrated.exitMath.perRoundOverrides)
+          ? migrated.exitMath.perRoundOverrides
+          : defaults.exitMath.perRoundOverrides
+      }
+    : defaults.exitMath
+
+  return migrated
+}
+
+export function normalizeStoredCompanies(storedCompanies, fallbackName = 'Startup Alpha') {
+  const fallback = { company1: createDefaultCompany(fallbackName) }
+
+  if (looksLikeSingleStoredCompany(storedCompanies)) {
+    return {
+      company1: migrateLegacyCompany(storedCompanies, storedCompanies.name || fallbackName)
     }
   }
 
-  return migrated
+  if (!storedCompanies || typeof storedCompanies !== 'object' || Array.isArray(storedCompanies)) {
+    return fallback
+  }
+
+  const entries = Object.entries(storedCompanies).filter(([, company]) => (
+    company &&
+    typeof company === 'object' &&
+    !Array.isArray(company)
+  ))
+
+  if (entries.length === 0) {
+    return fallback
+  }
+
+  return entries.reduce((acc, [companyId, company], index) => {
+    const defaultName = index === 0 ? fallbackName : `Startup ${index + 1}`
+    acc[companyId] = migrateLegacyCompany(company, company?.name || defaultName)
+    return acc
+  }, {})
 }
 
 /**

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -1,3 +1,5 @@
+import { buildScenarioOffsets, normalizeScenarioOffsets } from './scenarioOffsets'
+
 /**
  * Data structure definitions for the enhanced valuation framework
  * Supporting multiple prior investors and founders
@@ -132,7 +134,7 @@ export function createDefaultCompany(companyName = 'New Company') {
     esopTiming: 'pre-close',
 
     // Sensitivity scenarios: valuation % offsets to render as alternative cards
-    scenarioOffsets: [-30, -20, -10, 10, 20, 30],
+    scenarioOffsets: buildScenarioOffsets(30),
     
     // Legacy fields - to be removed after migration
     proRataPercent: 0, // DEPRECATED: Use priorInvestors with hasProRataRights
@@ -204,9 +206,7 @@ export function migrateLegacyCompany(legacyCompany) {
   if (migrated.grantedEsopPercent === undefined) migrated.grantedEsopPercent = 0
 
   // Ensure scenarioOffsets exist
-  if (!Array.isArray(migrated.scenarioOffsets) || migrated.scenarioOffsets.length === 0) {
-    migrated.scenarioOffsets = [-30, -20, -10, 10, 20, 30]
-  }
+  migrated.scenarioOffsets = normalizeScenarioOffsets(migrated.scenarioOffsets)
 
   // Ensure Exit Math fields exist
   if (migrated.showExitMath === undefined) migrated.showExitMath = false

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -4,6 +4,7 @@
  */
 
 import { migrateLegacyCompany, validateCompanyData } from './dataStructures'
+import { buildScenarioOffsets, formatScenarioOffsetValue, normalizeScenarioOffsets } from './scenarioOffsets'
 
 // Use 6 decimal places internally for percentages so the UI can display up to 4
 const P = 1e6
@@ -991,12 +992,12 @@ export function calculateEnhancedScenario(inputs) {
   }
 }
 
-const DEFAULT_SCENARIO_OFFSETS = [-30, -20, -10, 10, 20, 30]
+const DEFAULT_SCENARIO_OFFSETS = buildScenarioOffsets(30)
 
 const formatOffsetTitle = (offset) => {
   if (offset === 0) return 'Base Case'
   const sign = offset > 0 ? '+' : '−'
-  return `${sign}${Math.abs(offset)}%`
+  return `${sign}${formatScenarioOffsetValue(Math.abs(offset))}%`
 }
 
 /**
@@ -1025,11 +1026,7 @@ export function calculateEnhancedScenarios(company, options = {}) {
   }]
 
   const rawOffsets = Array.isArray(options.offsets) ? options.offsets : DEFAULT_SCENARIO_OFFSETS
-  const offsets = Array.from(new Set(
-    rawOffsets
-      .map(n => Number(n))
-      .filter(n => Number.isFinite(n) && n !== 0)
-  )).sort((a, b) => a - b)
+  const offsets = normalizeScenarioOffsets(rawOffsets)
 
   const isTwoStep = company.twoStepEnabled && company.step2PostMoney > 0 && company.step2Amount > 0
 

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -126,12 +126,17 @@ export function encodeScenarioToURL(scenarioData) {
       if (field === 'priorInvestors') {
         if (Array.isArray(value) && value.length > 0) {
           // Encode prior investors with essential data
-          const piData = value.map((investor, index) => ({
-            n: investor.name || `Investor ${index + 1}`,
-            o: investor.ownershipPercent || 0,
-            p: investor.proRataAmount || 0,
-            r: investor.hasProRataRights || false
-          })).filter(pi => pi.o > 0) // Only include investors with ownership > 0
+          const piData = value.map((investor, index) => {
+            const encoded = {
+              n: investor.name || `Investor ${index + 1}`,
+              o: investor.ownershipPercent || 0,
+              r: investor.hasProRataRights || false
+            }
+            if (investor.proRataOverride != null && investor.proRataOverride >= 0) {
+              encoded.po = investor.proRataOverride
+            }
+            return encoded
+          }).filter(pi => pi.o > 0) // Only include investors with ownership > 0
           
           if (piData.length > 0) {
             params.set(param, JSON.stringify(piData))
@@ -228,7 +233,7 @@ export function decodeScenarioFromURL(urlParams) {
       
       if (value !== null) {
         if (field === 'investorName') {
-          scenarioData[field] = decodeURIComponent(value)
+          scenarioData[field] = value
         } else if (field === 'showAdvanced' || field === 'twoStepEnabled') {
           scenarioData[field] = value === '1'
         } else if (field === 'esopTiming') {
@@ -264,8 +269,10 @@ export function decodeScenarioFromURL(urlParams) {
                 id: Date.now() + index + 1000, // Generate unique IDs offset from SAFEs
                 name: investor.n || `Investor ${index + 1}`,
                 ownershipPercent: investor.o || 0,
-                proRataAmount: investor.p || 0,
                 hasProRataRights: investor.r || false,
+                proRataOverride: (typeof investor.po === 'number' && investor.po >= 0)
+                  ? investor.po
+                  : (typeof investor.p === 'number' && investor.p >= 0 ? investor.p : null),
                 // These will be calculated by the engine:
                 postRoundPercent: 0,
                 dilution: 0

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -170,6 +170,13 @@ describe('Permalink Utilities', () => {
       expect(decoded.investorName).toBe('US & Partners')
     })
 
+    it('should not double-decode percent signs in investor names', () => {
+      const urlParams = 'pmv=13&rs=3&ip=2.75&op=0.25&in=100%25+Ventures'
+      const decoded = decodeScenarioFromURL(urlParams)
+
+      expect(decoded.investorName).toBe('100% Ventures')
+    })
+
     it('should return null for invalid URL parameters', () => {
       expect(decodeScenarioFromURL('')).toBe(null)
       expect(decodeScenarioFromURL('invalid=data')).toBe(null)
@@ -364,7 +371,7 @@ describe('Permalink Utilities', () => {
           id: 1,
           name: 'Seed VC',
           ownershipPercent: 15,
-          proRataAmount: 0.5,
+          proRataOverride: 0.5,
           hasProRataRights: true,
           postRoundPercent: 11.5,
           dilution: 3.5
@@ -373,7 +380,7 @@ describe('Permalink Utilities', () => {
           id: 2,
           name: 'Angel Group',
           ownershipPercent: 10,
-          proRataAmount: 0,
+          proRataOverride: null,
           hasProRataRights: false,
           postRoundPercent: 7.7,
           dilution: 2.3
@@ -408,8 +415,8 @@ describe('Permalink Utilities', () => {
         const piData = JSON.parse(piParam)
         
         expect(piData).toHaveLength(2)
-        expect(piData[0]).toEqual({ n: 'Seed VC', o: 15, p: 0.5, r: true })
-        expect(piData[1]).toEqual({ n: 'Angel Group', o: 10, p: 0, r: false })
+        expect(piData[0]).toEqual({ n: 'Seed VC', o: 15, po: 0.5, r: true })
+        expect(piData[1]).toEqual({ n: 'Angel Group', o: 10, r: false })
       })
 
       it('should encode founders array to URL', () => {
@@ -430,8 +437,8 @@ describe('Permalink Utilities', () => {
         const scenarioWithZeroOwnership = {
           ...multiPartyScenario,
           priorInvestors: [
-            { id: 1, name: 'Valid Investor', ownershipPercent: 15, proRataAmount: 0.5 },
-            { id: 2, name: 'Zero Investor', ownershipPercent: 0, proRataAmount: 0 }
+            { id: 1, name: 'Valid Investor', ownershipPercent: 15, proRataOverride: 0.5, hasProRataRights: true },
+            { id: 2, name: 'Zero Investor', ownershipPercent: 0, proRataOverride: null, hasProRataRights: false }
           ]
         }
         
@@ -481,7 +488,7 @@ describe('Permalink Utilities', () => {
         expect(decoded.priorInvestors).toHaveLength(2)
         expect(decoded.priorInvestors[0].name).toBe('Seed VC')
         expect(decoded.priorInvestors[0].ownershipPercent).toBe(15)
-        expect(decoded.priorInvestors[0].proRataAmount).toBe(0.5)
+        expect(decoded.priorInvestors[0].proRataOverride).toBe(0.5)
         expect(decoded.priorInvestors[0].hasProRataRights).toBe(true)
         expect(decoded.priorInvestors[0]).toHaveProperty('id')
         expect(decoded.priorInvestors[0].postRoundPercent).toBe(0) // Should be 0, calculated later
@@ -489,7 +496,7 @@ describe('Permalink Utilities', () => {
         
         expect(decoded.priorInvestors[1].name).toBe('Angel Group')
         expect(decoded.priorInvestors[1].ownershipPercent).toBe(10)
-        expect(decoded.priorInvestors[1].proRataAmount).toBe(0)
+        expect(decoded.priorInvestors[1].proRataOverride).toBe(null)
         expect(decoded.priorInvestors[1].hasProRataRights).toBe(false)
       })
 
@@ -512,7 +519,7 @@ describe('Permalink Utilities', () => {
         const scenarioWithoutAdvancedFlag = {
           ...mockScenario,
           // Note: showAdvanced is false, but we have multi-party data
-          priorInvestors: [{ id: 1, name: 'Investor', ownershipPercent: 15, proRataAmount: 0 }]
+          priorInvestors: [{ id: 1, name: 'Investor', ownershipPercent: 15, proRataOverride: null }]
         }
         
         const encoded = encodeScenarioToURL(scenarioWithoutAdvancedFlag)
@@ -547,7 +554,7 @@ describe('Permalink Utilities', () => {
               id: 1, 
               name: 'VC with Rights', 
               ownershipPercent: 20, 
-              proRataAmount: 1.0,
+              proRataOverride: 1.0,
               hasProRataRights: true,
               postRoundPercent: 15.4,
               dilution: 4.6
@@ -556,7 +563,7 @@ describe('Permalink Utilities', () => {
               id: 2, 
               name: 'VC without Rights', 
               ownershipPercent: 15, 
-              proRataAmount: 0,
+              proRataOverride: null,
               hasProRataRights: false,
               postRoundPercent: 11.5,
               dilution: 3.5
@@ -576,6 +583,36 @@ describe('Permalink Utilities', () => {
         expect(encoded).toMatch(/pi=.*%22r%22%3Afalse/) // r:false in URL encoding
       })
 
+      it('should preserve prior investor pro-rata overrides in round-trip', () => {
+        const scenarioWithOverride = {
+          ...mockScenario,
+          showAdvanced: true,
+          priorInvestors: [
+            {
+              id: 1,
+              name: 'Seed Fund',
+              ownershipPercent: 15,
+              proRataOverride: 0.8,
+              hasProRataRights: true
+            }
+          ]
+        }
+
+        const encoded = encodeScenarioToURL(scenarioWithOverride)
+        const decoded = decodeScenarioFromURL(encoded)
+
+        expect(encoded).toMatch(/pi=.*%22po%22%3A0.8/)
+        expect(decoded.priorInvestors[0].proRataOverride).toBe(0.8)
+      })
+
+      it('should treat legacy prior-investor p field as a pro-rata override on decode', () => {
+        const legacyPiJson = JSON.stringify([{ n: 'Seed Fund', o: 15, p: 0.8, r: true }])
+        const decoded = decodeScenarioFromURL(`pmv=13&rs=3&ip=2.75&op=0.25&in=US&pi=${encodeURIComponent(legacyPiJson)}`)
+
+        expect(decoded.priorInvestors[0].hasProRataRights).toBe(true)
+        expect(decoded.priorInvestors[0].proRataOverride).toBe(0.8)
+      })
+
       it('should generate unique IDs for decoded arrays', () => {
         const encoded = encodeScenarioToURL(multiPartyScenario)
         const decoded = decodeScenarioFromURL(encoded)
@@ -593,7 +630,7 @@ describe('Permalink Utilities', () => {
       it('should provide default names for unnamed entities', () => {
         const scenarioWithUnnamedEntities = {
           ...mockScenario,
-          priorInvestors: [{ ownershipPercent: 15, proRataAmount: 0.5 }],
+          priorInvestors: [{ ownershipPercent: 15, proRataOverride: 0.5, hasProRataRights: true }],
           founders: [{ ownershipPercent: 50 }]
         }
         
@@ -634,7 +671,7 @@ describe('Permalink Utilities', () => {
       it('should create compact URLs by excluding default values', () => {
         const scenarioWithDefaults = {
           ...mockScenario,
-          priorInvestors: [{ id: 1, name: 'Investor', ownershipPercent: 15, proRataAmount: 0 }],
+          priorInvestors: [{ id: 1, name: 'Investor', ownershipPercent: 15, proRataOverride: null, hasProRataRights: false }],
           currentEsopPercent: 0, // Default value, should be excluded
           targetEsopPercent: 0,  // Default value, should be excluded
           esopTiming: 'pre-close' // Default value, should be excluded
@@ -656,8 +693,8 @@ describe('Permalink Utilities', () => {
           investorName: 'Lead Investor',
           showAdvanced: true,
           priorInvestors: [
-            { id: 1, name: 'Seed Fund', ownershipPercent: 12.5, proRataAmount: 0.75 },
-            { id: 2, name: 'Strategic', ownershipPercent: 8.25, proRataAmount: 0 }
+            { id: 1, name: 'Seed Fund', ownershipPercent: 12.5, proRataOverride: 0.75, hasProRataRights: true },
+            { id: 2, name: 'Strategic', ownershipPercent: 8.25, proRataOverride: null, hasProRataRights: false }
           ],
           founders: [
             { id: 1, name: 'CEO & Founder', ownershipPercent: 55 },
@@ -682,7 +719,7 @@ describe('Permalink Utilities', () => {
         // Verify multi-party data
         expect(decoded.priorInvestors[0].name).toBe('Seed Fund')
         expect(decoded.priorInvestors[0].ownershipPercent).toBe(12.5)
-        expect(decoded.priorInvestors[0].proRataAmount).toBe(0.75)
+        expect(decoded.priorInvestors[0].proRataOverride).toBe(0.75)
         
         expect(decoded.founders[0].name).toBe('CEO & Founder')
         expect(decoded.founders[0].ownershipPercent).toBe(55)
@@ -709,7 +746,7 @@ describe('Permalink Utilities', () => {
               id: 1,
               name: 'Seed Fund',
               ownershipPercent: 15,
-              proRataAmount: 0.5,
+              proRataOverride: 0.5,
               hasProRataRights: true,
               postRoundPercent: 12.5,
               dilution: 2.5
@@ -718,7 +755,7 @@ describe('Permalink Utilities', () => {
               id: 2,
               name: 'Angel Group',
               ownershipPercent: 10,
-              proRataAmount: 0,
+              proRataOverride: null,
               hasProRataRights: false,
               postRoundPercent: 7.69,
               dilution: 2.31
@@ -772,11 +809,11 @@ describe('Permalink Utilities', () => {
         // Verify prior investors data
         expect(decodedScenario.priorInvestors[0].name).toBe('Seed Fund')
         expect(decodedScenario.priorInvestors[0].ownershipPercent).toBe(15)
-        expect(decodedScenario.priorInvestors[0].proRataAmount).toBe(0.5)
+        expect(decodedScenario.priorInvestors[0].proRataOverride).toBe(0.5)
         expect(decodedScenario.priorInvestors[0].hasProRataRights).toBe(true)
         expect(decodedScenario.priorInvestors[1].name).toBe('Angel Group')
         expect(decodedScenario.priorInvestors[1].ownershipPercent).toBe(10)
-        expect(decodedScenario.priorInvestors[1].proRataAmount).toBe(0)
+        expect(decodedScenario.priorInvestors[1].proRataOverride).toBe(null)
         expect(decodedScenario.priorInvestors[1].hasProRataRights).toBe(false)
         
         // Verify founders data

--- a/react-app/src/utils/scenarioOffsets.js
+++ b/react-app/src/utils/scenarioOffsets.js
@@ -1,0 +1,27 @@
+export function roundScenarioOffset(value) {
+  return Math.round(Number(value) * 100) / 100
+}
+
+export function formatScenarioOffsetValue(value) {
+  const rounded = roundScenarioOffset(value)
+  return Number.isInteger(rounded) ? `${rounded}` : `${rounded}`
+}
+
+export function buildScenarioOffsets(maxOffset) {
+  const max = roundScenarioOffset(Math.abs(Number(maxOffset) || 0))
+  if (!(max > 0)) return []
+
+  const quarter = roundScenarioOffset(max / 4)
+  const half = roundScenarioOffset(max / 2)
+
+  return [-max, -half, -quarter, quarter, half, max]
+}
+
+export function normalizeScenarioOffsets(offsets, defaultMax = 30) {
+  const numericOffsets = Array.isArray(offsets)
+    ? offsets.map(Number).filter(Number.isFinite).map(Math.abs)
+    : []
+
+  const max = numericOffsets.length > 0 ? Math.max(...numericOffsets) : defaultMax
+  return buildScenarioOffsets(max > 0 ? max : defaultMax)
+}

--- a/react-app/src/utils/scenarioOffsets.test.js
+++ b/react-app/src/utils/scenarioOffsets.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { buildScenarioOffsets, formatScenarioOffsetValue, normalizeScenarioOffsets } from './scenarioOffsets'
+
+describe('scenarioOffsets', () => {
+  it('builds a 3-down / 3-up band from a max delta', () => {
+    expect(buildScenarioOffsets(10)).toEqual([-10, -5, -2.5, 2.5, 5, 10])
+    expect(buildScenarioOffsets(20)).toEqual([-20, -10, -5, 5, 10, 20])
+  })
+
+  it('normalizes legacy offset arrays to a symmetric band using the max absolute delta', () => {
+    expect(normalizeScenarioOffsets([-30, -20, -10, 10, 20, 30])).toEqual([-30, -15, -7.5, 7.5, 15, 30])
+    expect(normalizeScenarioOffsets([-10, 10])).toEqual([-10, -5, -2.5, 2.5, 5, 10])
+  })
+
+  it('formats decimal offsets without trailing noise', () => {
+    expect(formatScenarioOffsetValue(10)).toBe('10')
+    expect(formatScenarioOffsetValue(2.5)).toBe('2.5')
+    expect(formatScenarioOffsetValue(6.25)).toBe('6.25')
+  })
+})


### PR DESCRIPTION
## Summary
- rehydrate active company and next company id from persisted workspace state
- hide alternative scenario rows in compare mode and keep scenario/apply payloads rooted in company inputs
- round-trip prior investor pro-rata overrides and granted ESOP values correctly through permalinks
- clamp round split inputs and add regression tests for the reviewed failure cases

## Verification
- npx vitest run
- npm run build
- npm run lint
- headless browser walkthrough for persisted multi-company state, compare mode, sensitivity apply, Exit Math, and permalink round-trip