### PR TITLE
Add rough warrants model

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2430,23 +2430,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-top: 1px solid var(--color-border);
 }
 
-.warrants-anchor-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-4);
-  margin-bottom: var(--space-3);
-}
-
-.warrants-anchor-row > .form-input-wrapper {
-  flex: 0 1 18rem;
-}
-
-.warrants-summary {
-  font-size: 0.85rem;
-  color: var(--color-fg-subtle);
-}
-
 .warrants-fd-percent {
   display: block;
   text-align: right;
@@ -2711,8 +2694,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 .repeater-table--warrants .repeater-header,
 .repeater-table--warrants .repeater-row {
-  /* Holder | Shares | Strike | % of FD | Actions */
-  grid-template-columns: minmax(140px, 1.4fr) minmax(120px, 1fr) 110px 90px 56px;
+  /* Holder | Amount | Valuation | % of FD | Actions */
+  grid-template-columns: minmax(110px, 1.4fr) 110px 110px 90px 56px;
 }
 
 .repeater-col {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2402,14 +2402,16 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-top: 1px solid var(--color-border);
 }
 
-.esop-section h5 {
+.esop-section h5,
+.warrants-section h5 {
   font-size: var(--text-md);
   font-weight: 600;
   color: var(--color-fg);
   margin: 0 0 var(--space-2);
 }
 
-.esop-subtitle {
+.esop-subtitle,
+.warrants-subtitle {
   margin: 0 0 var(--space-4);
   font-size: var(--text-sm);
   color: var(--color-fg-subtle);
@@ -2420,6 +2422,18 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   color: var(--color-fg-muted);
   font-style: normal;
   font-weight: 600;
+}
+
+.warrants-section {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.warrants-input-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 16rem);
+  gap: var(--space-4);
 }
 
 .esop-section .input-grid.esop-input-grid {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2430,10 +2430,28 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-top: 1px solid var(--color-border);
 }
 
-.warrants-input-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 16rem);
+.warrants-anchor-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.warrants-anchor-row > .form-input-wrapper {
+  flex: 0 1 18rem;
+}
+
+.warrants-summary {
+  font-size: 0.85rem;
+  color: var(--color-fg-subtle);
+}
+
+.warrants-fd-percent {
+  display: block;
+  text-align: right;
+  font-size: 0.85rem;
+  color: var(--color-fg-subtle);
 }
 
 .esop-section .input-grid.esop-input-grid {
@@ -2689,6 +2707,12 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .repeater-table--safes .repeater-row {
   /* Investor | Amount | Cap | Discount | Pro-rata | Allocation | Actions */
   grid-template-columns: minmax(110px, 1.4fr) 100px 110px 92px 64px 120px 56px;
+}
+
+.repeater-table--warrants .repeater-header,
+.repeater-table--warrants .repeater-row {
+  /* Holder | Shares | Strike | % of FD | Actions */
+  grid-template-columns: minmax(140px, 1.4fr) minmax(120px, 1fr) 110px 90px 56px;
 }
 
 .repeater-col {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -761,9 +761,6 @@ body {
 }
 
 .two-step-header h5 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #2d3748;
   margin: 0;
 }
 
@@ -2402,26 +2399,12 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-top: 1px solid var(--color-border);
 }
 
-.esop-section h5,
-.warrants-section h5 {
-  font-size: var(--text-md);
-  font-weight: 600;
-  color: var(--color-fg);
-  margin: 0 0 var(--space-2);
-}
-
-.esop-subtitle,
-.warrants-subtitle {
-  margin: 0 0 var(--space-4);
-  font-size: var(--text-sm);
+/* Shared subtitle for any advanced sub-section. Sits under .section-title-row. */
+.section-subtitle {
+  margin: 0.25rem 0 var(--space-3);
+  font-size: var(--text-xs);
   color: var(--color-fg-subtle);
-  line-height: 1.5;
-}
-
-.esop-subtitle em {
-  color: var(--color-fg-muted);
-  font-style: normal;
-  font-weight: 600;
+  line-height: 1.4;
 }
 
 .warrants-section {
@@ -2520,12 +2503,28 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   line-height: 1.4;
 }
 
-.esop-timing-section {
-  margin-top: var(--space-4);
-  padding: var(--space-4);
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+.esop-timing-row {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.esop-timing-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.esop-timing-row .esop-timing-explanation {
+  flex: 1 1 100%;
+  margin: 0.25rem 0 0;
+  font-size: var(--text-xs);
+  color: var(--color-fg-subtle);
+  line-height: 1.4;
 }
 
 .section-label {
@@ -2571,13 +2570,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .esop-timing-option:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-.esop-timing-explanation {
-  margin: var(--space-3) 0 0;
-  font-size: var(--text-sm);
-  color: var(--color-fg-muted);
-  line-height: 1.5;
 }
 
 @media (max-width: 768px) {
@@ -2837,22 +2829,10 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   font-size: 0.85rem;
 }
 
-/* ESOP when paired with 2-Step: tighten subtitle + timing block spacing so
-   the block balances with the (often-collapsed) 2-Step side. */
-.advanced-split .esop-section .esop-subtitle {
-  margin-bottom: var(--space-2);
-  font-size: 0.78rem;
-  line-height: 1.4;
-}
-
-.advanced-split .esop-section .esop-timing-section {
-  margin-top: var(--space-3);
-  padding: var(--space-3);
-}
-
-.advanced-split .esop-section .esop-timing-explanation {
-  font-size: 0.78rem;
-  line-height: 1.4;
+/* ESOP when paired with 2-Step: tighten the timing row's wrap to keep the
+   block balanced with the (often-collapsed) 2-Step side. */
+.advanced-split .esop-section .esop-timing-row {
+  margin-top: var(--space-2);
 }
 
 /* 2-Step Step 2 card — stack inputs vertically so each stays wide enough to
@@ -3231,10 +3211,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   /* ESOP section tighter */
   .esop-section .input-grid {
     grid-template-columns: 1fr;
-  }
-
-  .esop-timing-section {
-    padding: 0.65rem;
   }
 
   /* Pro-rata explanation and notes smaller */

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -53,9 +53,8 @@ const InputForm = ({ company, onUpdate }) => {
       }
       // Prevent negative values
       if (numValue < 0) numValue = 0
-      // Prevent unreasonably large values. Share counts can be much larger than $M values.
-      const maxValue = field === 'fdSharesOutstanding' ? 10_000_000_000 : 1_000_000
-      if (numValue > maxValue) numValue = maxValue
+      // Prevent unreasonably large values (> 1 trillion)
+      if (numValue > 1000000) numValue = 1000000
     }
     
     const newValues = { ...values, [field]: numValue }
@@ -235,8 +234,8 @@ const InputForm = ({ company, onUpdate }) => {
     const newWarrant = {
       id: Date.now(),
       name: '',
-      shares: 0,
-      strike: 0
+      amount: 0,
+      valuation: 0
     }
     const newValues = {
       ...values,
@@ -272,9 +271,7 @@ const InputForm = ({ company, onUpdate }) => {
       numValue = 0
     }
     if (numValue < 0) numValue = 0
-    // Shares can be very large; strike is $/share so a smaller cap is fine.
-    const maxValue = field === 'shares' ? 10_000_000_000 : 1_000_000
-    if (numValue > maxValue) numValue = maxValue
+    if (numValue > 1_000_000) numValue = 1_000_000
 
     const newValues = {
       ...values,
@@ -577,47 +574,26 @@ const InputForm = ({ company, onUpdate }) => {
               </div>
             </div>
             <p className="warrants-subtitle">
-              Rough model — assumes all warrants exercise on a fully-diluted basis. Strike payment is ignored for dilution math.
+              Rough model — &quot;$X of warrants at $Y valuation&quot; (standard venture debt phrasing). Pre-round % = amount / valuation.
             </p>
-
-            <div className="warrants-anchor-row">
-              <FormInput
-                label="FD Shares Outstanding"
-                type="number"
-                value={values.fdSharesOutstanding || ''}
-                onChange={(value) => handleChange('fdSharesOutstanding', value)}
-                step="1"
-                min="0"
-                placeholder="0"
-                clearable={true}
-                tooltip="Total fully-diluted shares outstanding pre-round (including warrants, ESOP, etc.). Used to convert warrant share counts to %."
-              />
-              {values.fdSharesOutstanding > 0 && (values.warrants || []).length > 0 && (
-                <div className="warrants-summary">
-                  Total warrants: {(values.warrants || []).reduce((s, w) => s + (Number(w.shares) || 0), 0).toLocaleString()} shares
-                  {' '}({(((values.warrants || []).reduce((s, w) => s + (Number(w.shares) || 0), 0) / values.fdSharesOutstanding) * 100).toFixed(2)}% of FD)
-                </div>
-              )}
-            </div>
 
             {(!values.warrants || values.warrants.length === 0) ? (
               <div className="no-safes-message">
-                No warrants added. Click "Add Warrant" to get started.
+                No warrants added. Click &quot;Add Warrant&quot; to get started.
               </div>
             ) : (
               <div className="repeater-table repeater-table--warrants">
                 <div className="repeater-header">
                   <span className="repeater-col repeater-col--name">Holder</span>
-                  <span className="repeater-col repeater-col--shares">Shares</span>
-                  <span className="repeater-col repeater-col--strike">Strike</span>
+                  <span className="repeater-col repeater-col--amount">Amount</span>
+                  <span className="repeater-col repeater-col--valuation">Valuation</span>
                   <span className="repeater-col repeater-col--alloc">% of FD</span>
                   <span className="repeater-col repeater-col--actions" aria-hidden="true" />
                 </div>
                 {values.warrants.map((warrant) => {
-                  const shares = Number(warrant.shares) || 0
-                  const fdPercent = values.fdSharesOutstanding > 0
-                    ? (shares / values.fdSharesOutstanding) * 100
-                    : 0
+                  const amount = Number(warrant.amount) || 0
+                  const valuation = Number(warrant.valuation) || 0
+                  const fdPercent = (amount > 0 && valuation > 0) ? (amount / valuation) * 100 : 0
                   return (
                     <div key={warrant.id} className="repeater-row repeater-row--warrant">
                       <div className="repeater-col repeater-col--name">
@@ -631,36 +607,39 @@ const InputForm = ({ company, onUpdate }) => {
                           compact
                         />
                       </div>
-                      <div className="repeater-col repeater-col--shares">
+                      <div className="repeater-col repeater-col--amount">
                         <FormInput
-                          label="Shares"
+                          label="Amount"
                           type="number"
-                          value={warrant.shares}
-                          onChange={(value) => updateWarrant(warrant.id, 'shares', value)}
-                          step="1"
+                          value={warrant.amount}
+                          onChange={(value) => updateWarrant(warrant.id, 'amount', value)}
+                          prefix="$"
+                          suffix="M"
+                          step="0.1"
                           min="0"
                           placeholder="0"
-                          id={`warrant-shares-${warrant.id}`}
+                          id={`warrant-amount-${warrant.id}`}
                           compact
                         />
                       </div>
-                      <div className="repeater-col repeater-col--strike">
+                      <div className="repeater-col repeater-col--valuation">
                         <FormInput
-                          label="Strike"
+                          label="Valuation"
                           type="number"
-                          value={warrant.strike}
-                          onChange={(value) => updateWarrant(warrant.id, 'strike', value)}
+                          value={warrant.valuation}
+                          onChange={(value) => updateWarrant(warrant.id, 'valuation', value)}
                           prefix="$"
-                          step="0.01"
+                          suffix="M"
+                          step="1"
                           min="0"
-                          placeholder="0.01"
-                          id={`warrant-strike-${warrant.id}`}
+                          placeholder="0"
+                          id={`warrant-valuation-${warrant.id}`}
                           compact
                         />
                       </div>
                       <div className="repeater-col repeater-col--alloc">
                         <span className="warrants-fd-percent">
-                          {values.fdSharesOutstanding > 0 ? `${fdPercent.toFixed(2)}%` : '—'}
+                          {fdPercent > 0 ? `${fdPercent.toFixed(2)}%` : '—'}
                         </span>
                       </div>
                       <div className="repeater-col repeater-col--actions">

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -505,6 +505,28 @@ const InputForm = ({ company, onUpdate }) => {
             </div>
           </div>
 
+          <div className="warrants-section">
+            <h5>Outstanding Warrants</h5>
+            <p className="warrants-subtitle">
+              Rough model — assumes all outstanding warrants exercise on a fully-diluted basis and dilute like other pre-round equity.
+            </p>
+            <div className="warrants-input-grid">
+              <FormInput
+                label="Warrants"
+                type="number"
+                value={values.preRoundWarrantsPercent || ''}
+                onChange={(value) => handleChange('preRoundWarrantsPercent', value)}
+                suffix="%"
+                step="0.01"
+                min="0"
+                max="100"
+                placeholder="0"
+                clearable={true}
+                tooltip="Pre-round warrants outstanding, as a % of fully-diluted shares."
+              />
+            </div>
+          </div>
+
           <div className="safes-section">
             <div className="section-title-row">
               <h5 className="section-label">SAFE Notes</h5>

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -53,8 +53,9 @@ const InputForm = ({ company, onUpdate }) => {
       }
       // Prevent negative values
       if (numValue < 0) numValue = 0
-      // Prevent unreasonably large values (> 1 trillion)
-      if (numValue > 1000000) numValue = 1000000
+      // Prevent unreasonably large values. Share counts can be much larger than $M values.
+      const maxValue = field === 'fdSharesOutstanding' ? 10_000_000_000 : 1_000_000
+      if (numValue > maxValue) numValue = maxValue
     }
     
     const newValues = { ...values, [field]: numValue }
@@ -223,6 +224,62 @@ const InputForm = ({ company, onUpdate }) => {
         safe.id === safeId
           ? { ...safe, [field]: numValue }
           : safe
+      )
+    }
+    setValues(newValues)
+    onUpdate(newValues)
+  }
+
+  // Warrant management functions
+  const addWarrant = () => {
+    const newWarrant = {
+      id: Date.now(),
+      name: '',
+      shares: 0,
+      strike: 0
+    }
+    const newValues = {
+      ...values,
+      warrants: [...(values.warrants || []), newWarrant]
+    }
+    setValues(newValues)
+    onUpdate(newValues)
+  }
+
+  const removeWarrant = (warrantId) => {
+    const newValues = {
+      ...values,
+      warrants: (values.warrants || []).filter(w => w.id !== warrantId)
+    }
+    setValues(newValues)
+    onUpdate(newValues)
+  }
+
+  const updateWarrant = (warrantId, field, value) => {
+    if (field === 'name') {
+      const newValues = {
+        ...values,
+        warrants: (values.warrants || []).map(w =>
+          w.id === warrantId ? { ...w, name: value } : w
+        )
+      }
+      setValues(newValues)
+      onUpdate(newValues)
+      return
+    }
+    let numValue = parseFloat(value)
+    if (isNaN(numValue) || value === '' || value === null || value === undefined) {
+      numValue = 0
+    }
+    if (numValue < 0) numValue = 0
+    // Shares can be very large; strike is $/share so a smaller cap is fine.
+    const maxValue = field === 'shares' ? 10_000_000_000 : 1_000_000
+    if (numValue > maxValue) numValue = maxValue
+
+    const newValues = {
+      ...values,
+      warrants: (values.warrants || []).map(w =>
+        w.id === warrantId ? { ...w, [field]: numValue } : w
       )
     }
     setValues(newValues)
@@ -506,25 +563,121 @@ const InputForm = ({ company, onUpdate }) => {
           </div>
 
           <div className="warrants-section">
-            <h5>Outstanding Warrants</h5>
+            <div className="section-title-row">
+              <h5 className="section-label">Outstanding Warrants</h5>
+              <div className="section-header-actions">
+                <button
+                  type="button"
+                  className="add-safe-btn"
+                  onClick={addWarrant}
+                  title="Add warrant"
+                >
+                  + Add Warrant
+                </button>
+              </div>
+            </div>
             <p className="warrants-subtitle">
-              Rough model — assumes all outstanding warrants exercise on a fully-diluted basis and dilute like other pre-round equity.
+              Rough model — assumes all warrants exercise on a fully-diluted basis. Strike payment is ignored for dilution math.
             </p>
-            <div className="warrants-input-grid">
+
+            <div className="warrants-anchor-row">
               <FormInput
-                label="Warrants"
+                label="FD Shares Outstanding"
                 type="number"
-                value={values.preRoundWarrantsPercent || ''}
-                onChange={(value) => handleChange('preRoundWarrantsPercent', value)}
-                suffix="%"
-                step="0.01"
+                value={values.fdSharesOutstanding || ''}
+                onChange={(value) => handleChange('fdSharesOutstanding', value)}
+                step="1"
                 min="0"
-                max="100"
                 placeholder="0"
                 clearable={true}
-                tooltip="Pre-round warrants outstanding, as a % of fully-diluted shares."
+                tooltip="Total fully-diluted shares outstanding pre-round (including warrants, ESOP, etc.). Used to convert warrant share counts to %."
               />
+              {values.fdSharesOutstanding > 0 && (values.warrants || []).length > 0 && (
+                <div className="warrants-summary">
+                  Total warrants: {(values.warrants || []).reduce((s, w) => s + (Number(w.shares) || 0), 0).toLocaleString()} shares
+                  {' '}({(((values.warrants || []).reduce((s, w) => s + (Number(w.shares) || 0), 0) / values.fdSharesOutstanding) * 100).toFixed(2)}% of FD)
+                </div>
+              )}
             </div>
+
+            {(!values.warrants || values.warrants.length === 0) ? (
+              <div className="no-safes-message">
+                No warrants added. Click "Add Warrant" to get started.
+              </div>
+            ) : (
+              <div className="repeater-table repeater-table--warrants">
+                <div className="repeater-header">
+                  <span className="repeater-col repeater-col--name">Holder</span>
+                  <span className="repeater-col repeater-col--shares">Shares</span>
+                  <span className="repeater-col repeater-col--strike">Strike</span>
+                  <span className="repeater-col repeater-col--alloc">% of FD</span>
+                  <span className="repeater-col repeater-col--actions" aria-hidden="true" />
+                </div>
+                {values.warrants.map((warrant) => {
+                  const shares = Number(warrant.shares) || 0
+                  const fdPercent = values.fdSharesOutstanding > 0
+                    ? (shares / values.fdSharesOutstanding) * 100
+                    : 0
+                  return (
+                    <div key={warrant.id} className="repeater-row repeater-row--warrant">
+                      <div className="repeater-col repeater-col--name">
+                        <FormInput
+                          label="Holder"
+                          type="text"
+                          value={warrant.name || ''}
+                          onChange={(value) => updateWarrant(warrant.id, 'name', value)}
+                          placeholder="Optional"
+                          id={`warrant-name-${warrant.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--shares">
+                        <FormInput
+                          label="Shares"
+                          type="number"
+                          value={warrant.shares}
+                          onChange={(value) => updateWarrant(warrant.id, 'shares', value)}
+                          step="1"
+                          min="0"
+                          placeholder="0"
+                          id={`warrant-shares-${warrant.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--strike">
+                        <FormInput
+                          label="Strike"
+                          type="number"
+                          value={warrant.strike}
+                          onChange={(value) => updateWarrant(warrant.id, 'strike', value)}
+                          prefix="$"
+                          step="0.01"
+                          min="0"
+                          placeholder="0.01"
+                          id={`warrant-strike-${warrant.id}`}
+                          compact
+                        />
+                      </div>
+                      <div className="repeater-col repeater-col--alloc">
+                        <span className="warrants-fd-percent">
+                          {values.fdSharesOutstanding > 0 ? `${fdPercent.toFixed(2)}%` : '—'}
+                        </span>
+                      </div>
+                      <div className="repeater-col repeater-col--actions">
+                        <button
+                          type="button"
+                          className="remove-safe-btn"
+                          onClick={() => removeWarrant(warrant.id)}
+                          title="Remove warrant"
+                        >
+                          ×
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
           </div>
 
           <div className="safes-section">

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -396,7 +396,7 @@ const InputForm = ({ company, onUpdate }) => {
             {/* 2-Step Round */}
             <div className="two-step-section">
               <div className="two-step-header">
-                <h5>2-Step Round</h5>
+                <h5 className="section-label">2-Step Round</h5>
                 <label className="two-step-checkbox">
                   <input
                     type="checkbox"
@@ -470,9 +470,11 @@ const InputForm = ({ company, onUpdate }) => {
             </div>
 
             <div className="esop-section">
-              <h5>Employee Stock Option Pool (ESOP)</h5>
-              <p className="esop-subtitle">
-                Total pool = Granted + Available. VCs typically negotiate the <em>available</em> slice post-close.
+              <div className="section-title-row">
+                <h5 className="section-label">Employee Stock Option Pool (ESOP)</h5>
+              </div>
+              <p className="section-subtitle">
+                Total pool = Granted + Available. VCs negotiate the available slice post-close.
               </p>
 
               <div className="input-grid esop-input-grid">
@@ -526,8 +528,8 @@ const InputForm = ({ company, onUpdate }) => {
               )}
 
               {values.targetEsopPercent > 0 && (
-                <div className="esop-timing-section">
-                  <label className="section-label">Top-up timing</label>
+                <div className="esop-timing-row">
+                  <span className="esop-timing-label">Top-up timing</span>
                   <div className="esop-timing-toggle" role="tablist">
                     <button
                       type="button"
@@ -548,11 +550,10 @@ const InputForm = ({ company, onUpdate }) => {
                       Post-Close
                     </button>
                   </div>
-
                   <p className="esop-timing-explanation">
                     {values.esopTiming === 'pre-close'
-                      ? 'Top-up happens before the round. Dilutes founders, prior investors, and granted ESOP — not new investors.'
-                      : 'Top-up happens after the round. Dilutes everyone proportionally, including new investors.'}
+                      ? 'Dilutes founders, priors, and granted ESOP — not new investors.'
+                      : 'Dilutes everyone proportionally, including new investors.'}
                   </p>
                 </div>
               )}
@@ -573,8 +574,8 @@ const InputForm = ({ company, onUpdate }) => {
                 </button>
               </div>
             </div>
-            <p className="warrants-subtitle">
-              Rough model — &quot;$X of warrants at $Y valuation&quot; (standard venture debt phrasing). Pre-round % = amount / valuation.
+            <p className="section-subtitle">
+              &quot;$X of warrants at $Y valuation&quot; — pre-round % = amount / valuation.
             </p>
 
             {(!values.warrants || values.warrants.length === 0) ? (

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -57,7 +57,6 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
       grantedEsopPercent: useCompanyInputs ? (sourceCompany.grantedEsopPercent || 0) : (scenario.grantedEsopPercent || 0),
       targetEsopPercent: useCompanyInputs ? (sourceCompany.targetEsopPercent || 0) : (scenario.targetEsopPercent || 0),
       esopTiming: sourceCompany.esopTiming || scenario.esopTiming || 'pre-close',
-      fdSharesOutstanding: useCompanyInputs ? (sourceCompany.fdSharesOutstanding || 0) : (scenario.fdSharesOutstanding || 0),
       warrants: useCompanyInputs ? (sourceCompany.warrants || []) : (scenario.warrants || []),
       twoStepEnabled: useCompanyInputs ? Boolean(sourceCompany.twoStepEnabled) : isTwoStep,
       step2PostMoney: isTwoStep ? scenario.step2.postMoney : (sourceCompany.step2PostMoney || 0),
@@ -658,15 +657,15 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
             {Array.isArray(scenario.warrantDetails) && scenario.warrantDetails.length > 0 && (
               scenario.warrantDetails.map((w, idx) => {
                 const isLast = idx === scenario.warrantDetails.length - 1
-                if (!w.shares || w.postRoundPercent <= 0) return null
+                if (!w.amount || !w.valuation || w.postRoundPercent <= 0) return null
                 const label = w.name && w.name.trim()
                   ? w.name.trim()
-                  : `${(w.shares).toLocaleString()} @ $${(w.strike || 0).toFixed(2)}`
+                  : `$${w.amount.toFixed(2)}M @ $${w.valuation.toFixed(0)}M`
                 return (
                   <div key={w.id || idx} className="table-row sub-row">
                     <div className="label">{isLast ? '└─' : '├─'} {label}</div>
                     <div className="amount amount-neutral">
-                      {(w.shares).toLocaleString()} sh
+                      ${w.amount.toFixed(2)}M @ ${w.valuation.toFixed(0)}M
                     </div>
                     <div className="percent">{formatPercent(w.postRoundPercent)}</div>
                   </div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -57,6 +57,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
       grantedEsopPercent: useCompanyInputs ? (sourceCompany.grantedEsopPercent || 0) : (scenario.grantedEsopPercent || 0),
       targetEsopPercent: useCompanyInputs ? (sourceCompany.targetEsopPercent || 0) : (scenario.targetEsopPercent || 0),
       esopTiming: sourceCompany.esopTiming || scenario.esopTiming || 'pre-close',
+      preRoundWarrantsPercent: useCompanyInputs ? (sourceCompany.preRoundWarrantsPercent || 0) : (scenario.preRoundWarrantsPercent || 0),
       twoStepEnabled: useCompanyInputs ? Boolean(sourceCompany.twoStepEnabled) : isTwoStep,
       step2PostMoney: isTwoStep ? scenario.step2.postMoney : (sourceCompany.step2PostMoney || 0),
       step2Amount: useCompanyInputs ? (sourceCompany.step2Amount || 0) : (isTwoStep ? scenario.step2.amount : 0),
@@ -144,7 +145,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   // Compute Prior Investors + Unknown as remainder so section totals sum to exactly 100%
   // (avoids double-counting pro-rata ownership in both New Round and Prior Investors)
   const adjustedPriorAndUnknownTotal = Math.max(0,
-    100 - scenario.roundPercent - (scenario.totalSafePercent || 0) - foundersTotal - (scenario.finalEsopPercent || 0)
+    100 - scenario.roundPercent - (scenario.totalSafePercent || 0) - foundersTotal - (scenario.finalEsopPercent || 0) - (scenario.finalWarrantsPercent || 0)
   )
 
   // Calculate unknown/other ownership lost using pre-round value from engine
@@ -634,7 +635,26 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
             )}
           </>
         )}
-        
+
+        {/* Warrants */}
+        {showAdvanced && scenario.finalWarrantsPercent > 0 && (
+          <div className="table-row">
+            <div className="label">Warrants</div>
+            <div className="amount">
+              {(() => {
+                const dilution = (scenario.preRoundWarrantsPercent || 0) - scenario.finalWarrantsPercent
+                if (Math.abs(dilution) < 0.01) return <span className='amount-neutral'>—</span>
+                return (
+                  <span className={dilution > 0 ? 'amount-negative' : 'amount-positive'}>
+                    {dilution > 0 ? `-${dilution.toFixed(1)}%` : `+${Math.abs(dilution).toFixed(1)}%`}
+                  </span>
+                )
+              })()}
+            </div>
+            <div className="percent percent-bold">{formatPercent(scenario.finalWarrantsPercent)}</div>
+          </div>
+        )}
+
         {/* Total row */}
         <div className="table-row total-row">
           <div className="label">Total</div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -57,7 +57,8 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
       grantedEsopPercent: useCompanyInputs ? (sourceCompany.grantedEsopPercent || 0) : (scenario.grantedEsopPercent || 0),
       targetEsopPercent: useCompanyInputs ? (sourceCompany.targetEsopPercent || 0) : (scenario.targetEsopPercent || 0),
       esopTiming: sourceCompany.esopTiming || scenario.esopTiming || 'pre-close',
-      preRoundWarrantsPercent: useCompanyInputs ? (sourceCompany.preRoundWarrantsPercent || 0) : (scenario.preRoundWarrantsPercent || 0),
+      fdSharesOutstanding: useCompanyInputs ? (sourceCompany.fdSharesOutstanding || 0) : (scenario.fdSharesOutstanding || 0),
+      warrants: useCompanyInputs ? (sourceCompany.warrants || []) : (scenario.warrants || []),
       twoStepEnabled: useCompanyInputs ? Boolean(sourceCompany.twoStepEnabled) : isTwoStep,
       step2PostMoney: isTwoStep ? scenario.step2.postMoney : (sourceCompany.step2PostMoney || 0),
       step2Amount: useCompanyInputs ? (sourceCompany.step2Amount || 0) : (isTwoStep ? scenario.step2.amount : 0),
@@ -638,21 +639,41 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
 
         {/* Warrants */}
         {showAdvanced && scenario.finalWarrantsPercent > 0 && (
-          <div className="table-row">
-            <div className="label">Warrants</div>
-            <div className="amount">
-              {(() => {
-                const dilution = (scenario.preRoundWarrantsPercent || 0) - scenario.finalWarrantsPercent
-                if (Math.abs(dilution) < 0.01) return <span className='amount-neutral'>—</span>
-                return (
-                  <span className={dilution > 0 ? 'amount-negative' : 'amount-positive'}>
-                    {dilution > 0 ? `-${dilution.toFixed(1)}%` : `+${Math.abs(dilution).toFixed(1)}%`}
-                  </span>
-                )
-              })()}
+          <>
+            <div className="table-row">
+              <div className="label">Warrants</div>
+              <div className="amount">
+                {(() => {
+                  const dilution = (scenario.preRoundWarrantsPercent || 0) - scenario.finalWarrantsPercent
+                  if (Math.abs(dilution) < 0.01) return <span className='amount-neutral'>—</span>
+                  return (
+                    <span className={dilution > 0 ? 'amount-negative' : 'amount-positive'}>
+                      {dilution > 0 ? `-${dilution.toFixed(1)}%` : `+${Math.abs(dilution).toFixed(1)}%`}
+                    </span>
+                  )
+                })()}
+              </div>
+              <div className="percent percent-bold">{formatPercent(scenario.finalWarrantsPercent)}</div>
             </div>
-            <div className="percent percent-bold">{formatPercent(scenario.finalWarrantsPercent)}</div>
-          </div>
+            {Array.isArray(scenario.warrantDetails) && scenario.warrantDetails.length > 0 && (
+              scenario.warrantDetails.map((w, idx) => {
+                const isLast = idx === scenario.warrantDetails.length - 1
+                if (!w.shares || w.postRoundPercent <= 0) return null
+                const label = w.name && w.name.trim()
+                  ? w.name.trim()
+                  : `${(w.shares).toLocaleString()} @ $${(w.strike || 0).toFixed(2)}`
+                return (
+                  <div key={w.id || idx} className="table-row sub-row">
+                    <div className="label">{isLast ? '└─' : '├─'} {label}</div>
+                    <div className="amount amount-neutral">
+                      {(w.shares).toLocaleString()} sh
+                    </div>
+                    <div className="percent">{formatPercent(w.postRoundPercent)}</div>
+                  </div>
+                )
+              })
+            )}
+          </>
         )}
 
         {/* Total row */}

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -37,20 +37,20 @@ export function createFounder(name = '', ownershipPercent = 0) {
 }
 
 /**
- * Creates a new warrant object. Warrants are modeled as a count of shares
- * exercisable at a strike price; the strike is informational for rough
- * dilution modeling (cash impact ignored).
+ * Creates a new warrant object. Warrants are expressed as a dollar amount
+ * struck at a reference valuation (the standard venture debt phrasing:
+ * "$500k of warrants at a $50M valuation"). Pre-round % = amount / valuation.
  * @param {string} name - Warrant holder name
- * @param {number} shares - Number of shares the warrant covers
- * @param {number} strike - Strike price per share ($)
+ * @param {number} amount - Warrant coverage in $M
+ * @param {number} valuation - Reference valuation in $M (post-money at issuance, typically)
  * @returns {Object} Warrant object
  */
-export function createWarrant(name = '', shares = 0, strike = 0) {
+export function createWarrant(name = '', amount = 0, valuation = 0) {
   return {
     id: Date.now() + Math.random(),
     name: name.trim(),
-    shares: Math.max(0, Number(shares) || 0),
-    strike: Math.max(0, Number(strike) || 0)
+    amount: Math.max(0, Number(amount) || 0),
+    valuation: Math.max(0, Number(valuation) || 0)
   }
 }
 
@@ -156,15 +156,15 @@ function normalizeFounder(founder = {}) {
 function normalizeWarrant(warrant = {}) {
   const base = createWarrant(
     typeof warrant.name === 'string' ? warrant.name : '',
-    clamp(getOptionalNumber(warrant.shares) ?? 0, 0, Number.MAX_SAFE_INTEGER),
-    Math.max(0, getOptionalNumber(warrant.strike) ?? 0)
+    Math.max(0, getOptionalNumber(warrant.amount) ?? 0),
+    Math.max(0, getOptionalNumber(warrant.valuation) ?? 0)
   )
   return {
     ...base,
     ...warrant,
     name: typeof warrant.name === 'string' ? warrant.name.trim() : '',
-    shares: Math.max(0, getOptionalNumber(warrant.shares) ?? 0),
-    strike: Math.max(0, getOptionalNumber(warrant.strike) ?? 0)
+    amount: Math.max(0, getOptionalNumber(warrant.amount) ?? 0),
+    valuation: Math.max(0, getOptionalNumber(warrant.valuation) ?? 0)
   }
 }
 
@@ -211,7 +211,6 @@ function looksLikeSingleStoredCompany(value) {
     'twoStepEnabled',
     'showExitMath',
     'exitMath',
-    'fdSharesOutstanding',
     'warrants'
   ].some((key) => Object.prototype.hasOwnProperty.call(value, key))
 }
@@ -263,10 +262,9 @@ export function createDefaultCompany(companyName = 'New Company') {
     targetEsopPercent: 0,
     esopTiming: 'pre-close',
 
-    // Warrants: rough model — assume all outstanding warrants exercised on a
-    // fully-diluted basis. Dilutes like other pre-round equity when the round closes.
-    // Warrant % is derived from totalWarrantShares / fdSharesOutstanding.
-    fdSharesOutstanding: 0,
+    // Warrants: rough model. Each warrant is "$X of warrants at $Y valuation"
+    // (standard venture debt phrasing). Pre-round % = sum(amount / valuation).
+    // Dilutes like other pre-round equity when the round closes.
     warrants: [],
 
     // Sensitivity scenarios: valuation % offsets to render as alternative cards
@@ -382,11 +380,11 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   migrated.currentEsopPercent = Math.max(0, getOptionalNumber(migrated.currentEsopPercent) ?? defaults.currentEsopPercent)
   migrated.grantedEsopPercent = Math.max(0, getOptionalNumber(migrated.grantedEsopPercent) ?? defaults.grantedEsopPercent)
   migrated.targetEsopPercent = Math.max(0, getOptionalNumber(migrated.targetEsopPercent) ?? defaults.targetEsopPercent)
-  migrated.fdSharesOutstanding = Math.max(0, getOptionalNumber(migrated.fdSharesOutstanding) ?? 0)
   migrated.warrants = Array.isArray(migrated.warrants)
     ? migrated.warrants.map((w) => normalizeWarrant(w))
     : []
   delete migrated.preRoundWarrantsPercent
+  delete migrated.fdSharesOutstanding
   migrated.percentPrecision = clamp(getOptionalNumber(migrated.percentPrecision) ?? defaults.percentPrecision, 0, 6)
 
   // Ensure scenarioOffsets exist

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -37,6 +37,24 @@ export function createFounder(name = '', ownershipPercent = 0) {
 }
 
 /**
+ * Creates a new warrant object. Warrants are modeled as a count of shares
+ * exercisable at a strike price; the strike is informational for rough
+ * dilution modeling (cash impact ignored).
+ * @param {string} name - Warrant holder name
+ * @param {number} shares - Number of shares the warrant covers
+ * @param {number} strike - Strike price per share ($)
+ * @returns {Object} Warrant object
+ */
+export function createWarrant(name = '', shares = 0, strike = 0) {
+  return {
+    id: Date.now() + Math.random(),
+    name: name.trim(),
+    shares: Math.max(0, Number(shares) || 0),
+    strike: Math.max(0, Number(strike) || 0)
+  }
+}
+
+/**
  * Validates prior investors array
  * @param {Array} priorInvestors - Array of prior investor objects
  * @returns {boolean} True if valid
@@ -135,6 +153,21 @@ function normalizeFounder(founder = {}) {
   }
 }
 
+function normalizeWarrant(warrant = {}) {
+  const base = createWarrant(
+    typeof warrant.name === 'string' ? warrant.name : '',
+    clamp(getOptionalNumber(warrant.shares) ?? 0, 0, Number.MAX_SAFE_INTEGER),
+    Math.max(0, getOptionalNumber(warrant.strike) ?? 0)
+  )
+  return {
+    ...base,
+    ...warrant,
+    name: typeof warrant.name === 'string' ? warrant.name.trim() : '',
+    shares: Math.max(0, getOptionalNumber(warrant.shares) ?? 0),
+    strike: Math.max(0, getOptionalNumber(warrant.strike) ?? 0)
+  }
+}
+
 function normalizeSafe(safe = {}) {
   const {
     proRataAmount: _legacyProRataAmount,
@@ -178,7 +211,8 @@ function looksLikeSingleStoredCompany(value) {
     'twoStepEnabled',
     'showExitMath',
     'exitMath',
-    'preRoundWarrantsPercent'
+    'fdSharesOutstanding',
+    'warrants'
   ].some((key) => Object.prototype.hasOwnProperty.call(value, key))
 }
 
@@ -231,7 +265,9 @@ export function createDefaultCompany(companyName = 'New Company') {
 
     // Warrants: rough model — assume all outstanding warrants exercised on a
     // fully-diluted basis. Dilutes like other pre-round equity when the round closes.
-    preRoundWarrantsPercent: 0,
+    // Warrant % is derived from totalWarrantShares / fdSharesOutstanding.
+    fdSharesOutstanding: 0,
+    warrants: [],
 
     // Sensitivity scenarios: valuation % offsets to render as alternative cards
     scenarioOffsets: buildScenarioOffsets(30),
@@ -346,11 +382,11 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   migrated.currentEsopPercent = Math.max(0, getOptionalNumber(migrated.currentEsopPercent) ?? defaults.currentEsopPercent)
   migrated.grantedEsopPercent = Math.max(0, getOptionalNumber(migrated.grantedEsopPercent) ?? defaults.grantedEsopPercent)
   migrated.targetEsopPercent = Math.max(0, getOptionalNumber(migrated.targetEsopPercent) ?? defaults.targetEsopPercent)
-  migrated.preRoundWarrantsPercent = clamp(
-    Math.max(0, getOptionalNumber(migrated.preRoundWarrantsPercent) ?? 0),
-    0,
-    100
-  )
+  migrated.fdSharesOutstanding = Math.max(0, getOptionalNumber(migrated.fdSharesOutstanding) ?? 0)
+  migrated.warrants = Array.isArray(migrated.warrants)
+    ? migrated.warrants.map((w) => normalizeWarrant(w))
+    : []
+  delete migrated.preRoundWarrantsPercent
   migrated.percentPrecision = clamp(getOptionalNumber(migrated.percentPrecision) ?? defaults.percentPrecision, 0, 6)
 
   // Ensure scenarioOffsets exist

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -177,7 +177,8 @@ function looksLikeSingleStoredCompany(value) {
     'targetEsopPercent',
     'twoStepEnabled',
     'showExitMath',
-    'exitMath'
+    'exitMath',
+    'preRoundWarrantsPercent'
   ].some((key) => Object.prototype.hasOwnProperty.call(value, key))
 }
 
@@ -227,6 +228,10 @@ export function createDefaultCompany(companyName = 'New Company') {
     grantedEsopPercent: 0,
     targetEsopPercent: 0,
     esopTiming: 'pre-close',
+
+    // Warrants: rough model — assume all outstanding warrants exercised on a
+    // fully-diluted basis. Dilutes like other pre-round equity when the round closes.
+    preRoundWarrantsPercent: 0,
 
     // Sensitivity scenarios: valuation % offsets to render as alternative cards
     scenarioOffsets: buildScenarioOffsets(30),
@@ -341,6 +346,11 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   migrated.currentEsopPercent = Math.max(0, getOptionalNumber(migrated.currentEsopPercent) ?? defaults.currentEsopPercent)
   migrated.grantedEsopPercent = Math.max(0, getOptionalNumber(migrated.grantedEsopPercent) ?? defaults.grantedEsopPercent)
   migrated.targetEsopPercent = Math.max(0, getOptionalNumber(migrated.targetEsopPercent) ?? defaults.targetEsopPercent)
+  migrated.preRoundWarrantsPercent = clamp(
+    Math.max(0, getOptionalNumber(migrated.preRoundWarrantsPercent) ?? 0),
+    0,
+    100
+  )
   migrated.percentPrecision = clamp(getOptionalNumber(migrated.percentPrecision) ?? defaults.percentPrecision, 0, 6)
 
   // Ensure scenarioOffsets exist

--- a/react-app/src/utils/multiParty-calculations.test.js
+++ b/react-app/src/utils/multiParty-calculations.test.js
@@ -1374,8 +1374,8 @@ describe('Hand-computed scenario verification', () => {
     })
   })
 
-  describe('Warrants (shares + strike + FD anchor)', () => {
-    it('derives % from FD shares and dilutes like pre-round equity', () => {
+  describe('Warrants (amount + valuation)', () => {
+    it('derives pre-round % from amount/valuation and dilutes like pre-round equity', () => {
       const result = calculateEnhancedScenario({
         postMoneyVal: 20,
         roundSize: 5,
@@ -1387,12 +1387,10 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 0,
         targetEsopPercent: 0,
-        // 500k shares of penny warrants in a 10M FD cap = 5% of pre-round
-        fdSharesOutstanding: 10_000_000,
-        warrants: [{ id: 100, name: 'Venture Debt', shares: 500_000, strike: 0.01 }]
+        // $0.5M of warrants at $10M valuation = 5% of pre-round
+        warrants: [{ id: 100, name: 'Venture Debt', amount: 0.5, valuation: 10 }]
       })
 
-      // Pre-round warrants = 500k / 10M = 5%
       expect(result.preRoundWarrantsPercent).toBeCloseTo(5, 2)
       // roundPercent = 25 → warrants dilute to 5 * 0.75 = 3.75
       expect(result.finalWarrantsPercent).toBeCloseTo(3.75, 2)
@@ -1404,7 +1402,7 @@ describe('Hand-computed scenario verification', () => {
       expect(total).toBeCloseTo(100, 1)
     })
 
-    it('exposes per-warrant breakdown with shares, strike, and exerciseProceeds', () => {
+    it('sums multiple warrants at different valuations', () => {
       const result = calculateEnhancedScenario({
         postMoneyVal: 20,
         roundSize: 5,
@@ -1416,22 +1414,23 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 0,
         targetEsopPercent: 0,
-        fdSharesOutstanding: 10_000_000,
         warrants: [
-          { id: 1, name: 'SVB', shares: 200_000, strike: 0.01 },
-          { id: 2, name: 'Advisor', shares: 100_000, strike: 1.50 }
+          // $0.5M @ $50M = 1%
+          { id: 1, name: 'SVB', amount: 0.5, valuation: 50 },
+          // $0.2M @ $10M = 2%
+          { id: 2, name: 'Advisor', amount: 0.2, valuation: 10 }
         ]
       })
       expect(result.warrantDetails).toHaveLength(2)
       expect(result.warrantDetails[0].name).toBe('SVB')
-      expect(result.warrantDetails[0].shares).toBe(200_000)
-      expect(result.warrantDetails[0].exerciseProceeds).toBeCloseTo(2000, 2) // 200k * $0.01
-      expect(result.warrantDetails[1].exerciseProceeds).toBeCloseTo(150_000, 2) // 100k * $1.50
-      // Combined = 300k / 10M = 3% of pre-round → 3 * 0.75 = 2.25 final
+      expect(result.warrantDetails[0].preRoundPercent).toBeCloseTo(1, 2)
+      expect(result.warrantDetails[1].preRoundPercent).toBeCloseTo(2, 2)
+      // Combined pre-round = 3%, post-round (×0.75) = 2.25%
+      expect(result.preRoundWarrantsPercent).toBeCloseTo(3, 2)
       expect(result.finalWarrantsPercent).toBeCloseTo(2.25, 2)
     })
 
-    it('contributes 0% when fdSharesOutstanding is zero', () => {
+    it('contributes 0% when amount or valuation is zero', () => {
       const result = calculateEnhancedScenario({
         postMoneyVal: 20,
         roundSize: 5,
@@ -1443,8 +1442,10 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 0,
         targetEsopPercent: 0,
-        fdSharesOutstanding: 0,
-        warrants: [{ id: 1, name: 'X', shares: 500_000, strike: 0.01 }]
+        warrants: [
+          { id: 1, name: 'Incomplete', amount: 0.5, valuation: 0 },
+          { id: 2, name: 'Empty', amount: 0, valuation: 50 }
+        ]
       })
       expect(result.preRoundWarrantsPercent).toBe(0)
       expect(result.finalWarrantsPercent).toBe(0)
@@ -1462,8 +1463,7 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 10,
         targetEsopPercent: 0,
-        fdSharesOutstanding: 10_000_000,
-        warrants: [{ id: 100, name: 'Bank', shares: 500_000, strike: 0.01 }]
+        warrants: [{ id: 100, name: 'Bank', amount: 0.5, valuation: 10 }] // 5%
       })
       const total = result.roundPercent
         + result.priorInvestors.reduce((s, i) => s + i.postRoundPercent, 0)
@@ -1485,8 +1485,7 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 5,
         grantedEsopPercent: 0,
-        fdSharesOutstanding: 10_000_000,
-        warrants: [{ id: 100, name: 'Bank', shares: 1_000_000, strike: 0.01 }]
+        warrants: [{ id: 100, name: 'Bank', amount: 1, valuation: 10 }] // 10%
       }
       const withTopUp = calculateEnhancedScenario({
         ...base,

--- a/react-app/src/utils/multiParty-calculations.test.js
+++ b/react-app/src/utils/multiParty-calculations.test.js
@@ -1374,8 +1374,8 @@ describe('Hand-computed scenario verification', () => {
     })
   })
 
-  describe('Warrants (pre-round outstanding)', () => {
-    it('dilutes warrants like pre-round equity and sums to 100%', () => {
+  describe('Warrants (shares + strike + FD anchor)', () => {
+    it('derives % from FD shares and dilutes like pre-round equity', () => {
       const result = calculateEnhancedScenario({
         postMoneyVal: 20,
         roundSize: 5,
@@ -1387,10 +1387,14 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 0,
         targetEsopPercent: 0,
-        preRoundWarrantsPercent: 5
+        // 500k shares of penny warrants in a 10M FD cap = 5% of pre-round
+        fdSharesOutstanding: 10_000_000,
+        warrants: [{ id: 100, name: 'Venture Debt', shares: 500_000, strike: 0.01 }]
       })
 
-      // roundPercent = 25. Pre-round equity * 0.75. Warrants 5 * 0.75 = 3.75
+      // Pre-round warrants = 500k / 10M = 5%
+      expect(result.preRoundWarrantsPercent).toBeCloseTo(5, 2)
+      // roundPercent = 25 → warrants dilute to 5 * 0.75 = 3.75
       expect(result.finalWarrantsPercent).toBeCloseTo(3.75, 2)
 
       const total = result.roundPercent
@@ -1398,6 +1402,52 @@ describe('Hand-computed scenario verification', () => {
         + result.founders.reduce((s, f) => s + f.postRoundPercent, 0)
         + result.finalWarrantsPercent
       expect(total).toBeCloseTo(100, 1)
+    })
+
+    it('exposes per-warrant breakdown with shares, strike, and exerciseProceeds', () => {
+      const result = calculateEnhancedScenario({
+        postMoneyVal: 20,
+        roundSize: 5,
+        investorPortion: 5,
+        otherPortion: 0,
+        showAdvanced: true,
+        priorInvestors: [],
+        founders: [{ id: 1, name: 'Founders', ownershipPercent: 100 }],
+        safes: [],
+        currentEsopPercent: 0,
+        targetEsopPercent: 0,
+        fdSharesOutstanding: 10_000_000,
+        warrants: [
+          { id: 1, name: 'SVB', shares: 200_000, strike: 0.01 },
+          { id: 2, name: 'Advisor', shares: 100_000, strike: 1.50 }
+        ]
+      })
+      expect(result.warrantDetails).toHaveLength(2)
+      expect(result.warrantDetails[0].name).toBe('SVB')
+      expect(result.warrantDetails[0].shares).toBe(200_000)
+      expect(result.warrantDetails[0].exerciseProceeds).toBeCloseTo(2000, 2) // 200k * $0.01
+      expect(result.warrantDetails[1].exerciseProceeds).toBeCloseTo(150_000, 2) // 100k * $1.50
+      // Combined = 300k / 10M = 3% of pre-round → 3 * 0.75 = 2.25 final
+      expect(result.finalWarrantsPercent).toBeCloseTo(2.25, 2)
+    })
+
+    it('contributes 0% when fdSharesOutstanding is zero', () => {
+      const result = calculateEnhancedScenario({
+        postMoneyVal: 20,
+        roundSize: 5,
+        investorPortion: 5,
+        otherPortion: 0,
+        showAdvanced: true,
+        priorInvestors: [],
+        founders: [{ id: 1, name: 'Founders', ownershipPercent: 100 }],
+        safes: [],
+        currentEsopPercent: 0,
+        targetEsopPercent: 0,
+        fdSharesOutstanding: 0,
+        warrants: [{ id: 1, name: 'X', shares: 500_000, strike: 0.01 }]
+      })
+      expect(result.preRoundWarrantsPercent).toBe(0)
+      expect(result.finalWarrantsPercent).toBe(0)
     })
 
     it('auto-scales founders + priors when warrants + ESOP claim pre-round space', () => {
@@ -1412,11 +1462,9 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 10,
         targetEsopPercent: 0,
-        preRoundWarrantsPercent: 5
+        fdSharesOutstanding: 10_000_000,
+        warrants: [{ id: 100, name: 'Bank', shares: 500_000, strike: 0.01 }]
       })
-
-      // Pre-round space = 100 - 10 (ESOP) - 5 (warrants) = 85. Founders+priors (100) scale to 85.
-      // Check totals sum to ~100%.
       const total = result.roundPercent
         + result.priorInvestors.reduce((s, i) => s + i.postRoundPercent, 0)
         + result.founders.reduce((s, f) => s + f.postRoundPercent, 0)
@@ -1426,7 +1474,7 @@ describe('Hand-computed scenario verification', () => {
     })
 
     it('applies post-close ESOP top-up dilution to warrants too', () => {
-      const withTopUp = calculateEnhancedScenario({
+      const base = {
         postMoneyVal: 20,
         roundSize: 5,
         investorPortion: 5,
@@ -1437,24 +1485,18 @@ describe('Hand-computed scenario verification', () => {
         safes: [],
         currentEsopPercent: 5,
         grantedEsopPercent: 0,
+        fdSharesOutstanding: 10_000_000,
+        warrants: [{ id: 100, name: 'Bank', shares: 1_000_000, strike: 0.01 }]
+      }
+      const withTopUp = calculateEnhancedScenario({
+        ...base,
         targetEsopPercent: 10,
-        esopTiming: 'post-close',
-        preRoundWarrantsPercent: 10
+        esopTiming: 'post-close'
       })
       const withoutTopUp = calculateEnhancedScenario({
-        postMoneyVal: 20,
-        roundSize: 5,
-        investorPortion: 5,
-        otherPortion: 0,
-        showAdvanced: true,
-        priorInvestors: [],
-        founders: [{ id: 1, name: 'Founders', ownershipPercent: 85 }],
-        safes: [],
-        currentEsopPercent: 5,
-        targetEsopPercent: 0,
-        preRoundWarrantsPercent: 10
+        ...base,
+        targetEsopPercent: 0
       })
-      // Warrants are further diluted by the post-close top-up
       expect(withTopUp.finalWarrantsPercent).toBeLessThan(withoutTopUp.finalWarrantsPercent)
     })
   })

--- a/react-app/src/utils/multiParty-calculations.test.js
+++ b/react-app/src/utils/multiParty-calculations.test.js
@@ -1373,4 +1373,89 @@ describe('Hand-computed scenario verification', () => {
       expect(r.founders[0].postRoundPercent).toBeCloseTo(71.23, 1)
     })
   })
+
+  describe('Warrants (pre-round outstanding)', () => {
+    it('dilutes warrants like pre-round equity and sums to 100%', () => {
+      const result = calculateEnhancedScenario({
+        postMoneyVal: 20,
+        roundSize: 5,
+        investorPortion: 4,
+        otherPortion: 1,
+        showAdvanced: true,
+        priorInvestors: [{ id: 1, name: 'Seed', ownershipPercent: 15, hasProRataRights: false }],
+        founders: [{ id: 2, name: 'Founders', ownershipPercent: 80 }],
+        safes: [],
+        currentEsopPercent: 0,
+        targetEsopPercent: 0,
+        preRoundWarrantsPercent: 5
+      })
+
+      // roundPercent = 25. Pre-round equity * 0.75. Warrants 5 * 0.75 = 3.75
+      expect(result.finalWarrantsPercent).toBeCloseTo(3.75, 2)
+
+      const total = result.roundPercent
+        + result.priorInvestors.reduce((s, i) => s + i.postRoundPercent, 0)
+        + result.founders.reduce((s, f) => s + f.postRoundPercent, 0)
+        + result.finalWarrantsPercent
+      expect(total).toBeCloseTo(100, 1)
+    })
+
+    it('auto-scales founders + priors when warrants + ESOP claim pre-round space', () => {
+      const result = calculateEnhancedScenario({
+        postMoneyVal: 10,
+        roundSize: 2,
+        investorPortion: 2,
+        otherPortion: 0,
+        showAdvanced: true,
+        priorInvestors: [{ id: 1, name: 'Seed', ownershipPercent: 20, hasProRataRights: false }],
+        founders: [{ id: 2, name: 'Founders', ownershipPercent: 80 }],
+        safes: [],
+        currentEsopPercent: 10,
+        targetEsopPercent: 0,
+        preRoundWarrantsPercent: 5
+      })
+
+      // Pre-round space = 100 - 10 (ESOP) - 5 (warrants) = 85. Founders+priors (100) scale to 85.
+      // Check totals sum to ~100%.
+      const total = result.roundPercent
+        + result.priorInvestors.reduce((s, i) => s + i.postRoundPercent, 0)
+        + result.founders.reduce((s, f) => s + f.postRoundPercent, 0)
+        + result.finalEsopPercent
+        + result.finalWarrantsPercent
+      expect(total).toBeCloseTo(100, 1)
+    })
+
+    it('applies post-close ESOP top-up dilution to warrants too', () => {
+      const withTopUp = calculateEnhancedScenario({
+        postMoneyVal: 20,
+        roundSize: 5,
+        investorPortion: 5,
+        otherPortion: 0,
+        showAdvanced: true,
+        priorInvestors: [],
+        founders: [{ id: 1, name: 'Founders', ownershipPercent: 85 }],
+        safes: [],
+        currentEsopPercent: 5,
+        grantedEsopPercent: 0,
+        targetEsopPercent: 10,
+        esopTiming: 'post-close',
+        preRoundWarrantsPercent: 10
+      })
+      const withoutTopUp = calculateEnhancedScenario({
+        postMoneyVal: 20,
+        roundSize: 5,
+        investorPortion: 5,
+        otherPortion: 0,
+        showAdvanced: true,
+        priorInvestors: [],
+        founders: [{ id: 1, name: 'Founders', ownershipPercent: 85 }],
+        safes: [],
+        currentEsopPercent: 5,
+        targetEsopPercent: 0,
+        preRoundWarrantsPercent: 10
+      })
+      // Warrants are further diluted by the post-close top-up
+      expect(withTopUp.finalWarrantsPercent).toBeLessThan(withoutTopUp.finalWarrantsPercent)
+    })
+  })
 })

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -284,7 +284,6 @@ function calculateTwoStepScenario(inputs) {
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close',
-    fdSharesOutstanding = 0,
     warrants = []
   } = migratedInputs
 
@@ -301,12 +300,14 @@ function calculateTwoStepScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
-  const effectiveFdSharesOutstanding = showAdvanced ? fdSharesOutstanding : 0
   const effectiveWarrants = showAdvanced ? (Array.isArray(warrants) ? warrants : []) : []
-  const totalWarrantShares = effectiveWarrants.reduce((s, w) => s + (Number(w.shares) || 0), 0)
-  const effectivePreRoundWarrantsPercent = (effectiveFdSharesOutstanding > 0 && totalWarrantShares > 0)
-    ? Math.min(100, (totalWarrantShares / effectiveFdSharesOutstanding) * 100)
-    : 0
+  const totalWarrantAmount = effectiveWarrants.reduce((s, w) => s + (Number(w.amount) || 0), 0)
+  const effectivePreRoundWarrantsPercent = effectiveWarrants.reduce((sum, w) => {
+    const amt = Number(w.amount) || 0
+    const val = Number(w.valuation) || 0
+    if (amt <= 0 || val <= 0) return sum
+    return sum + (amt / val) * 100
+  }, 0)
 
   // Validate founders + priors ≤ 100% on their own; auto-scale to accommodate ESOP otherwise.
   // See single-step path for rationale.
@@ -447,10 +448,10 @@ function calculateTwoStepScenario(inputs) {
   }
 
   const warrantDetails = effectiveWarrants.map(w => {
-    const shares = Number(w.shares) || 0
-    const strike = Number(w.strike) || 0
-    const preRoundPercent = effectiveFdSharesOutstanding > 0
-      ? rp((shares / effectiveFdSharesOutstanding) * 100)
+    const amount = Number(w.amount) || 0
+    const valuation = Number(w.valuation) || 0
+    const preRoundPercent = (amount > 0 && valuation > 0)
+      ? rp((amount / valuation) * 100)
       : 0
     let postRoundPercent = rp(
       preRoundPercent * (100 - step1RoundPercent - safeCalc.totalSafePercent - esopCalc.esopIncreasePreClose) / 100 * step2DilutionFactor
@@ -461,9 +462,8 @@ function calculateTwoStepScenario(inputs) {
     return {
       id: w.id,
       name: w.name || '',
-      shares,
-      strike,
-      exerciseProceeds: r$(shares * strike),
+      amount,
+      valuation,
       preRoundPercent,
       postRoundPercent
     }
@@ -630,10 +630,9 @@ function calculateTwoStepScenario(inputs) {
     esopTiming,
 
     // Warrants
-    fdSharesOutstanding: effectiveFdSharesOutstanding,
     warrants: effectiveWarrants,
     warrantDetails,
-    totalWarrantShares,
+    totalWarrantAmount,
     preRoundWarrantsPercent: effectivePreRoundWarrantsPercent,
     finalWarrantsPercent,
 
@@ -732,7 +731,6 @@ export function calculateEnhancedScenario(inputs) {
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close',
-    fdSharesOutstanding = 0,
     warrants = []
   } = migratedInputs
 
@@ -743,14 +741,16 @@ export function calculateEnhancedScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
-  const effectiveFdSharesOutstanding = showAdvanced ? fdSharesOutstanding : 0
   const effectiveWarrants = showAdvanced ? (Array.isArray(warrants) ? warrants : []) : []
-  const totalWarrantShares = effectiveWarrants.reduce((s, w) => s + (Number(w.shares) || 0), 0)
-  // Warrant % of pre-round FD cap. fdSharesOutstanding is the "100%" of the pre-round cap
-  // (FD basis, including warrants). If fds is 0 or no warrants, contributes 0%.
-  const effectivePreRoundWarrantsPercent = (effectiveFdSharesOutstanding > 0 && totalWarrantShares > 0)
-    ? Math.min(100, (totalWarrantShares / effectiveFdSharesOutstanding) * 100)
-    : 0
+  // Each warrant: "$amount of warrants at $valuation" → contributes amount/valuation%
+  // of pre-round FD cap. Sum across warrants.
+  const totalWarrantAmount = effectiveWarrants.reduce((s, w) => s + (Number(w.amount) || 0), 0)
+  const effectivePreRoundWarrantsPercent = effectiveWarrants.reduce((sum, w) => {
+    const amt = Number(w.amount) || 0
+    const val = Number(w.valuation) || 0
+    if (amt <= 0 || val <= 0) return sum
+    return sum + (amt / val) * 100
+  }, 0)
   
   // Validate founders + priors can't exceed 100% on their own (obvious user error).
   const rawFoundersTotal = effectiveFounders.reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)
@@ -894,10 +894,10 @@ export function calculateEnhancedScenario(inputs) {
 
   // Per-warrant breakdown (each warrant's slice diluted the same way)
   const warrantDetails = effectiveWarrants.map(w => {
-    const shares = Number(w.shares) || 0
-    const strike = Number(w.strike) || 0
-    const preRoundPercent = effectiveFdSharesOutstanding > 0
-      ? rp((shares / effectiveFdSharesOutstanding) * 100)
+    const amount = Number(w.amount) || 0
+    const valuation = Number(w.valuation) || 0
+    const preRoundPercent = (amount > 0 && valuation > 0)
+      ? rp((amount / valuation) * 100)
       : 0
     let postRoundPercent = rp(preRoundPercent * (100 - totalNewOwnership) / 100)
     if (esopCalc.esopIncreasePostClose > 0) {
@@ -906,9 +906,8 @@ export function calculateEnhancedScenario(inputs) {
     return {
       id: w.id,
       name: w.name || '',
-      shares,
-      strike,
-      exerciseProceeds: r$(shares * strike),
+      amount,
+      valuation,
       preRoundPercent,
       postRoundPercent
     }
@@ -1068,10 +1067,9 @@ export function calculateEnhancedScenario(inputs) {
     esopTiming: esopTiming || 'pre-close',
 
     // Warrants
-    fdSharesOutstanding: effectiveFdSharesOutstanding || 0,
     warrants: effectiveWarrants || [],
     warrantDetails: warrantDetails || [],
-    totalWarrantShares: totalWarrantShares || 0,
+    totalWarrantAmount: totalWarrantAmount || 0,
     preRoundWarrantsPercent: effectivePreRoundWarrantsPercent || 0,
     finalWarrantsPercent: finalWarrantsPercent || 0,
 

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -283,7 +283,8 @@ function calculateTwoStepScenario(inputs) {
     currentEsopPercent = 0,
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
-    esopTiming = 'pre-close'
+    esopTiming = 'pre-close',
+    preRoundWarrantsPercent = 0
   } = migratedInputs
 
   if (V1 <= 0 || S1 <= 0 || V1 <= S1 || V2 <= 0 || S2 <= 0 || V2 <= S2) {
@@ -299,6 +300,7 @@ function calculateTwoStepScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
+  const effectivePreRoundWarrantsPercent = showAdvanced ? preRoundWarrantsPercent : 0
 
   // Validate founders + priors ≤ 100% on their own; auto-scale to accommodate ESOP otherwise.
   // See single-step path for rationale.
@@ -310,7 +312,7 @@ function calculateTwoStepScenario(inputs) {
     return null
   }
 
-  const targetNonEsop2 = Math.max(0, 100 - effectiveCurrentEsopPercent)
+  const targetNonEsop2 = Math.max(0, 100 - effectiveCurrentEsopPercent - effectivePreRoundWarrantsPercent)
   const preRoundScaleFactor2 = preRoundNonEsop2 > targetNonEsop2 + 1e-6 && preRoundNonEsop2 > 0
     ? targetNonEsop2 / preRoundNonEsop2
     : 1
@@ -428,6 +430,16 @@ function calculateTwoStepScenario(inputs) {
     }
   })
 
+  // --- Warrants ---
+  // Dilute identically to founders: step 1 pre-round dilution then step 2 dilution factor,
+  // plus post-close ESOP top-up if present.
+  let finalWarrantsPercent = rp(
+    effectivePreRoundWarrantsPercent * (100 - step1RoundPercent - safeCalc.totalSafePercent - esopCalc.esopIncreasePreClose) / 100 * step2DilutionFactor
+  )
+  if (esopCalc.esopIncreasePostClose > 0) {
+    finalWarrantsPercent = rp(finalWarrantsPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
+  }
+
   // Apply post-close ESOP to round percentages
   let finalRoundPercent = totalRoundPercent
   let finalInvestorPercent = totalInvestorPercent
@@ -519,12 +531,14 @@ function calculateTwoStepScenario(inputs) {
 
   const totalAccountedOwnership = finalRoundPercent + safeFinalPercent
     + totalPriorInvestorOwnership + totalFounderOwnership + esopCalc.finalEsopPercent
+    + finalWarrantsPercent
     - proRataOwnershipInRound
   const unknownOwnership = rp(100 - totalAccountedOwnership)
 
   const preRoundTrackedOwnership = scaledPriorInvestors.reduce((sum, inv) => sum + (inv.ownershipPercent || 0), 0)
     + scaledFounders.reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)
     + effectiveCurrentEsopPercent
+    + effectivePreRoundWarrantsPercent
   const preRoundUnknownPercent = Math.max(0, rp(100 - preRoundTrackedOwnership))
 
   // --- Analytics ---
@@ -585,6 +599,10 @@ function calculateTwoStepScenario(inputs) {
     esopIncreasePreClose: esopCalc.esopIncreasePreClose,
     esopIncreasePostClose: esopCalc.esopIncreasePostClose,
     esopTiming,
+
+    // Warrants
+    preRoundWarrantsPercent: effectivePreRoundWarrantsPercent,
+    finalWarrantsPercent,
 
     // Multi-party ownership results
     priorInvestors: postRoundPriorInvestors,
@@ -680,7 +698,8 @@ export function calculateEnhancedScenario(inputs) {
     currentEsopPercent = 0,
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
-    esopTiming = 'pre-close'
+    esopTiming = 'pre-close',
+    preRoundWarrantsPercent = 0
   } = migratedInputs
 
   // When showAdvanced is false, ignore all advanced inputs
@@ -690,6 +709,7 @@ export function calculateEnhancedScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
+  const effectivePreRoundWarrantsPercent = showAdvanced ? preRoundWarrantsPercent : 0
   
   // Validate founders + priors can't exceed 100% on their own (obvious user error).
   const rawFoundersTotal = effectiveFounders.reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)
@@ -701,11 +721,12 @@ export function calculateEnhancedScenario(inputs) {
     return null
   }
 
-  // Reconcile with ESOP: users commonly enter founders = 100% and then add an ESOP pool,
-  // expecting the pool to be carved out of the cap table. When founders + priors + current
-  // ESOP > 100%, scale founders + priors proportionally to fit in (100 − currentEsopPercent)
-  // so section totals sum to exactly 100% instead of silently overshooting.
-  const targetNonEsop = Math.max(0, 100 - effectiveCurrentEsopPercent)
+  // Reconcile with ESOP + warrants: users commonly enter founders = 100% and then add
+  // an ESOP pool and/or outstanding warrants, expecting those to be carved out of the
+  // cap table. When founders + priors + currentEsop + warrants > 100%, scale founders
+  // + priors proportionally to fit in (100 − currentEsop − warrants) so section totals
+  // sum to exactly 100% instead of silently overshooting.
+  const targetNonEsop = Math.max(0, 100 - effectiveCurrentEsopPercent - effectivePreRoundWarrantsPercent)
   const preRoundScaleFactor = preRoundNonEsop > targetNonEsop + 1e-6 && preRoundNonEsop > 0
     ? targetNonEsop / preRoundNonEsop
     : 1
@@ -824,6 +845,12 @@ export function calculateEnhancedScenario(inputs) {
     }
   })
   
+  // Warrants dilute identically to pre-round equity (no pro-rata, no strike).
+  let finalWarrantsPercent = rp(effectivePreRoundWarrantsPercent * (100 - totalNewOwnership) / 100)
+  if (esopCalc.esopIncreasePostClose > 0) {
+    finalWarrantsPercent = rp(finalWarrantsPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
+  }
+
   // Calculate total ownership for verification
   const totalPriorInvestorOwnership = postRoundPriorInvestors.reduce((sum, inv) => sum + inv.postRoundPercent, 0)
   const totalFounderOwnership = postRoundFounders.reduce((sum, founder) => sum + founder.postRoundPercent, 0)
@@ -837,6 +864,7 @@ export function calculateEnhancedScenario(inputs) {
 
   const totalAccountedOwnership = finalRoundPercent + safeCalc.totalSafePercent
     + totalPriorInvestorOwnership + totalFounderOwnership + esopCalc.finalEsopPercent
+    + finalWarrantsPercent
     - proRataOwnershipInRound
 
   // Calculate unknown ownership (what's not accounted for)
@@ -846,6 +874,7 @@ export function calculateEnhancedScenario(inputs) {
   const preRoundTrackedOwnership = (scaledPriorInvestors.reduce((sum, inv) => sum + (inv.ownershipPercent || 0), 0))
     + (scaledFounders.reduce((sum, f) => sum + (f.ownershipPercent || 0), 0))
     + effectiveCurrentEsopPercent
+    + effectivePreRoundWarrantsPercent
   const preRoundUnknownPercent = Math.max(0, rp(100 - preRoundTrackedOwnership))
 
   // Detect if investorName matches a prior investor - combine them in results
@@ -974,7 +1003,11 @@ export function calculateEnhancedScenario(inputs) {
     esopIncreasePreClose: esopCalc.esopIncreasePreClose || 0,
     esopIncreasePostClose: esopCalc.esopIncreasePostClose || 0,
     esopTiming: esopTiming || 'pre-close',
-    
+
+    // Warrants
+    preRoundWarrantsPercent: effectivePreRoundWarrantsPercent || 0,
+    finalWarrantsPercent: finalWarrantsPercent || 0,
+
     // Multi-party ownership results
     priorInvestors: postRoundPriorInvestors || [],
     founders: postRoundFounders || [],

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -284,7 +284,8 @@ function calculateTwoStepScenario(inputs) {
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close',
-    preRoundWarrantsPercent = 0
+    fdSharesOutstanding = 0,
+    warrants = []
   } = migratedInputs
 
   if (V1 <= 0 || S1 <= 0 || V1 <= S1 || V2 <= 0 || S2 <= 0 || V2 <= S2) {
@@ -300,7 +301,12 @@ function calculateTwoStepScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
-  const effectivePreRoundWarrantsPercent = showAdvanced ? preRoundWarrantsPercent : 0
+  const effectiveFdSharesOutstanding = showAdvanced ? fdSharesOutstanding : 0
+  const effectiveWarrants = showAdvanced ? (Array.isArray(warrants) ? warrants : []) : []
+  const totalWarrantShares = effectiveWarrants.reduce((s, w) => s + (Number(w.shares) || 0), 0)
+  const effectivePreRoundWarrantsPercent = (effectiveFdSharesOutstanding > 0 && totalWarrantShares > 0)
+    ? Math.min(100, (totalWarrantShares / effectiveFdSharesOutstanding) * 100)
+    : 0
 
   // Validate founders + priors ≤ 100% on their own; auto-scale to accommodate ESOP otherwise.
   // See single-step path for rationale.
@@ -439,6 +445,29 @@ function calculateTwoStepScenario(inputs) {
   if (esopCalc.esopIncreasePostClose > 0) {
     finalWarrantsPercent = rp(finalWarrantsPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
   }
+
+  const warrantDetails = effectiveWarrants.map(w => {
+    const shares = Number(w.shares) || 0
+    const strike = Number(w.strike) || 0
+    const preRoundPercent = effectiveFdSharesOutstanding > 0
+      ? rp((shares / effectiveFdSharesOutstanding) * 100)
+      : 0
+    let postRoundPercent = rp(
+      preRoundPercent * (100 - step1RoundPercent - safeCalc.totalSafePercent - esopCalc.esopIncreasePreClose) / 100 * step2DilutionFactor
+    )
+    if (esopCalc.esopIncreasePostClose > 0) {
+      postRoundPercent = rp(postRoundPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
+    }
+    return {
+      id: w.id,
+      name: w.name || '',
+      shares,
+      strike,
+      exerciseProceeds: r$(shares * strike),
+      preRoundPercent,
+      postRoundPercent
+    }
+  })
 
   // Apply post-close ESOP to round percentages
   let finalRoundPercent = totalRoundPercent
@@ -601,6 +630,10 @@ function calculateTwoStepScenario(inputs) {
     esopTiming,
 
     // Warrants
+    fdSharesOutstanding: effectiveFdSharesOutstanding,
+    warrants: effectiveWarrants,
+    warrantDetails,
+    totalWarrantShares,
     preRoundWarrantsPercent: effectivePreRoundWarrantsPercent,
     finalWarrantsPercent,
 
@@ -699,7 +732,8 @@ export function calculateEnhancedScenario(inputs) {
     grantedEsopPercent = 0,
     targetEsopPercent = 0,
     esopTiming = 'pre-close',
-    preRoundWarrantsPercent = 0
+    fdSharesOutstanding = 0,
+    warrants = []
   } = migratedInputs
 
   // When showAdvanced is false, ignore all advanced inputs
@@ -709,7 +743,14 @@ export function calculateEnhancedScenario(inputs) {
   const effectiveCurrentEsopPercent = showAdvanced ? currentEsopPercent : 0
   const effectiveGrantedEsopPercent = showAdvanced ? Math.min(grantedEsopPercent, currentEsopPercent) : 0
   const effectiveTargetEsopPercent = showAdvanced ? targetEsopPercent : 0
-  const effectivePreRoundWarrantsPercent = showAdvanced ? preRoundWarrantsPercent : 0
+  const effectiveFdSharesOutstanding = showAdvanced ? fdSharesOutstanding : 0
+  const effectiveWarrants = showAdvanced ? (Array.isArray(warrants) ? warrants : []) : []
+  const totalWarrantShares = effectiveWarrants.reduce((s, w) => s + (Number(w.shares) || 0), 0)
+  // Warrant % of pre-round FD cap. fdSharesOutstanding is the "100%" of the pre-round cap
+  // (FD basis, including warrants). If fds is 0 or no warrants, contributes 0%.
+  const effectivePreRoundWarrantsPercent = (effectiveFdSharesOutstanding > 0 && totalWarrantShares > 0)
+    ? Math.min(100, (totalWarrantShares / effectiveFdSharesOutstanding) * 100)
+    : 0
   
   // Validate founders + priors can't exceed 100% on their own (obvious user error).
   const rawFoundersTotal = effectiveFounders.reduce((sum, f) => sum + (f.ownershipPercent || 0), 0)
@@ -850,6 +891,28 @@ export function calculateEnhancedScenario(inputs) {
   if (esopCalc.esopIncreasePostClose > 0) {
     finalWarrantsPercent = rp(finalWarrantsPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
   }
+
+  // Per-warrant breakdown (each warrant's slice diluted the same way)
+  const warrantDetails = effectiveWarrants.map(w => {
+    const shares = Number(w.shares) || 0
+    const strike = Number(w.strike) || 0
+    const preRoundPercent = effectiveFdSharesOutstanding > 0
+      ? rp((shares / effectiveFdSharesOutstanding) * 100)
+      : 0
+    let postRoundPercent = rp(preRoundPercent * (100 - totalNewOwnership) / 100)
+    if (esopCalc.esopIncreasePostClose > 0) {
+      postRoundPercent = rp(postRoundPercent * (100 - esopCalc.esopIncreasePostClose) / 100)
+    }
+    return {
+      id: w.id,
+      name: w.name || '',
+      shares,
+      strike,
+      exerciseProceeds: r$(shares * strike),
+      preRoundPercent,
+      postRoundPercent
+    }
+  })
 
   // Calculate total ownership for verification
   const totalPriorInvestorOwnership = postRoundPriorInvestors.reduce((sum, inv) => sum + inv.postRoundPercent, 0)
@@ -1005,6 +1068,10 @@ export function calculateEnhancedScenario(inputs) {
     esopTiming: esopTiming || 'pre-close',
 
     // Warrants
+    fdSharesOutstanding: effectiveFdSharesOutstanding || 0,
+    warrants: effectiveWarrants || [],
+    warrantDetails: warrantDetails || [],
+    totalWarrantShares: totalWarrantShares || 0,
     preRoundWarrantsPercent: effectivePreRoundWarrantsPercent || 0,
     finalWarrantsPercent: finalWarrantsPercent || 0,
 

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -23,6 +23,8 @@ const URL_PARAM_MAP = {
   grantedEsopPercent: 'ge',
   targetEsopPercent: 'te',
   esopTiming: 'et',
+  // Warrants
+  preRoundWarrantsPercent: 'wp',
   percentPrecision: 'pp',
   // 2-Step Round
   twoStepEnabled: 'ts',
@@ -163,6 +165,7 @@ export function encodeScenarioToURL(scenarioData) {
       
       // Only include non-zero values for optional fields
       if (['proRataPercent', 'currentEsopPercent', 'grantedEsopPercent', 'targetEsopPercent',
+           'preRoundWarrantsPercent',
            'step2PostMoney', 'step2Amount', 'step2InvestorPortion', 'step2OtherPortion'].includes(field) && value === 0) {
         return
       }
@@ -218,6 +221,8 @@ export function decodeScenarioFromURL(urlParams) {
       grantedEsopPercent: 0,
       targetEsopPercent: 0,
       esopTiming: 'pre-close',
+      // Warrants default
+      preRoundWarrantsPercent: 0,
       percentPrecision: 2,
       // 2-Step Round defaults
       twoStepEnabled: false,
@@ -314,7 +319,9 @@ export function decodeScenarioFromURL(urlParams) {
     if (!params.has('adv') && (scenarioData.proRataPercent > 0 || scenarioData.preRoundFounderOwnership > 0 ||
         (scenarioData.safes && scenarioData.safes.length > 0) || scenarioData.currentEsopPercent > 0 ||
         scenarioData.grantedEsopPercent > 0 ||
-        scenarioData.targetEsopPercent > 0 || (scenarioData.priorInvestors && scenarioData.priorInvestors.length > 0) ||
+        scenarioData.targetEsopPercent > 0 ||
+        scenarioData.preRoundWarrantsPercent > 0 ||
+        (scenarioData.priorInvestors && scenarioData.priorInvestors.length > 0) ||
         (scenarioData.founders && scenarioData.founders.length > 0))) {
       scenarioData.showAdvanced = true
     }

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -24,7 +24,6 @@ const URL_PARAM_MAP = {
   targetEsopPercent: 'te',
   esopTiming: 'et',
   // Warrants
-  fdSharesOutstanding: 'fds',
   warrants: 'wts',
   percentPrecision: 'pp',
   // 2-Step Round
@@ -130,14 +129,14 @@ export function encodeScenarioToURL(scenarioData) {
         if (Array.isArray(value) && value.length > 0) {
           const wtsData = value.map(w => {
             const encoded = {
-              s: Number(w.shares) || 0,
-              k: Number(w.strike) || 0
+              a: Number(w.amount) || 0,
+              v: Number(w.valuation) || 0
             }
             if (w.name && String(w.name).trim()) {
               encoded.n = String(w.name).trim()
             }
             return encoded
-          }).filter(w => w.s > 0)
+          }).filter(w => w.a > 0 && w.v > 0)
           if (wtsData.length > 0) {
             params.set(param, JSON.stringify(wtsData))
           }
@@ -186,7 +185,6 @@ export function encodeScenarioToURL(scenarioData) {
       
       // Only include non-zero values for optional fields
       if (['proRataPercent', 'currentEsopPercent', 'grantedEsopPercent', 'targetEsopPercent',
-           'fdSharesOutstanding',
            'step2PostMoney', 'step2Amount', 'step2InvestorPortion', 'step2OtherPortion'].includes(field) && value === 0) {
         return
       }
@@ -243,7 +241,6 @@ export function decodeScenarioFromURL(urlParams) {
       targetEsopPercent: 0,
       esopTiming: 'pre-close',
       // Warrants defaults
-      fdSharesOutstanding: 0,
       warrants: [],
       percentPrecision: 2,
       // 2-Step Round defaults
@@ -294,8 +291,8 @@ export function decodeScenarioFromURL(urlParams) {
               scenarioData[field] = wtsData.map((w, index) => ({
                 id: Date.now() + index + 3000,
                 name: w.n || '',
-                shares: Number(w.s) || 0,
-                strike: Number(w.k) || 0
+                amount: Number(w.a) || 0,
+                valuation: Number(w.v) || 0
               }))
             }
           } catch (error) {
@@ -357,7 +354,6 @@ export function decodeScenarioFromURL(urlParams) {
         (scenarioData.safes && scenarioData.safes.length > 0) || scenarioData.currentEsopPercent > 0 ||
         scenarioData.grantedEsopPercent > 0 ||
         scenarioData.targetEsopPercent > 0 ||
-        scenarioData.fdSharesOutstanding > 0 ||
         (scenarioData.warrants && scenarioData.warrants.length > 0) ||
         (scenarioData.priorInvestors && scenarioData.priorInvestors.length > 0) ||
         (scenarioData.founders && scenarioData.founders.length > 0))) {

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -24,7 +24,8 @@ const URL_PARAM_MAP = {
   targetEsopPercent: 'te',
   esopTiming: 'et',
   // Warrants
-  preRoundWarrantsPercent: 'wp',
+  fdSharesOutstanding: 'fds',
+  warrants: 'wts',
   percentPrecision: 'pp',
   // 2-Step Round
   twoStepEnabled: 'ts',
@@ -124,6 +125,26 @@ export function encodeScenarioToURL(scenarioData) {
         return
       }
       
+      // Handle warrants array encoding
+      if (field === 'warrants') {
+        if (Array.isArray(value) && value.length > 0) {
+          const wtsData = value.map(w => {
+            const encoded = {
+              s: Number(w.shares) || 0,
+              k: Number(w.strike) || 0
+            }
+            if (w.name && String(w.name).trim()) {
+              encoded.n = String(w.name).trim()
+            }
+            return encoded
+          }).filter(w => w.s > 0)
+          if (wtsData.length > 0) {
+            params.set(param, JSON.stringify(wtsData))
+          }
+        }
+        return
+      }
+
       // Handle prior investors array encoding
       if (field === 'priorInvestors') {
         if (Array.isArray(value) && value.length > 0) {
@@ -165,7 +186,7 @@ export function encodeScenarioToURL(scenarioData) {
       
       // Only include non-zero values for optional fields
       if (['proRataPercent', 'currentEsopPercent', 'grantedEsopPercent', 'targetEsopPercent',
-           'preRoundWarrantsPercent',
+           'fdSharesOutstanding',
            'step2PostMoney', 'step2Amount', 'step2InvestorPortion', 'step2OtherPortion'].includes(field) && value === 0) {
         return
       }
@@ -221,8 +242,9 @@ export function decodeScenarioFromURL(urlParams) {
       grantedEsopPercent: 0,
       targetEsopPercent: 0,
       esopTiming: 'pre-close',
-      // Warrants default
-      preRoundWarrantsPercent: 0,
+      // Warrants defaults
+      fdSharesOutstanding: 0,
+      warrants: [],
       percentPrecision: 2,
       // 2-Step Round defaults
       twoStepEnabled: false,
@@ -263,6 +285,21 @@ export function decodeScenarioFromURL(urlParams) {
             }
           } catch (error) {
             console.warn('Failed to decode SAFEs array from URL:', error)
+            scenarioData[field] = []
+          }
+        } else if (field === 'warrants') {
+          try {
+            const wtsData = JSON.parse(value)
+            if (Array.isArray(wtsData)) {
+              scenarioData[field] = wtsData.map((w, index) => ({
+                id: Date.now() + index + 3000,
+                name: w.n || '',
+                shares: Number(w.s) || 0,
+                strike: Number(w.k) || 0
+              }))
+            }
+          } catch (error) {
+            console.warn('Failed to decode warrants array from URL:', error)
             scenarioData[field] = []
           }
         } else if (field === 'priorInvestors') {
@@ -320,7 +357,8 @@ export function decodeScenarioFromURL(urlParams) {
         (scenarioData.safes && scenarioData.safes.length > 0) || scenarioData.currentEsopPercent > 0 ||
         scenarioData.grantedEsopPercent > 0 ||
         scenarioData.targetEsopPercent > 0 ||
-        scenarioData.preRoundWarrantsPercent > 0 ||
+        scenarioData.fdSharesOutstanding > 0 ||
+        (scenarioData.warrants && scenarioData.warrants.length > 0) ||
         (scenarioData.priorInvestors && scenarioData.priorInvestors.length > 0) ||
         (scenarioData.founders && scenarioData.founders.length > 0))) {
       scenarioData.showAdvanced = true

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -836,7 +836,7 @@ describe('Permalink Utilities', () => {
   })
 
   describe('Warrants permalink support', () => {
-    it('roundtrips preRoundWarrantsPercent via wp param', () => {
+    it('roundtrips fdSharesOutstanding (fds) and warrants array (wts)', () => {
       const data = {
         postMoneyVal: 13,
         roundSize: 3,
@@ -844,27 +844,58 @@ describe('Permalink Utilities', () => {
         otherPortion: 0.25,
         investorName: 'US',
         showAdvanced: true,
-        preRoundWarrantsPercent: 4.5
+        fdSharesOutstanding: 10_000_000,
+        warrants: [
+          { id: 1, name: 'SVB', shares: 500_000, strike: 0.01 },
+          { id: 2, name: 'Advisor', shares: 100_000, strike: 1.5 }
+        ]
       }
       const encoded = encodeScenarioToURL(data)
-      expect(encoded).toContain('wp=4.5')
+      expect(encoded).toContain('fds=10000000')
+      expect(encoded).toContain('wts=')
       const decoded = decodeScenarioFromURL(encoded)
-      expect(decoded.preRoundWarrantsPercent).toBe(4.5)
+      expect(decoded.fdSharesOutstanding).toBe(10_000_000)
+      expect(decoded.warrants).toHaveLength(2)
+      expect(decoded.warrants[0].name).toBe('SVB')
+      expect(decoded.warrants[0].shares).toBe(500_000)
+      expect(decoded.warrants[0].strike).toBe(0.01)
+      expect(decoded.warrants[1].name).toBe('Advisor')
     })
 
-    it('omits wp when warrants are zero', () => {
+    it('omits fds and wts when warrants are absent', () => {
       const encoded = encodeScenarioToURL({
         postMoneyVal: 13,
         roundSize: 3,
         investorPortion: 2.75,
         otherPortion: 0.25,
         investorName: 'US',
-        preRoundWarrantsPercent: 0
+        fdSharesOutstanding: 0,
+        warrants: []
       })
-      expect(encoded).not.toContain('wp=')
+      expect(encoded).not.toContain('fds=')
+      expect(encoded).not.toContain('wts=')
     })
 
-    it('auto-enables showAdvanced when wp is present', () => {
+    it('drops warrants with zero shares', () => {
+      const encoded = encodeScenarioToURL({
+        postMoneyVal: 13,
+        roundSize: 3,
+        investorPortion: 2.75,
+        otherPortion: 0.25,
+        investorName: 'US',
+        showAdvanced: true,
+        fdSharesOutstanding: 5_000_000,
+        warrants: [
+          { id: 1, name: 'Real', shares: 100_000, strike: 0.01 },
+          { id: 2, name: 'Empty', shares: 0, strike: 0 }
+        ]
+      })
+      const decoded = decodeScenarioFromURL(encoded)
+      expect(decoded.warrants).toHaveLength(1)
+      expect(decoded.warrants[0].name).toBe('Real')
+    })
+
+    it('auto-enables showAdvanced when warrants are present', () => {
       const encoded = encodeScenarioToURL({
         postMoneyVal: 13,
         roundSize: 3,
@@ -872,11 +903,12 @@ describe('Permalink Utilities', () => {
         otherPortion: 0.25,
         investorName: 'US',
         showAdvanced: false,
-        preRoundWarrantsPercent: 3
+        fdSharesOutstanding: 10_000_000,
+        warrants: [{ id: 1, name: 'X', shares: 500_000, strike: 0.01 }]
       })
       const decoded = decodeScenarioFromURL(encoded)
       expect(decoded.showAdvanced).toBe(true)
-      expect(decoded.preRoundWarrantsPercent).toBe(3)
+      expect(decoded.fdSharesOutstanding).toBe(10_000_000)
     })
   })
 })

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -834,4 +834,49 @@ describe('Permalink Utilities', () => {
       })
     })
   })
+
+  describe('Warrants permalink support', () => {
+    it('roundtrips preRoundWarrantsPercent via wp param', () => {
+      const data = {
+        postMoneyVal: 13,
+        roundSize: 3,
+        investorPortion: 2.75,
+        otherPortion: 0.25,
+        investorName: 'US',
+        showAdvanced: true,
+        preRoundWarrantsPercent: 4.5
+      }
+      const encoded = encodeScenarioToURL(data)
+      expect(encoded).toContain('wp=4.5')
+      const decoded = decodeScenarioFromURL(encoded)
+      expect(decoded.preRoundWarrantsPercent).toBe(4.5)
+    })
+
+    it('omits wp when warrants are zero', () => {
+      const encoded = encodeScenarioToURL({
+        postMoneyVal: 13,
+        roundSize: 3,
+        investorPortion: 2.75,
+        otherPortion: 0.25,
+        investorName: 'US',
+        preRoundWarrantsPercent: 0
+      })
+      expect(encoded).not.toContain('wp=')
+    })
+
+    it('auto-enables showAdvanced when wp is present', () => {
+      const encoded = encodeScenarioToURL({
+        postMoneyVal: 13,
+        roundSize: 3,
+        investorPortion: 2.75,
+        otherPortion: 0.25,
+        investorName: 'US',
+        showAdvanced: false,
+        preRoundWarrantsPercent: 3
+      })
+      const decoded = decodeScenarioFromURL(encoded)
+      expect(decoded.showAdvanced).toBe(true)
+      expect(decoded.preRoundWarrantsPercent).toBe(3)
+    })
+  })
 })

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -836,7 +836,7 @@ describe('Permalink Utilities', () => {
   })
 
   describe('Warrants permalink support', () => {
-    it('roundtrips fdSharesOutstanding (fds) and warrants array (wts)', () => {
+    it('roundtrips warrants array (wts) with amount + valuation', () => {
       const data = {
         postMoneyVal: 13,
         roundSize: 3,
@@ -844,39 +844,34 @@ describe('Permalink Utilities', () => {
         otherPortion: 0.25,
         investorName: 'US',
         showAdvanced: true,
-        fdSharesOutstanding: 10_000_000,
         warrants: [
-          { id: 1, name: 'SVB', shares: 500_000, strike: 0.01 },
-          { id: 2, name: 'Advisor', shares: 100_000, strike: 1.5 }
+          { id: 1, name: 'SVB', amount: 0.5, valuation: 50 },
+          { id: 2, name: 'Advisor', amount: 0.2, valuation: 10 }
         ]
       }
       const encoded = encodeScenarioToURL(data)
-      expect(encoded).toContain('fds=10000000')
       expect(encoded).toContain('wts=')
       const decoded = decodeScenarioFromURL(encoded)
-      expect(decoded.fdSharesOutstanding).toBe(10_000_000)
       expect(decoded.warrants).toHaveLength(2)
       expect(decoded.warrants[0].name).toBe('SVB')
-      expect(decoded.warrants[0].shares).toBe(500_000)
-      expect(decoded.warrants[0].strike).toBe(0.01)
-      expect(decoded.warrants[1].name).toBe('Advisor')
+      expect(decoded.warrants[0].amount).toBe(0.5)
+      expect(decoded.warrants[0].valuation).toBe(50)
+      expect(decoded.warrants[1].amount).toBe(0.2)
     })
 
-    it('omits fds and wts when warrants are absent', () => {
+    it('omits wts when warrants are absent or incomplete', () => {
       const encoded = encodeScenarioToURL({
         postMoneyVal: 13,
         roundSize: 3,
         investorPortion: 2.75,
         otherPortion: 0.25,
         investorName: 'US',
-        fdSharesOutstanding: 0,
         warrants: []
       })
-      expect(encoded).not.toContain('fds=')
       expect(encoded).not.toContain('wts=')
     })
 
-    it('drops warrants with zero shares', () => {
+    it('drops warrants missing amount or valuation', () => {
       const encoded = encodeScenarioToURL({
         postMoneyVal: 13,
         roundSize: 3,
@@ -884,10 +879,10 @@ describe('Permalink Utilities', () => {
         otherPortion: 0.25,
         investorName: 'US',
         showAdvanced: true,
-        fdSharesOutstanding: 5_000_000,
         warrants: [
-          { id: 1, name: 'Real', shares: 100_000, strike: 0.01 },
-          { id: 2, name: 'Empty', shares: 0, strike: 0 }
+          { id: 1, name: 'Real', amount: 0.5, valuation: 50 },
+          { id: 2, name: 'NoVal', amount: 0.5, valuation: 0 },
+          { id: 3, name: 'NoAmt', amount: 0, valuation: 50 }
         ]
       })
       const decoded = decodeScenarioFromURL(encoded)
@@ -903,12 +898,11 @@ describe('Permalink Utilities', () => {
         otherPortion: 0.25,
         investorName: 'US',
         showAdvanced: false,
-        fdSharesOutstanding: 10_000_000,
-        warrants: [{ id: 1, name: 'X', shares: 500_000, strike: 0.01 }]
+        warrants: [{ id: 1, name: 'X', amount: 0.5, valuation: 50 }]
       })
       const decoded = decodeScenarioFromURL(encoded)
       expect(decoded.showAdvanced).toBe(true)
-      expect(decoded.fdSharesOutstanding).toBe(10_000_000)
+      expect(decoded.warrants).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Adds a single `preRoundWarrantsPercent` scalar that assumes outstanding warrants exercise on a fully-diluted basis, so they dilute like founders / granted ESOP when the round closes — no strike price, no per-holder tracking.
- Wired into single-step and two-step calc engines with pre-round auto-scaling (founders+priors fit into `100 − ESOP − warrants`), URL permalink (`wp=`, auto-enables Advanced), a new "Outstanding Warrants" input, and a "Warrants" row on every scenario card.

## Test plan
- [x] `npx vitest run` — all 364 tests pass (incl. 4 new: dilution math, ESOP+warrant auto-scaling, post-close top-up, URL roundtrip).
- [x] Browser verified: `?wp=5` permalink auto-opens Advanced, populates input, renders Warrants at 3.85% (5% × 76.92%), totals sum to 100%.