### PR TITLE
Show Exit Math card in compare mode

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -415,6 +415,10 @@ body {
   min-width: 0;
 }
 
+.top-row.compare-mode > .exit-math-module {
+  flex: 0 0 clamp(280px, 22vw, 380px);
+}
+
 .base-result-compare {
   display: flex;
   flex-direction: row;

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -200,7 +200,7 @@ function App() {
   const compareIds = selectedCompanyIds.filter(id => companies[id])
   const isCompareMode = compareIds.length >= 2
   const cardIds = isCompareMode ? compareIds : [activeCompany]
-  const showExitMath = !isCompareMode && companies[activeCompany]?.showExitMath
+  const showExitMath = Boolean(companies[activeCompany]?.showExitMath)
   const advancedOpen = !isCompareMode && !showExitMath && Boolean(companies[activeCompany]?.showAdvanced)
 
   return (


### PR DESCRIPTION
## Summary
- Drop the `!isCompareMode` gate on `showExitMath` in `App.jsx` so the Exit Math card continues to render for the active company when two or more companies are selected for compare.
- Add a `flex: 0 0 clamp(280px, 22vw, 380px)` rule for `.top-row.compare-mode > .exit-math-module` in `App.css` so the card keeps a stable width beside the compare rail (which already scrolls horizontally when space gets tight).

## Test plan
- [ ] Toggle Exit Math header button with a single company — card renders as before.
- [ ] Select a second company for compare — verify Exit Math card stays visible and reflects the active company's projection.
- [ ] Switch active tab among compared companies — Exit Math card updates to that company's `investorName`, initial check, and ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)