### PR TITLE
Unify investors view sorted by FDO

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2729,6 +2729,78 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   line-height: 1.3;
 }
 
+/* Read-only rows (SAFE, lead) inside the Investors table — tinted, non-editable */
+.repeater-table--investors .repeater-row--safe {
+  background: var(--color-bg-subtle);
+  padding-bottom: 0.35rem;
+}
+
+.repeater-table--investors .repeater-row--lead {
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+
+.repeater-table--investors .repeater-row--safe:hover,
+.repeater-table--investors .repeater-row--lead:hover {
+  background: var(--color-bg-muted);
+}
+
+.repeater-readonly-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-fg);
+  padding: 4px 6px;
+}
+
+.repeater-readonly-value {
+  display: block;
+  text-align: right;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-fg);
+  padding: 4px 6px;
+}
+
+.repeater-kind-tag {
+  display: inline-block;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--color-bg-muted);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+}
+
+.repeater-kind-tag--lead {
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  color: var(--color-accent);
+}
+
+/* Greyed pro-rata readout for prior investors whose pro-rata is disabled */
+.repeater-prorata-readonly {
+  display: block;
+  text-align: right;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-fg-faint);
+  font-style: italic;
+  padding: 4px 6px;
+  cursor: help;
+}
+
+.repeater-prorata-active {
+  display: block;
+  text-align: right;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-fg);
+  padding: 4px 6px;
+}
+
 /* ---- Compact FormInput variant (used inside repeater tables) ---- */
 .form-input-wrapper.compact {
   min-height: 30px;

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -705,6 +705,9 @@ const InputForm = ({ company, onUpdate }) => {
             onUpdate={handlePriorInvestorsUpdate}
             roundSize={values.roundSize}
             investorName={values.investorName || 'US'}
+            safes={values.safes || []}
+            postMoneyVal={values.postMoneyVal}
+            investorPortion={values.investorPortion}
           />
 
           <FoundersSection

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -1,7 +1,16 @@
 import { createPriorInvestor, calculateTotalOwnership } from '../utils/dataStructures'
+import { calculateSafeConversions } from '../utils/multiPartyCalculations'
 import FormInput from './FormInput'
 
-function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, investorName = '' }) {
+function PriorInvestorsSection({
+  priorInvestors = [],
+  onUpdate,
+  roundSize = 0,
+  investorName = '',
+  safes = [],
+  postMoneyVal = 0,
+  investorPortion = 0
+}) {
   const addPriorInvestor = () => {
     const newInvestor = createPriorInvestor('New Investor', 0, false)
     onUpdate([...priorInvestors, newInvestor])
@@ -38,23 +47,49 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
     onUpdate(priorInvestors.filter(investor => investor.id !== investorId))
   }
 
-  const getCalculatedProRata = (investor) => {
-    if (!investor.ownershipPercent || !roundSize) return 0
-    return (investor.ownershipPercent / 100) * roundSize
+  const getCalculatedProRata = (ownershipPercent) => {
+    if (!ownershipPercent || !roundSize) return 0
+    return (ownershipPercent / 100) * roundSize
   }
 
   const totalOwnership = calculateTotalOwnership(priorInvestors)
   const hasProRataInvestors = priorInvestors.some(inv => inv.hasProRataRights)
 
+  // Build unified row list: prior investors + SAFEs (post-conversion) + new lead
+  const preMoneyVal = Math.max(0, (postMoneyVal || 0) - (roundSize || 0))
+  const { safeDetails } = calculateSafeConversions(safes, preMoneyVal)
+
+  const priorRows = priorInvestors.map(investor => ({
+    kind: 'prior',
+    key: `prior-${investor.id}`,
+    fdoPct: investor.ownershipPercent || 0,
+    investor
+  }))
+
+  const safeRows = safeDetails.map(safe => ({
+    kind: 'safe',
+    key: `safe-${safe.id}`,
+    fdoPct: safe.percent || 0,
+    safe
+  }))
+
+  const leadFdoPct = postMoneyVal > 0 ? (investorPortion / postMoneyVal) * 100 : 0
+  const showLeadRow = investorPortion > 0 && postMoneyVal > 0
+  const leadRows = showLeadRow
+    ? [{ kind: 'lead', key: 'lead', fdoPct: leadFdoPct, name: (investorName || 'Lead').trim() || 'Lead' }]
+    : []
+
+  const allRows = [...priorRows, ...safeRows, ...leadRows].sort((a, b) => b.fdoPct - a.fdoPct)
+
   return (
     <div className="prior-investors-section">
       <div className="founders-investors-header">
         <div className="section-title-row">
-          <h5 className="section-label">Prior Investors</h5>
+          <h5 className="section-label">Investors — sorted by FDO</h5>
           <div className="section-header-actions">
             {totalOwnership > 0 && (
               <span className="section-total-pill">
-                Total: <strong>{totalOwnership.toFixed(1)}%</strong>
+                Prior total: <strong>{totalOwnership.toFixed(1)}%</strong>
               </span>
             )}
             <button
@@ -68,98 +103,172 @@ function PriorInvestorsSection({ priorInvestors = [], onUpdate, roundSize = 0, i
         </div>
       </div>
 
-      {priorInvestors.length === 0 ? (
+      {allRows.length === 0 ? (
         <div className="no-investors-message">
-          No prior investors added. Click "Add Investor" to include previous round participants.
+          No investors yet. Click "Add Investor" to include prior round participants.
         </div>
       ) : (
         <div className="repeater-table repeater-table--investors">
           <div className="repeater-header">
             <span className="repeater-col repeater-col--name">Name</span>
-            <span className="repeater-col repeater-col--pct">Ownership</span>
+            <span className="repeater-col repeater-col--pct">FDO</span>
             <span className="repeater-col repeater-col--prorata">Pro-rata</span>
             <span className="repeater-col repeater-col--alloc">Allocation</span>
             <span className="repeater-col repeater-col--actions" aria-hidden="true" />
           </div>
-          {priorInvestors.map(investor => {
-            const calculatedProRata = getCalculatedProRata(investor)
-            const hasOverride = investor.proRataOverride != null
-            const displayAmount = hasOverride ? investor.proRataOverride : calculatedProRata
-            const matchesLead = investor.name === investorName && investor.name
-            const allocActive = investor.hasProRataRights && investor.ownershipPercent > 0 && roundSize > 0
-            return (
-              <div key={investor.id} className="repeater-row">
-                <div className="repeater-col repeater-col--name">
-                  <FormInput
-                    label="Name"
-                    type="text"
-                    value={investor.name}
-                    onChange={(value) => updateInvestor(investor.id, 'name', value)}
-                    placeholder="Investor name"
-                    compact
-                  />
-                </div>
-                <div className="repeater-col repeater-col--pct">
-                  <FormInput
-                    label="Ownership"
-                    type="number"
-                    value={investor.ownershipPercent}
-                    onChange={(value) => updateInvestor(investor.id, 'ownershipPercent', value)}
-                    suffix="%"
-                    min="0"
-                    max="100"
-                    step="0.1"
-                    compact
-                  />
-                </div>
-                <div className="repeater-col repeater-col--prorata">
-                  <label className="repeater-checkbox" title="Pro-rata rights">
-                    <input
-                      type="checkbox"
-                      checked={investor.hasProRataRights}
-                      onChange={(e) => updateInvestor(investor.id, 'hasProRataRights', e.target.checked)}
-                    />
-                  </label>
-                </div>
-                <div className="repeater-col repeater-col--alloc">
-                  {allocActive && !matchesLead ? (
+
+          {allRows.map(row => {
+            if (row.kind === 'prior') {
+              const investor = row.investor
+              const calculatedProRata = getCalculatedProRata(investor.ownershipPercent)
+              const hasOverride = investor.proRataOverride != null
+              const displayAmount = hasOverride ? investor.proRataOverride : calculatedProRata
+              const matchesLead = investor.name === investorName && investor.name
+              const allocActive = investor.hasProRataRights && investor.ownershipPercent > 0 && roundSize > 0
+              return (
+                <div key={row.key} className="repeater-row">
+                  <div className="repeater-col repeater-col--name">
                     <FormInput
-                      label="Allocation"
-                      type="number"
-                      value={displayAmount}
-                      onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
-                      prefix="$"
-                      suffix="M"
-                      step="0.01"
-                      min="0"
+                      label="Name"
+                      type="text"
+                      value={investor.name}
+                      onChange={(value) => updateInvestor(investor.id, 'name', value)}
+                      placeholder="Investor name"
                       compact
                     />
-                  ) : (
-                    <span className="repeater-alloc-placeholder" title={matchesLead ? `Handled via ${investorName} round portion` : 'Enable pro-rata to set allocation'}>
-                      {matchesLead ? 'via lead' : '—'}
-                    </span>
-                  )}
-                </div>
-                <div className="repeater-col repeater-col--actions">
-                  {hasOverride && allocActive && !matchesLead && (
+                  </div>
+                  <div className="repeater-col repeater-col--pct">
+                    <FormInput
+                      label="Ownership"
+                      type="number"
+                      value={investor.ownershipPercent}
+                      onChange={(value) => updateInvestor(investor.id, 'ownershipPercent', value)}
+                      suffix="%"
+                      min="0"
+                      max="100"
+                      step="0.1"
+                      compact
+                    />
+                  </div>
+                  <div className="repeater-col repeater-col--prorata">
+                    <label className="repeater-checkbox" title="Pro-rata rights">
+                      <input
+                        type="checkbox"
+                        checked={investor.hasProRataRights}
+                        onChange={(e) => updateInvestor(investor.id, 'hasProRataRights', e.target.checked)}
+                      />
+                    </label>
+                  </div>
+                  <div className="repeater-col repeater-col--alloc">
+                    {matchesLead ? (
+                      <span className="repeater-alloc-placeholder" title={`Handled via ${investorName} round portion`}>
+                        via lead
+                      </span>
+                    ) : allocActive ? (
+                      <FormInput
+                        label="Allocation"
+                        type="number"
+                        value={displayAmount}
+                        onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
+                        prefix="$"
+                        suffix="M"
+                        step="0.01"
+                        min="0"
+                        compact
+                      />
+                    ) : calculatedProRata > 0 ? (
+                      <span
+                        className="repeater-prorata-readonly"
+                        title="Calculated pro-rata (not enabled). Toggle the checkbox to commit."
+                      >
+                        ${calculatedProRata.toFixed(2)}M
+                      </span>
+                    ) : (
+                      <span className="repeater-alloc-placeholder">—</span>
+                    )}
+                  </div>
+                  <div className="repeater-col repeater-col--actions">
+                    {hasOverride && allocActive && !matchesLead && (
+                      <button
+                        type="button"
+                        className="reset-pro-rata-btn"
+                        onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
+                        title={`Reset to calculated ($${parseFloat(calculatedProRata.toPrecision(10))}M)`}
+                      >
+                        ↺
+                      </button>
+                    )}
                     <button
+                      className="remove-investor-btn"
+                      onClick={() => removeInvestor(investor.id)}
                       type="button"
-                      className="reset-pro-rata-btn"
-                      onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
-                      title={`Reset to calculated ($${parseFloat(calculatedProRata.toPrecision(10))}M)`}
+                      title="Remove investor"
                     >
-                      ↺
+                      ×
                     </button>
-                  )}
-                  <button
-                    className="remove-investor-btn"
-                    onClick={() => removeInvestor(investor.id)}
-                    type="button"
-                    title="Remove investor"
-                  >
-                    ×
-                  </button>
+                  </div>
                 </div>
+              )
+            }
+
+            if (row.kind === 'safe') {
+              const safe = row.safe
+              const safeLabel = safe.investorName ? safe.investorName : `#${safe.index}`
+              const safeProRata$ = safe.proRata ? getCalculatedProRata(safe.percent) : 0
+              const matchesLead = safe.investorName && investorName && safe.investorName.trim() === investorName.trim()
+              return (
+                <div key={row.key} className="repeater-row repeater-row--safe">
+                  <div className="repeater-col repeater-col--name">
+                    <span className="repeater-readonly-name">
+                      <span className="repeater-kind-tag">SAFE</span> {safeLabel}
+                    </span>
+                  </div>
+                  <div className="repeater-col repeater-col--pct">
+                    <span className="repeater-readonly-value">{safe.percent.toFixed(2)}%</span>
+                  </div>
+                  <div className="repeater-col repeater-col--prorata">
+                    <label className="repeater-checkbox" title="Pro-rata rights on SAFE (edit in SAFE section)">
+                      <input type="checkbox" checked={Boolean(safe.proRata)} readOnly disabled />
+                    </label>
+                  </div>
+                  <div className="repeater-col repeater-col--alloc">
+                    {matchesLead ? (
+                      <span className="repeater-alloc-placeholder" title={`Handled via ${investorName} round portion`}>via lead</span>
+                    ) : safe.proRata && safeProRata$ > 0 ? (
+                      <span className="repeater-prorata-active" title="SAFE pro-rata (edit in SAFE section)">
+                        ${safeProRata$.toFixed(2)}M
+                      </span>
+                    ) : safeProRata$ > 0 ? (
+                      <span className="repeater-prorata-readonly" title="Calculated pro-rata (SAFE pro-rata disabled)">
+                        ${safeProRata$.toFixed(2)}M
+                      </span>
+                    ) : (
+                      <span className="repeater-alloc-placeholder">—</span>
+                    )}
+                  </div>
+                  <div className="repeater-col repeater-col--actions" aria-hidden="true" />
+                </div>
+              )
+            }
+
+            // lead row
+            return (
+              <div key={row.key} className="repeater-row repeater-row--lead">
+                <div className="repeater-col repeater-col--name">
+                  <span className="repeater-readonly-name">
+                    <span className="repeater-kind-tag repeater-kind-tag--lead">LEAD</span> {row.name}
+                  </span>
+                </div>
+                <div className="repeater-col repeater-col--pct">
+                  <span className="repeater-readonly-value">{row.fdoPct.toFixed(2)}%</span>
+                </div>
+                <div className="repeater-col repeater-col--prorata">
+                  <span className="repeater-alloc-placeholder" title="Lead is taking the round">—</span>
+                </div>
+                <div className="repeater-col repeater-col--alloc">
+                  <span className="repeater-alloc-placeholder" title="Lead is taking the round">taking round</span>
+                </div>
+                <div className="repeater-col repeater-col--actions" aria-hidden="true" />
               </div>
             )
           })}

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -74,7 +74,7 @@ function calculateProRataAllocations(priorInvestors, roundSize) {
 /**
  * Calculate SAFE conversions (unchanged from original logic)
  */
-function calculateSafeConversions(safes, preMoneyVal) {
+export function calculateSafeConversions(safes, preMoneyVal) {
   let totalSafePercent = 0
   let totalSafeAmount = 0
   let safeDetails = []


### PR DESCRIPTION
## Summary
- Rename \"Prior Investors\" to **Investors — sorted by FDO** and fold SAFEs (post-conversion) + the new lead into the same list as read-only rows
- Sort every row by FDO descending so the biggest pro-rata claims surface first
- Always render each prior investor's calculated pro-rata \$ (greyed when the checkbox is off) so you can see the size of every claim in one place — the checkbox still controls whether the amount is committed to the round

Context: when negotiating you want one list ordered by size to see who you have to fight, rather than bouncing between the prior-investors table, the SAFE section, and the lead's inputs.

## Test plan
- [x] `npx vitest run` — 358 tests pass
- [x] Manual QA: with 3 prior investors at 25/12/5%, 1 SAFE (\$2M @ \$20M cap with pro-rata on), and US lead with \$2.75M on \$13M post — rows render in order 25% → LEAD 21.15% → SAFE 20% → 12% → 5%, and every row shows its pro-rata \$
- [ ] Confirm share/permalink flow still works (no shape changes were made)

🤖 Generated with [Claude Code](https://claude.com/claude-code)