### PR TITLE
Let compare mode use full width and fit more scenarios

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -399,15 +399,15 @@ body {
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
-  gap: 2rem;
-  width: fit-content;
-  max-width: min(1600px, 100%);
+  gap: clamp(1rem, 1.5vw, 2rem);
+  width: 100%;
+  max-width: 100%;
   padding-inline: clamp(var(--space-3), 1.5vw, var(--space-5));
   box-sizing: border-box;
 }
 
 .top-row.compare-mode > .input-form {
-  flex: 0 0 clamp(320px, 28vw, 440px);
+  flex: 0 0 clamp(300px, 24vw, 400px);
 }
 
 .top-row.compare-mode > .base-result-compare {
@@ -422,21 +422,21 @@ body {
 .base-result-compare {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   width: 100%;
   max-width: 100%;
-  /* `safe center` keeps cards centered in the rail until they exceed it, then
-     falls back to flex-start so the leftmost card stays reachable via scroll. */
-  justify-content: safe center;
-  /* Scale gap with viewport so wide screens get breathing room without cramping narrow ones. */
-  gap: clamp(var(--space-2), 1.2vw, var(--space-5));
-  overflow-x: auto;
+  justify-content: flex-start;
+  align-content: flex-start;
+  gap: clamp(var(--space-2), 1vw, var(--space-4));
+  overflow-x: visible;
   padding-bottom: var(--space-2);
 }
 
 .base-result-compare > .scenario-card {
   --card-pad-x: var(--space-3);
-  flex: 0 0 340px;
-  max-width: 380px;
+  flex: 1 1 280px;
+  min-width: 260px;
+  max-width: 420px;
   padding: var(--space-3);
 }
 

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -400,8 +400,9 @@ body {
   justify-content: flex-start;
   align-items: flex-start;
   gap: clamp(1rem, 1.5vw, 2rem);
-  width: 100%;
+  width: fit-content;
   max-width: 100%;
+  margin-inline: auto;
   padding-inline: clamp(var(--space-3), 1.5vw, var(--space-5));
   box-sizing: border-box;
 }

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -272,6 +272,7 @@ function App() {
               investorName={companies[activeCompany]?.investorName || 'US'}
               exitMath={companies[activeCompany]?.exitMath}
               onUpdate={(exitMath) => updateCompany(activeCompany, { exitMath })}
+              companyName={isCompareMode ? companies[activeCompany]?.name : undefined}
             />
           )}
         </div>

--- a/react-app/src/components/ExitMathModule.jsx
+++ b/react-app/src/components/ExitMathModule.jsx
@@ -17,7 +17,7 @@ function formatMoney(valueM) {
   return `$${valueM.toFixed(2)}M`
 }
 
-const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate }) => {
+const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate, companyName }) => {
   const [showOverrides, setShowOverrides] = useState(false)
 
   const state = {
@@ -72,7 +72,7 @@ const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate 
   return (
     <div className="exit-math-module">
       <div className="exit-math-header">
-        <h3>Exit Math</h3>
+        <h3>{companyName ? `Exit Math — ${companyName}` : 'Exit Math'}</h3>
         <span className="exit-math-subtitle">{investorName} returns at exit</span>
       </div>
 


### PR DESCRIPTION
## Summary
- Compare mode already supported N companies, but CSS capped the row at 1600px and forced each card to a fixed 340px non-shrinking width — so visually only ~2 cards fit before overflowing.
- Drop the 1600px cap, let cards flex between 280–420px with `flex: 1 1 280px` + `max-width: 420px`, and allow the rail to wrap when needed.
- Cards now adapt to available space whether Exit Math is open or not. 3–4 comparisons fit comfortably on a typical laptop; more wrap cleanly to a second row instead of triggering horizontal scroll.

## Test plan
- [x] `npx vitest run` — 358 passed, 1 skipped
- [x] Visual: 2 cards at 1440px — both expand to fill rail
- [x] Visual: 3 cards at 1600px — all fit in one row
- [x] Visual: 4 cards at 1600px — 3 fit, 4th wraps to row 2
- [x] Visual: 3 cards + Exit Math at 1920px — all fit in one row next to InputForm and Exit Math
- [x] Mobile `@media (max-width: 768px)` rule untouched — existing column stack preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)