### PR TITLE
Add guided walkthrough and first-impression polish

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -376,22 +376,25 @@ body {
 .load-example-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0;
   background: var(--color-bg);
   color: var(--color-fg-muted);
   border: none;
   border-left: 1px solid var(--color-border);
-  padding: var(--space-2) var(--space-4);
+  padding: var(--space-2) var(--space-3);
   font-family: inherit;
   font-weight: 600;
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast), gap 0.2s ease, padding 0.2s ease;
 }
 
 .load-example-btn:hover {
   background: var(--color-accent-soft);
   color: var(--color-accent);
+  gap: 6px;
+  padding-right: var(--space-4);
 }
 
 .load-example-icon {
@@ -404,6 +407,21 @@ body {
 
 .load-example-btn:hover .load-example-icon {
   color: #d39400;
+}
+
+/* Collapsed by default — only the star icon shows. Hover reveals the label. */
+.load-example-text {
+  display: inline-block;
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease;
+}
+
+.load-example-btn:hover .load-example-text,
+.load-example-btn:focus-visible .load-example-text {
+  max-width: 160px;
+  opacity: 1;
 }
 
 .add-company-btn:hover,

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -352,6 +352,57 @@ body {
   align-self: stretch;
 }
 
+/* Container for Load Example + Add Scenario buttons on the right of the tabs row */
+.tabs-actions {
+  display: flex;
+  align-items: stretch;
+  flex: 0 0 auto;
+  align-self: stretch;
+}
+
+.tabs-actions > button {
+  border-radius: 0;
+  align-self: stretch;
+  margin-left: 0;
+}
+
+.tabs-actions > .add-company-btn {
+  border-left: 1px solid var(--color-border);
+}
+
+.load-example-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--color-bg);
+  color: var(--color-fg-muted);
+  border: none;
+  border-left: 1px solid var(--color-border);
+  padding: var(--space-2) var(--space-4);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.load-example-btn:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.load-example-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  color: #f5b400;
+}
+
+.load-example-btn:hover .load-example-icon {
+  color: #d39400;
+}
+
 .add-company-btn:hover,
 .add-safe-btn:hover,
 .add-investor-btn:hover,
@@ -3043,6 +3094,17 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   }
 
   .tabs-container > .add-company-btn {
+    width: 100%;
+    justify-content: center;
+    border-left: none;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .tabs-actions {
+    flex-direction: column;
+  }
+  .tabs-actions > .add-company-btn,
+  .tabs-actions > .load-example-btn {
     width: 100%;
     justify-content: center;
     border-left: none;

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -190,9 +190,12 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  flex: 1 1 0;
-  min-width: clamp(170px, 12vw, 210px);
-  max-width: clamp(210px, 15vw, 240px);
+  /* Sized to content (with min/max clamp). Tabs collectively shrink past
+     their content size only when the row otherwise overflows, at which point
+     the tab-name's text-overflow: ellipsis takes over. */
+  flex: 0 1 auto;
+  min-width: 130px;
+  max-width: 360px;
   justify-content: flex-start;
 }
 
@@ -567,6 +570,25 @@ body {
 .base-scenario.compare-inactive.compare-tint-3 {
   background: hsl(280 25% 97%);
   border-left: 3px solid hsl(280 35% 70%);
+}
+
+/* Placeholder rendered in compare mode when a selected scenario can't compute
+   (e.g. pre-round ownership > 100%). Keeps the tab visible and clickable. */
+.scenario-card.compare-pending {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  border: 1px dashed #f59e9e;
+  background: #fff5f5;
+  cursor: pointer;
+}
+
+.compare-pending-message {
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  line-height: 1.45;
+  margin-top: var(--space-2);
 }
 
 /* Scenarios Rows Layout */

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -3643,3 +3643,258 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-color: #c7c3ff;
   background: #f5f4ff;
 }
+
+/* App subtitle (under logo) */
+.app-header-titles {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.app-subtitle {
+  font-size: var(--text-xs);
+  color: var(--color-fg-faint);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+/* Tour button (left side of header, mirrors exit-math toggle on right) */
+.header-tour-btn {
+  position: absolute;
+  top: 50%;
+  left: var(--space-6);
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-fg-subtle);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  font-family: inherit;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.header-tour-btn:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.header-tour-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  font-size: 0.7rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+/* ======================================================================
+   Walkthrough overlay
+   ====================================================================== */
+
+.walkthrough {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.walkthrough-mask {
+  position: fixed;
+  background: rgba(15, 23, 42, 0.55);
+  pointer-events: auto;
+  transition: top 0.18s ease, left 0.18s ease, width 0.18s ease, height 0.18s ease;
+}
+
+.walkthrough-mask-full {
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
+.walkthrough-spotlight-ring {
+  position: fixed;
+  border-radius: 10px;
+  box-shadow: 0 0 0 2px rgba(99, 91, 255, 0.85), 0 8px 32px rgba(99, 91, 255, 0.25);
+  pointer-events: none;
+  transition: top 0.18s ease, left 0.18s ease, width 0.18s ease, height 0.18s ease;
+  animation: walkthrough-pulse 2s ease-in-out infinite;
+}
+
+@keyframes walkthrough-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(99, 91, 255, 0.85), 0 8px 32px rgba(99, 91, 255, 0.25); }
+  50%      { box-shadow: 0 0 0 2px rgba(99, 91, 255, 0.85), 0 12px 36px rgba(99, 91, 255, 0.45); }
+}
+
+.walkthrough-tooltip {
+  position: fixed;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35), 0 4px 12px rgba(15, 23, 42, 0.15);
+  padding: 18px 20px 16px;
+  pointer-events: auto;
+  font-family: inherit;
+  color: var(--color-fg);
+  border: 1px solid rgba(99, 91, 255, 0.2);
+  animation: walkthrough-tooltip-in 0.2s ease-out;
+}
+
+@keyframes walkthrough-tooltip-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.walkthrough-tooltip::before {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: #ffffff;
+  border: 1px solid rgba(99, 91, 255, 0.2);
+  transform: rotate(45deg);
+}
+
+.walkthrough-tooltip--top::before {
+  top: -7px;
+  left: 50%;
+  margin-left: -6px;
+  border-right: none;
+  border-bottom: none;
+}
+
+.walkthrough-tooltip--bottom::before {
+  bottom: -7px;
+  left: 50%;
+  margin-left: -6px;
+  border-left: none;
+  border-top: none;
+}
+
+.walkthrough-tooltip--left::before {
+  left: -7px;
+  top: 50%;
+  margin-top: -6px;
+  border-top: none;
+  border-right: none;
+}
+
+.walkthrough-tooltip--right::before {
+  right: -7px;
+  top: 50%;
+  margin-top: -6px;
+  border-bottom: none;
+  border-left: none;
+}
+
+.walkthrough-tooltip--center::before {
+  display: none;
+}
+
+.walkthrough-step-counter {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-fg-faint);
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.walkthrough-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-fg);
+  margin: 0 0 6px 0;
+  line-height: 1.3;
+}
+
+.walkthrough-body {
+  font-size: 0.875rem;
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+  margin: 0 0 14px 0;
+}
+
+.walkthrough-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.walkthrough-nav {
+  display: flex;
+  gap: 8px;
+}
+
+.walkthrough-btn {
+  font-family: inherit;
+  font-size: 0.825rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.walkthrough-btn-skip {
+  background: none;
+  color: var(--color-fg-faint);
+  border-color: transparent;
+}
+
+.walkthrough-btn-skip:hover {
+  color: var(--color-fg-muted);
+}
+
+.walkthrough-btn-secondary {
+  background: var(--color-bg);
+  color: var(--color-fg-muted);
+  border-color: var(--color-border);
+}
+
+.walkthrough-btn-secondary:hover {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.walkthrough-btn-primary {
+  background: #635bff;
+  color: #ffffff;
+  border-color: #635bff;
+}
+
+.walkthrough-btn-primary:hover {
+  background: #4f46e5;
+  border-color: #4f46e5;
+}
+
+@media (max-width: 480px) {
+  .header-tour-btn {
+    left: var(--space-3);
+    padding: 0.3rem 0.6rem;
+  }
+  .header-tour-label {
+    display: none;
+  }
+  .header-exit-math-toggle {
+    right: var(--space-3);
+  }
+  .walkthrough-tooltip {
+    width: calc(100vw - 32px) !important;
+    left: 16px !important;
+  }
+}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -7,12 +7,14 @@ import ScenarioControls from './components/ScenarioControls'
 import Logo from './components/Logo'
 import NotificationContainer from './components/NotificationContainer'
 import ExitMathModule from './components/ExitMathModule'
+import Walkthrough from './components/Walkthrough'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
 import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink'
 import { updateSocialSharingMeta } from './utils/socialSharing'
 import { createDefaultCompany, nextUniqueName, normalizeStoredCompanies } from './utils/dataStructures'
+import { buildWalkthroughSteps, TOUR_SEEN_KEY } from './utils/walkthroughSteps'
 
 function getFirstCompanyId(companies) {
   return Object.keys(companies || {})[0] || 'company1'
@@ -38,6 +40,7 @@ function App() {
 
   const [scenarios, setScenarios] = useState([])
   const [baseScenariosById, setBaseScenariosById] = useState({})
+  const [tourActive, setTourActive] = useState(false)
   const { notifications, removeNotification, showSuccess, showInfo, showError } = useNotifications()
 
   const updateCompany = useCallback((companyId, data) => {
@@ -149,6 +152,32 @@ function App() {
     }
   }, [hasLoadedFromURL, activeCompany, showInfo, updateCompany])
 
+  // Auto-launch the tour on first visit
+  useEffect(() => {
+    try {
+      const seen = window.localStorage.getItem(TOUR_SEEN_KEY)
+      if (!seen) {
+        // Slight delay so initial layout settles before measuring targets
+        const id = setTimeout(() => setTourActive(true), 350)
+        return () => clearTimeout(id)
+      }
+    } catch {
+      /* localStorage unavailable; skip auto-launch */
+    }
+  }, [])
+
+  const closeTour = useCallback(() => {
+    setTourActive(false)
+    try { window.localStorage.setItem(TOUR_SEEN_KEY, '1') } catch { /* ignore */ }
+  }, [])
+
+  const startTour = useCallback(() => setTourActive(true), [])
+
+  const tourSteps = useMemo(() => buildWalkthroughSteps({
+    openAdvanced: (val) => updateCompany(activeCompany, { showAdvanced: val }),
+    openExitMath: (val) => updateCompany(activeCompany, { showExitMath: val })
+  }), [activeCompany, updateCompany])
+
 
   useEffect(() => {
     const currentCompany = companies[activeCompany]
@@ -210,10 +239,23 @@ function App() {
         onRemove={removeNotification}
       />
       <header className="app-header">
-        <Logo size={40} />
+        <button
+          type="button"
+          className="header-tour-btn"
+          onClick={startTour}
+          title="Replay the guided tour"
+        >
+          <span className="header-tour-icon" aria-hidden="true">?</span>
+          <span className="header-tour-label">Tour</span>
+        </button>
+        <div className="app-header-titles">
+          <Logo size={40} />
+          <p className="app-subtitle">Term-sheet, dilution &amp; exit modeling</p>
+        </div>
         <button
           type="button"
           className="exit-math-toggle header-exit-math-toggle"
+          data-tour="exit-math-toggle"
           onClick={() => updateCompany(activeCompany, { showExitMath: !(companies[activeCompany]?.showExitMath) })}
           aria-pressed={companies[activeCompany]?.showExitMath || false}
         >
@@ -304,6 +346,13 @@ function App() {
           </div>
         )}
       </main>
+
+      <Walkthrough
+        open={tourActive}
+        steps={tourSteps}
+        onClose={closeTour}
+        onComplete={closeTour}
+      />
     </div>
   )
 }

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -340,7 +340,26 @@ function App() {
           >
             {cardIds.map((cid, idx) => {
               const base = baseScenariosById[cid]
-              if (!base) return null
+              const co = companies[cid]
+              if (!base) {
+                // Selected for compare but the scenario can't currently compute
+                // (e.g. pre-round ownership over 100%). Render a placeholder so
+                // the user can see the tab is checked and click to fix it.
+                return (
+                  <div
+                    key={cid}
+                    className={`scenario-card base-scenario compare-${cid === activeCompany ? 'active' : 'inactive'} compare-tint-${idx % 4} compare-pending`}
+                    onClick={() => setActiveCompany(cid)}
+                    title="Click to open this scenario and fix its inputs"
+                  >
+                    <h3 className="scenario-title">Base Case — {co?.name || cid}</h3>
+                    <div className="compare-pending-message">
+                      Can&rsquo;t compute this scenario.<br />
+                      Click the tab to open it and check inputs (most often this means pre-round ownership exceeds 100%).
+                    </div>
+                  </div>
+                )
+              }
               return (
                 <ScenarioCard
                   key={cid}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import './App.css'
 import CompanyTabs from './components/CompanyTabs'
 import InputForm from './components/InputForm'
@@ -14,6 +14,7 @@ import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
 import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink'
 import { updateSocialSharingMeta } from './utils/socialSharing'
 import { createDefaultCompany, nextUniqueName, normalizeStoredCompanies } from './utils/dataStructures'
+import { createExampleScenario, createExampleCompareVariant, EXAMPLE_PRIMARY_NAME, EXAMPLE_VARIANT_NAME } from './utils/exampleScenario'
 import { buildWalkthroughSteps, TOUR_SEEN_KEY } from './utils/walkthroughSteps'
 
 function getFirstCompanyId(companies) {
@@ -30,7 +31,7 @@ function getNextCompanyNumber(companies) {
 
 function App() {
   const [storedCompanies, setStoredCompanies] = useLocalStorage('valuationFramework', {
-    company1: createDefaultCompany('Startup Alpha')
+    company1: createDefaultCompany('Scenario 1')
   })
   const companies = useMemo(() => normalizeStoredCompanies(storedCompanies), [storedCompanies])
   const [activeCompany, setActiveCompany] = useState(() => getFirstCompanyId(companies))
@@ -65,15 +66,54 @@ function App() {
 
   const addCompany = () => {
     const newCompanyId = `company${nextCompanyId}`
-    const companyName = nextCompanyId <= 26
-      ? `Startup ${String.fromCharCode(64 + nextCompanyId)}`
-      : `Startup ${nextCompanyId}`
+    const companyName = `Scenario ${nextCompanyId}`
     const newCompany = createDefaultCompany(companyName)
 
     setStoredCompanies(prev => ({ ...normalizeStoredCompanies(prev), [newCompanyId]: newCompany }))
     setActiveCompany(newCompanyId)
     setNextCompanyId(prev => prev + 1)
   }
+
+  const ensureExample = useCallback(() => {
+    const existing = Object.entries(companies).find(([, c]) => c?.name === EXAMPLE_PRIMARY_NAME)
+    if (existing) {
+      setActiveCompany(existing[0])
+      return existing[0]
+    }
+    const newCompanyId = `company${nextCompanyId}`
+    const exampleScenario = createExampleScenario(EXAMPLE_PRIMARY_NAME)
+    setStoredCompanies(prev => ({ ...normalizeStoredCompanies(prev), [newCompanyId]: exampleScenario }))
+    setActiveCompany(newCompanyId)
+    setNextCompanyId(prev => prev + 1)
+    return newCompanyId
+  }, [companies, nextCompanyId, setStoredCompanies])
+
+  const loadExample = useCallback(() => {
+    ensureExample()
+  }, [ensureExample])
+
+  const ensureCompareDemo = useCallback(() => {
+    let primaryId = Object.entries(companies).find(([, c]) => c?.name === EXAMPLE_PRIMARY_NAME)?.[0]
+    let variantId = Object.entries(companies).find(([, c]) => c?.name === EXAMPLE_VARIANT_NAME)?.[0]
+
+    let nextId = nextCompanyId
+    const updates = {}
+    if (!primaryId) {
+      primaryId = `company${nextId++}`
+      updates[primaryId] = createExampleScenario(EXAMPLE_PRIMARY_NAME)
+    }
+    if (!variantId) {
+      variantId = `company${nextId++}`
+      updates[variantId] = createExampleCompareVariant(EXAMPLE_VARIANT_NAME)
+    }
+
+    if (Object.keys(updates).length > 0) {
+      setStoredCompanies(prev => ({ ...normalizeStoredCompanies(prev), ...updates }))
+      setNextCompanyId(nextId)
+    }
+
+    setSelectedCompanyIds([primaryId, variantId])
+  }, [companies, nextCompanyId, setStoredCompanies, setSelectedCompanyIds])
 
   const duplicateCompany = (companyId) => {
     const source = companies[companyId]
@@ -124,7 +164,7 @@ function App() {
     const companyIds = Object.keys(companies || {})
 
     if (companyIds.length === 0) {
-      const fallback = { company1: createDefaultCompany('Startup Alpha') }
+      const fallback = { company1: createDefaultCompany('Scenario 1') }
       setStoredCompanies(fallback)
       setActiveCompany('company1')
       setNextCompanyId(2)
@@ -152,13 +192,20 @@ function App() {
     }
   }, [hasLoadedFromURL, activeCompany, showInfo, updateCompany])
 
+  // Stable refs so the auto-launch effect runs once without re-firing when companies change
+  const ensureExampleRef = useRef(ensureExample)
+  ensureExampleRef.current = ensureExample
+
   // Auto-launch the tour on first visit
   useEffect(() => {
     try {
       const seen = window.localStorage.getItem(TOUR_SEEN_KEY)
       if (!seen) {
         // Slight delay so initial layout settles before measuring targets
-        const id = setTimeout(() => setTourActive(true), 350)
+        const id = setTimeout(() => {
+          ensureExampleRef.current()
+          setTourActive(true)
+        }, 350)
         return () => clearTimeout(id)
       }
     } catch {
@@ -171,12 +218,16 @@ function App() {
     try { window.localStorage.setItem(TOUR_SEEN_KEY, '1') } catch { /* ignore */ }
   }, [])
 
-  const startTour = useCallback(() => setTourActive(true), [])
+  const startTour = useCallback(() => {
+    ensureExample()
+    setTourActive(true)
+  }, [ensureExample])
 
   const tourSteps = useMemo(() => buildWalkthroughSteps({
     openAdvanced: (val) => updateCompany(activeCompany, { showAdvanced: val }),
-    openExitMath: (val) => updateCompany(activeCompany, { showExitMath: val })
-  }), [activeCompany, updateCompany])
+    openExitMath: (val) => updateCompany(activeCompany, { showExitMath: val }),
+    enterCompare: () => ensureCompareDemo()
+  }), [activeCompany, updateCompany, ensureCompareDemo])
 
 
   useEffect(() => {
@@ -272,6 +323,7 @@ function App() {
           onRemoveCompany={removeCompany}
           onUpdateCompany={updateCompany}
           onDuplicateCompany={duplicateCompany}
+          onLoadExample={loadExample}
           selectedCompanyIds={selectedCompanyIds}
           onToggleCompareSelection={toggleCompareSelection}
         />
@@ -282,7 +334,10 @@ function App() {
             onUpdate={(data) => updateCompany(activeCompany, data)}
           />
 
-          <div className={`base-result${isCompareMode ? ' base-result-compare' : ''}`}>
+          <div
+            className={`base-result${isCompareMode ? ' base-result-compare' : ''}`}
+            data-tour={isCompareMode ? 'compare-view' : undefined}
+          >
             {cardIds.map((cid, idx) => {
               const base = baseScenariosById[cid]
               if (!base) return null

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -23,7 +23,7 @@ describe('App Component - Local Storage Integration', () => {
       render(<App />)
       
       // Verify default company exists by checking the tab name
-      expect(screen.getByText('Startup Alpha')).toBeInTheDocument()
+      expect(screen.getByText('Scenario 1')).toBeInTheDocument()
       
       // The app should be functional with default data
       expect(screen.getByText('Investment Parameters')).toBeInTheDocument()
@@ -65,7 +65,7 @@ describe('App Component - Local Storage Integration', () => {
       render(<App />)
       
       // Should render with default data despite corruption
-      expect(screen.getByText('Startup Alpha')).toBeInTheDocument()
+      expect(screen.getByText('Scenario 1')).toBeInTheDocument()
       expect(console.error).toHaveBeenCalled()
     })
 
@@ -98,7 +98,7 @@ describe('App Component - Local Storage Integration', () => {
       })
       
       // App should still render and be functional
-      expect(screen.getByText('Startup Alpha')).toBeInTheDocument()
+      expect(screen.getByText('Scenario 1')).toBeInTheDocument()
       expect(screen.getByText('Investment Parameters')).toBeInTheDocument()
       
       // Restore original method

--- a/react-app/src/App.multicompany.test.jsx
+++ b/react-app/src/App.multicompany.test.jsx
@@ -101,7 +101,7 @@ describe('App multi-company state', () => {
     const stored = JSON.parse(window.localStorage.getItem('valuationFramework'))
     expect(Object.keys(stored).sort()).toEqual(['company2', 'company3'])
     expect(stored.company2.name).toBe('Persisted Beta')
-    expect(stored.company3.name).toBe('Startup C')
+    expect(stored.company3.name).toBe('Scenario 3')
   })
 
   it('hides non-base scenarios while compare mode is active', async () => {

--- a/react-app/src/components/CompanyTabs-dup-compare.test.jsx
+++ b/react-app/src/components/CompanyTabs-dup-compare.test.jsx
@@ -35,7 +35,7 @@ describe('CompanyTabs duplicate + compare', () => {
 
   it('renders duplicate button and calls onDuplicateCompany on click', () => {
     render(<CompanyTabs {...props} />)
-    const btns = screen.getAllByRole('button', { name: /duplicate company/i })
+    const btns = screen.getAllByRole('button', { name: /duplicate scenario/i })
     expect(btns).toHaveLength(2)
     fireEvent.click(btns[0])
     expect(props.onDuplicateCompany).toHaveBeenCalledWith('c1')
@@ -43,7 +43,7 @@ describe('CompanyTabs duplicate + compare', () => {
 
   it('duplicate click does not change active tab (stopPropagation)', () => {
     render(<CompanyTabs {...props} />)
-    const btns = screen.getAllByRole('button', { name: /duplicate company/i })
+    const btns = screen.getAllByRole('button', { name: /duplicate scenario/i })
     fireEvent.click(btns[1])
     expect(props.onCompanyChange).not.toHaveBeenCalled()
     expect(props.onDuplicateCompany).toHaveBeenCalledWith('c2')

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -100,7 +100,7 @@ const CompanyTabs = ({
                   />
                 ) : (
                   <>
-                    <span className="tab-name">{company.name}</span>
+                    <span className="tab-name" title={company.name}>{company.name}</span>
                     <div className="tab-actions">
                       <button
                         className="tab-edit-btn"

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -8,6 +8,7 @@ const CompanyTabs = ({
   onRemoveCompany,
   onUpdateCompany,
   onDuplicateCompany,
+  onLoadExample,
   selectedCompanyIds = [],
   onToggleCompareSelection,
 }) => {
@@ -118,8 +119,8 @@ const CompanyTabs = ({
                             e.stopPropagation()
                             onDuplicateCompany(companyId)
                           }}
-                          title="Duplicate company"
-                          aria-label="Duplicate company"
+                          title="Duplicate scenario"
+                          aria-label="Duplicate scenario"
                         >
                           ⧉
                         </button>
@@ -134,7 +135,7 @@ const CompanyTabs = ({
                               onRemoveCompany(companyId)
                             }
                           }}
-                          title="Remove company"
+                          title="Delete scenario"
                         >
                           ×
                         </button>
@@ -149,11 +150,24 @@ const CompanyTabs = ({
           </div>
         </div>
 
-        <button className="add-company-btn" onClick={onAddCompany} title="Add new company">
-          <span className="add-icon">+</span>
-          <span className="add-text">Add Company</span>
-          <div className="btn-glow" />
-        </button>
+        <div className="tabs-actions">
+          {onLoadExample && (
+            <button
+              type="button"
+              className="load-example-btn"
+              onClick={onLoadExample}
+              title="Load a populated example scenario that exercises every feature"
+            >
+              <span className="load-example-icon" aria-hidden="true">★</span>
+              <span className="load-example-text">Load Example</span>
+            </button>
+          )}
+          <button className="add-company-btn" onClick={onAddCompany} title="Add new scenario">
+            <span className="add-icon">+</span>
+            <span className="add-text">Add Scenario</span>
+            <div className="btn-glow" />
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -63,7 +63,7 @@ const CompanyTabs = ({
   }
 
   return (
-    <div className="company-tabs">
+    <div className="company-tabs" data-tour="company-tabs">
       <div className="tabs-container">
         <div className="tabs-scroll" ref={tabsScrollRef}>
           <div className="tabs-list">

--- a/react-app/src/components/FoundersSection.jsx
+++ b/react-app/src/components/FoundersSection.jsx
@@ -50,7 +50,7 @@ function FoundersSection({ founders = [], onUpdate }) {
 
       {founders.length === 0 ? (
         <div className="no-founders-message">
-          No founders added. Click "Add Founder" to add founding team members.
+          No founders yet. Add the founding team to track each person’s dilution through the round.
         </div>
       ) : (
         <div className="repeater-table repeater-table--founders">

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -668,7 +668,7 @@ const InputForm = ({ company, onUpdate }) => {
             )}
           </div>
 
-          <div className="safes-section">
+          <div className="safes-section" data-tour="safes-section">
             <div className="section-title-row">
               <h5 className="section-label">SAFE Notes</h5>
               <div className="section-header-actions">

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -308,16 +308,22 @@ const InputForm = ({ company, onUpdate }) => {
         <h3>Investment Parameters</h3>
         <div className="header-controls">
           <div className="investor-name-input">
-            <label htmlFor="investor-name">Your firm:</label>
+            <label htmlFor="investor-name" title="Your firm's name. Used as a label throughout the model.">Your firm:</label>
             <input
               id="investor-name"
               type="text"
               value={values.investorName || 'US'}
               onChange={(e) => handleChange('investorName', e.target.value)}
               placeholder="e.g. LSVP"
+              title="Your firm's name. Used as a label throughout the model."
             />
           </div>
-          <div className="calculated-money-toggle" onClick={handleToggleInputMode}>
+          <div
+            className="calculated-money-toggle"
+            data-tour="money-toggle"
+            onClick={handleToggleInputMode}
+            title="Click to switch between entering post-money or pre-money valuation. The other side is computed."
+          >
             {inputMode === 'post-money' ? (
               <>Pre-Money: <span className="value">${safePreMoneyVal.toFixed(1)}M</span></>
             ) : (
@@ -328,7 +334,7 @@ const InputForm = ({ company, onUpdate }) => {
         </div>
       </div>
 
-      <div className="input-grid">
+      <div className="input-grid" data-tour="core-inputs">
         <FormInput
           label={inputMode === 'post-money' ? 'Post-Money Valuation' : 'Pre-Money Valuation'}
           type="number"
@@ -365,6 +371,7 @@ const InputForm = ({ company, onUpdate }) => {
 
         <FormInput
           label="Other Portion"
+          tooltip="Everything in the round that isn't your firm's check — co-investors and pro-rata participants."
           type="number"
           value={values.otherPortion}
           onChange={(value) => handleChange('otherPortion', value)}
@@ -378,9 +385,10 @@ const InputForm = ({ company, onUpdate }) => {
 
       {/* Advanced Features Toggle */}
       <div className="advanced-toggle">
-        <button 
+        <button
           type="button"
           className="toggle-advanced-btn"
+          data-tour="advanced-toggle"
           onClick={() => handleChange('showAdvanced', !values.showAdvanced)}
         >
           {values.showAdvanced ? '▼' : '▶'} Advanced Features
@@ -580,7 +588,7 @@ const InputForm = ({ company, onUpdate }) => {
 
             {(!values.warrants || values.warrants.length === 0) ? (
               <div className="no-safes-message">
-                No warrants added. Click &quot;Add Warrant&quot; to get started.
+                No warrants. Add to model warrant coverage from venture debt or strategic agreements.
               </div>
             ) : (
               <div className="repeater-table repeater-table--warrants">
@@ -677,7 +685,7 @@ const InputForm = ({ company, onUpdate }) => {
 
             {(!values.safes || values.safes.length === 0) ? (
               <div className="no-safes-message">
-                No SAFE notes added. Click "Add SAFE" to get started.
+                No SAFE notes. Add convertibles to see how they convert into this round at their cap or discount.
               </div>
             ) : (
               <div className="repeater-table repeater-table--safes">

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -82,7 +82,7 @@ function PriorInvestorsSection({
   const allRows = [...priorRows, ...safeRows, ...leadRows].sort((a, b) => b.fdoPct - a.fdoPct)
 
   return (
-    <div className="prior-investors-section">
+    <div className="prior-investors-section" data-tour="prior-investors">
       <div className="founders-investors-header">
         <div className="section-title-row">
           <h5 className="section-label" title="Fully-Diluted Ownership — % of company assuming all SAFEs, warrants, and granted options have converted/vested.">

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -85,7 +85,9 @@ function PriorInvestorsSection({
     <div className="prior-investors-section">
       <div className="founders-investors-header">
         <div className="section-title-row">
-          <h5 className="section-label">Investors — sorted by FDO</h5>
+          <h5 className="section-label" title="Fully-Diluted Ownership — % of company assuming all SAFEs, warrants, and granted options have converted/vested.">
+            Investors — sorted by Fully-Diluted Ownership (FDO)
+          </h5>
           <div className="section-header-actions">
             {totalOwnership > 0 && (
               <span className="section-total-pill">
@@ -105,14 +107,20 @@ function PriorInvestorsSection({
 
       {allRows.length === 0 ? (
         <div className="no-investors-message">
-          No investors yet. Click "Add Investor" to include prior round participants.
+          No prior investors yet. Add existing cap-table holders to model their dilution and pro-rata participation in this round.
         </div>
       ) : (
         <div className="repeater-table repeater-table--investors">
           <div className="repeater-header">
             <span className="repeater-col repeater-col--name">Name</span>
-            <span className="repeater-col repeater-col--pct">FDO</span>
-            <span className="repeater-col repeater-col--prorata">Pro-rata</span>
+            <span
+              className="repeater-col repeater-col--pct"
+              title="Fully-Diluted Ownership — % of company assuming all SAFEs, warrants, and granted options have converted/vested."
+            >FDO</span>
+            <span
+              className="repeater-col repeater-col--prorata"
+              title="Pro-rata: right to invest in this round in proportion to existing ownership, preserving stake."
+            >Pro-rata</span>
             <span className="repeater-col repeater-col--alloc">Allocation</span>
             <span className="repeater-col repeater-col--actions" aria-hidden="true" />
           </div>

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -212,7 +212,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   const deltaClass = (d) => d === null ? '' : d > 0.05 ? 'delta-up' : d < -0.05 ? 'delta-down' : 'delta-flat'
 
   return (
-    <div className={getCardClass()}>
+    <div className={getCardClass()} data-tour={isBase ? 'base-card' : undefined}>
       <div className="scenario-header">
         {isBase ? (
           <h3 className="scenario-title">{baseTitle}</h3>
@@ -715,6 +715,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
           <div className="share-buttons">
             <button
               className="permalink-btn-inline"
+              data-tour="permalink-btn"
               onClick={handleCopyPermalink}
               title="Share permalink for this scenario"
               disabled={!!copyFeedback}

--- a/react-app/src/components/ScenarioControls.jsx
+++ b/react-app/src/components/ScenarioControls.jsx
@@ -43,8 +43,8 @@ const ScenarioControls = ({ offsets = [], onChange }) => {
   }
 
   return (
-    <div className="scenario-controls" role="group" aria-label="Sensitivity scenarios">
-      <span className="scenario-controls-label">Sensitivity</span>
+    <div className="scenario-controls" data-tour="scenario-controls" role="group" aria-label="Sensitivity scenarios">
+      <span className="scenario-controls-label" title="Adds offset scenario cards (e.g. ±10%, ±20%) so partners can see how the cap table flexes at different valuations">Sensitivity</span>
       <div className="scenario-pills">
         {currentBand.map(n => {
           const direction = n < 0 ? 'down' : 'up'

--- a/react-app/src/components/Walkthrough.jsx
+++ b/react-app/src/components/Walkthrough.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
+
+const SPOTLIGHT_PADDING = 8
+const TOOLTIP_MARGIN = 16
+const TOOLTIP_WIDTH = 360
+
+// Geometry helper: where to render the tooltip relative to the target rect.
+function computeTooltipPosition(rect, placement, viewport) {
+  if (!rect || placement === 'center') {
+    return {
+      left: Math.max(16, viewport.width / 2 - TOOLTIP_WIDTH / 2),
+      top: Math.max(16, viewport.height / 2 - 120),
+      arrow: null
+    }
+  }
+
+  const space = {
+    top: rect.top,
+    bottom: viewport.height - rect.bottom,
+    left: rect.left,
+    right: viewport.width - rect.right
+  }
+
+  let resolved = placement
+  if (placement === 'auto') {
+    resolved = space.bottom > 220 ? 'bottom'
+      : space.top > 220 ? 'top'
+      : space.right > TOOLTIP_WIDTH + 40 ? 'right'
+      : 'left'
+  }
+
+  let left, top, arrow
+  switch (resolved) {
+    case 'top':
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      top = rect.top - TOOLTIP_MARGIN - 8
+      arrow = 'bottom'
+      // Tooltip's bottom edge sits at this `top`; push up so it doesn't overflow above
+      top = Math.max(16, top - 200)
+      break
+    case 'bottom':
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2
+      top = rect.bottom + TOOLTIP_MARGIN
+      arrow = 'top'
+      break
+    case 'left':
+      left = rect.left - TOOLTIP_WIDTH - TOOLTIP_MARGIN
+      top = rect.top + rect.height / 2 - 100
+      arrow = 'right'
+      break
+    case 'right':
+    default:
+      left = rect.right + TOOLTIP_MARGIN
+      top = rect.top + rect.height / 2 - 100
+      arrow = 'left'
+      break
+  }
+
+  // Clamp inside viewport
+  left = Math.min(Math.max(16, left), viewport.width - TOOLTIP_WIDTH - 16)
+  top = Math.min(Math.max(16, top), viewport.height - 240)
+
+  return { left, top, arrow }
+}
+
+function Walkthrough({ open, steps, onClose, onComplete }) {
+  const [stepIndex, setStepIndex] = useState(0)
+  const [targetRect, setTargetRect] = useState(null)
+  const [viewport, setViewport] = useState({ width: window.innerWidth, height: window.innerHeight })
+  const enteredStepRef = useRef(-1)
+  const measureTimeoutRef = useRef(null)
+
+  const currentStep = steps[stepIndex]
+  const total = steps.length
+
+  // Reset when reopened
+  useEffect(() => {
+    if (open) {
+      setStepIndex(0)
+      enteredStepRef.current = -1
+    }
+  }, [open])
+
+  // Track viewport size
+  useEffect(() => {
+    if (!open) return
+    const onResize = () => setViewport({ width: window.innerWidth, height: window.innerHeight })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [open])
+
+  // Measure target — repeatable so resize/scroll/auto-open all refresh geometry
+  const measureTarget = useCallback(() => {
+    if (!open || !currentStep) return
+    if (!currentStep.target) {
+      setTargetRect(null)
+      return
+    }
+    const el = document.querySelector(currentStep.target)
+    if (!el) {
+      setTargetRect(null)
+      return
+    }
+    // Scroll target into view if it's fully off-screen
+    const rect = el.getBoundingClientRect()
+    if (rect.bottom < 0 || rect.top > window.innerHeight) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+    setTargetRect({
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+      bottom: rect.bottom,
+      right: rect.right
+    })
+  }, [open, currentStep])
+
+  // Run onEnter side effects (e.g. open Advanced / Exit Math) once per step, then measure
+  useLayoutEffect(() => {
+    if (!open || !currentStep) return
+    if (enteredStepRef.current === stepIndex) {
+      measureTarget()
+      return
+    }
+    enteredStepRef.current = stepIndex
+    if (typeof currentStep.onEnter === 'function') {
+      currentStep.onEnter()
+    }
+
+    if (currentStep.waitForTarget) {
+      // Retry measurement a few times so the just-toggled panel has time to render
+      const attempts = [0, 60, 160, 320]
+      attempts.forEach((delay) => {
+        const id = setTimeout(measureTarget, delay)
+        measureTimeoutRef.current = id
+      })
+    } else {
+      measureTarget()
+    }
+  }, [open, stepIndex, currentStep, measureTarget])
+
+  // Re-measure on resize / scroll
+  useEffect(() => {
+    if (!open) return
+    const onScroll = () => measureTarget()
+    const onResize = () => measureTarget()
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [open, measureTarget])
+
+  // ESC closes
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose && onClose()
+      else if (e.key === 'ArrowRight') goNext()
+      else if (e.key === 'ArrowLeft') goPrev()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, stepIndex])
+
+  const goNext = () => {
+    if (stepIndex >= total - 1) {
+      onComplete && onComplete()
+    } else {
+      setStepIndex((i) => Math.min(total - 1, i + 1))
+    }
+  }
+  const goPrev = () => setStepIndex((i) => Math.max(0, i - 1))
+  const handleSkip = () => onClose && onClose()
+
+  if (!open || !currentStep) return null
+
+  const placement = currentStep.placement || 'auto'
+  // If no rect (target missing or center step), use centered fallback
+  const useCenter = !targetRect || placement === 'center'
+  const tooltip = computeTooltipPosition(useCenter ? null : targetRect, placement, viewport)
+
+  // Spotlight: dim everything except the target rect.
+  // Implementation: four absolutely-positioned dark rectangles around the cutout.
+  let spotlight = null
+  if (!useCenter && targetRect) {
+    const padded = {
+      top: Math.max(0, targetRect.top - SPOTLIGHT_PADDING),
+      left: Math.max(0, targetRect.left - SPOTLIGHT_PADDING),
+      width: targetRect.width + SPOTLIGHT_PADDING * 2,
+      height: targetRect.height + SPOTLIGHT_PADDING * 2
+    }
+    const right = padded.left + padded.width
+    const bottom = padded.top + padded.height
+    spotlight = (
+      <>
+        <div className="walkthrough-mask" style={{ top: 0, left: 0, width: '100vw', height: padded.top }} />
+        <div className="walkthrough-mask" style={{ top: bottom, left: 0, width: '100vw', height: `calc(100vh - ${bottom}px)` }} />
+        <div className="walkthrough-mask" style={{ top: padded.top, left: 0, width: padded.left, height: padded.height }} />
+        <div className="walkthrough-mask" style={{ top: padded.top, left: right, width: `calc(100vw - ${right}px)`, height: padded.height }} />
+        <div
+          className="walkthrough-spotlight-ring"
+          style={{
+            top: padded.top,
+            left: padded.left,
+            width: padded.width,
+            height: padded.height
+          }}
+        />
+      </>
+    )
+  } else {
+    // Centered card — full-screen dim
+    spotlight = <div className="walkthrough-mask walkthrough-mask-full" />
+  }
+
+  const isFirst = stepIndex === 0
+  const isLast = stepIndex === total - 1
+
+  return (
+    <div className="walkthrough" role="dialog" aria-modal="true" aria-label={currentStep.title}>
+      {spotlight}
+      <div
+        className={`walkthrough-tooltip walkthrough-tooltip--${tooltip.arrow || 'center'}`}
+        style={{ left: tooltip.left, top: tooltip.top, width: TOOLTIP_WIDTH }}
+      >
+        <div className="walkthrough-step-counter">Step {stepIndex + 1} of {total}</div>
+        <h4 className="walkthrough-title">{currentStep.title}</h4>
+        <p className="walkthrough-body">{currentStep.body}</p>
+        <div className="walkthrough-actions">
+          <button type="button" className="walkthrough-btn walkthrough-btn-skip" onClick={handleSkip}>
+            Skip
+          </button>
+          <div className="walkthrough-nav">
+            {!isFirst && (
+              <button type="button" className="walkthrough-btn walkthrough-btn-secondary" onClick={goPrev}>
+                Back
+              </button>
+            )}
+            <button type="button" className="walkthrough-btn walkthrough-btn-primary" onClick={goNext}>
+              {isLast ? 'Done' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Walkthrough

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -422,7 +422,7 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   return migrated
 }
 
-export function normalizeStoredCompanies(storedCompanies, fallbackName = 'Startup Alpha') {
+export function normalizeStoredCompanies(storedCompanies, fallbackName = 'Scenario 1') {
   const fallback = { company1: createDefaultCompany(fallbackName) }
 
   if (looksLikeSingleStoredCompany(storedCompanies)) {
@@ -446,7 +446,7 @@ export function normalizeStoredCompanies(storedCompanies, fallbackName = 'Startu
   }
 
   return entries.reduce((acc, [companyId, company], index) => {
-    const defaultName = index === 0 ? fallbackName : `Startup ${index + 1}`
+    const defaultName = index === 0 ? fallbackName : `Scenario ${index + 1}`
     acc[companyId] = migrateLegacyCompany(company, company?.name || defaultName)
     return acc
   }, {})

--- a/react-app/src/utils/exampleScenario.js
+++ b/react-app/src/utils/exampleScenario.js
@@ -1,0 +1,101 @@
+import {
+  createPriorInvestor,
+  createFounder,
+  createWarrant
+} from './dataStructures'
+import { buildScenarioOffsets } from './scenarioOffsets'
+
+const safeId = (suffix) => `safe-${Date.now()}-${suffix}-${Math.random().toString(36).slice(2, 8)}`
+
+// A rich, presentation-ready Series B scenario that exercises almost every
+// feature the app supports: prior investors with pro-rata, multiple founders,
+// SAFE notes (capped + uncapped), an ESOP top-up, a venture-debt warrant, and
+// scenario-sensitivity offsets. Pre-round ownership is tuned to ~92% so a
+// small "Unknown/Other" remainder appears (a useful teaching moment).
+export function createExampleScenario(name = 'Example: Series B') {
+  return {
+    name,
+    postMoneyVal: 80,
+    roundSize: 20,
+    investorPortion: 14,
+    otherPortion: 6,
+    investorName: 'LSVP',
+    showAdvanced: true,
+    percentPrecision: 2,
+
+    twoStepEnabled: false,
+    step2PostMoney: 0,
+    step2Amount: 0,
+    step2InvestorPortion: 0,
+    step2OtherPortion: 0,
+
+    showExitMath: false,
+    exitMath: {
+      exitValuations: [200, 500, 1000, 2500, 5000],
+      numRounds: 3,
+      uniformDilution: 20,
+      perRoundOverrides: []
+    },
+
+    priorInvestors: [
+      createPriorInvestor('Seed Lead', 18, true),
+      createPriorInvestor('Pre-seed Angel', 4, false),
+      createPriorInvestor('Strategic Angel', 2.5, false)
+    ],
+    founders: [
+      createFounder('CEO', 28),
+      createFounder('CTO', 22),
+      createFounder('VP Engineering', 8)
+    ],
+
+    safes: [
+      {
+        id: safeId('bridge'),
+        investorName: 'Bridge Round',
+        amount: 2,
+        cap: 40,
+        discount: 20,
+        proRata: true,
+        proRataOverride: null
+      },
+      {
+        id: safeId('accel'),
+        investorName: 'Accelerator',
+        amount: 0.5,
+        cap: 25,
+        discount: 0,
+        proRata: false,
+        proRataOverride: null
+      }
+    ],
+
+    currentEsopPercent: 8,
+    grantedEsopPercent: 5,
+    targetEsopPercent: 12,
+    esopTiming: 'pre-close',
+
+    warrants: [
+      createWarrant('Venture Debt', 1, 50)
+    ],
+
+    scenarioOffsets: buildScenarioOffsets(20),
+
+    // Legacy fields kept for migration compatibility
+    proRataPercent: 0,
+    preRoundFounderOwnership: 0
+  }
+}
+
+// A second variant for compare-mode demos: same cap table at a 20% higher post-money.
+export function createExampleCompareVariant(name = 'Example: stretched valuation') {
+  const base = createExampleScenario(name)
+  return {
+    ...base,
+    postMoneyVal: 96,
+    investorPortion: 16,
+    otherPortion: 4
+  }
+}
+
+export const EXAMPLE_PRIMARY_NAME = 'Example: Series B'
+export const EXAMPLE_VARIANT_NAME = 'Example: stretched valuation'

--- a/react-app/src/utils/walkthroughSteps.js
+++ b/react-app/src/utils/walkthroughSteps.js
@@ -5,24 +5,25 @@
 //   title        — short title shown in tooltip
 //   body         — one or two sentences of explanation
 //   placement    — 'auto' | 'top' | 'bottom' | 'left' | 'right' | 'center'
-//   onEnter      — optional fn(ctx) called when the step becomes active. Use to open
-//                  panels (Advanced, Exit Math) so the next step's target is rendered.
-//   waitForTarget— if true, the tour briefly retries finding the target after onEnter
-//                  (lets a panel open + render before measuring).
+//   onEnter      — optional fn called when the step becomes active. Use to open
+//                  panels (Advanced, Exit Math, compare mode) so the next step's
+//                  target is rendered.
+//   waitForTarget— if true, the tour briefly retries finding the target after
+//                  onEnter (lets a panel open + render before measuring).
 
-export const buildWalkthroughSteps = ({ openAdvanced, openExitMath } = {}) => [
+export const buildWalkthroughSteps = ({ openAdvanced, openExitMath, enterCompare } = {}) => [
   {
     id: 'welcome',
     target: null,
     title: 'Welcome',
-    body: 'This tool models cap tables, dilution, and exits when offering a term sheet. Quick 60-second tour.',
+    body: 'This tool models cap tables, dilution, and exits when offering a term sheet. We loaded a populated example so you can see every feature in action — your other scenarios are untouched.',
     placement: 'center'
   },
   {
     id: 'company-tabs',
     target: '[data-tour="company-tabs"]',
-    title: 'One tab per deal',
-    body: 'Each tab is a separate company. Tick the checkboxes to compare two or more side-by-side.',
+    title: 'One tab per scenario',
+    body: 'Each tab is a separate scenario — different company, different round structure, or just a what-if. Use the checkboxes to compare two or more side-by-side.',
     placement: 'bottom'
   },
   {
@@ -56,11 +57,41 @@ export const buildWalkthroughSteps = ({ openAdvanced, openExitMath } = {}) => [
     waitForTarget: true
   },
   {
+    id: 'prior-investors',
+    target: '[data-tour="prior-investors"]',
+    title: 'Prior investors with pro-rata',
+    body: 'Existing holders are sorted by Fully-Diluted Ownership (FDO). Tick pro-rata to let them buy in proportional to their stake, or override the allocation in $M directly.',
+    placement: 'right',
+    onEnter: () => openAdvanced && openAdvanced(true),
+    waitForTarget: true,
+    allowCenterFallback: true
+  },
+  {
+    id: 'safes',
+    target: '[data-tour="safes-section"]',
+    title: 'SAFEs convert at this round',
+    body: 'Add SAFE notes with cap and discount — they convert into the round at whichever is more favorable to the holder. Pro-rata works here too.',
+    placement: 'right',
+    onEnter: () => openAdvanced && openAdvanced(true),
+    waitForTarget: true,
+    allowCenterFallback: true
+  },
+  {
     id: 'scenario-controls',
     target: '[data-tour="scenario-controls"]',
     title: 'Sensitivity analysis',
     body: 'Add valuation offsets here — see how the cap table flexes at +20% or −10%. Color-coded by direction and magnitude.',
     placement: 'top',
+    allowCenterFallback: true
+  },
+  {
+    id: 'compare-mode',
+    target: '[data-tour="compare-view"]',
+    title: 'Compare scenarios side-by-side',
+    body: 'We just ticked two example scenarios so the cap tables render side-by-side. In your own data, tick any two tabs to compare them.',
+    placement: 'top',
+    onEnter: () => enterCompare && enterCompare(),
+    waitForTarget: true,
     allowCenterFallback: true
   },
   {

--- a/react-app/src/utils/walkthroughSteps.js
+++ b/react-app/src/utils/walkthroughSteps.js
@@ -1,0 +1,84 @@
+// Walkthrough steps for the guided tour.
+// Each step:
+//   id           — stable id for testing/debug
+//   target       — CSS selector for the spotlight; null = centered card with no spotlight
+//   title        — short title shown in tooltip
+//   body         — one or two sentences of explanation
+//   placement    — 'auto' | 'top' | 'bottom' | 'left' | 'right' | 'center'
+//   onEnter      — optional fn(ctx) called when the step becomes active. Use to open
+//                  panels (Advanced, Exit Math) so the next step's target is rendered.
+//   waitForTarget— if true, the tour briefly retries finding the target after onEnter
+//                  (lets a panel open + render before measuring).
+
+export const buildWalkthroughSteps = ({ openAdvanced, openExitMath } = {}) => [
+  {
+    id: 'welcome',
+    target: null,
+    title: 'Welcome',
+    body: 'This tool models cap tables, dilution, and exits when offering a term sheet. Quick 60-second tour.',
+    placement: 'center'
+  },
+  {
+    id: 'company-tabs',
+    target: '[data-tour="company-tabs"]',
+    title: 'One tab per deal',
+    body: 'Each tab is a separate company. Tick the checkboxes to compare two or more side-by-side.',
+    placement: 'bottom'
+  },
+  {
+    id: 'core-inputs',
+    target: '[data-tour="core-inputs"]',
+    title: 'The four inputs that drive everything',
+    body: 'Post-money valuation, round size, your firm’s portion, and the rest of the round. Every output updates live.',
+    placement: 'right'
+  },
+  {
+    id: 'money-toggle',
+    target: '[data-tour="money-toggle"]',
+    title: 'Pre-money or post-money — your call',
+    body: 'Click to flip between entering post-money (with computed pre-money) or vice versa. Same math either way.',
+    placement: 'bottom'
+  },
+  {
+    id: 'base-card',
+    target: '[data-tour="base-card"]',
+    title: 'The post-round cap table',
+    body: 'Your scenario, fully diluted. Click any section header to expand: new round, founders, prior investors, ESOP, SAFEs, warrants. Everything sums to 100%.',
+    placement: 'left'
+  },
+  {
+    id: 'advanced-toggle',
+    target: '[data-tour="advanced-toggle"]',
+    title: 'Model the messy stuff',
+    body: 'Open Advanced to add prior investors with pro-rata rights, SAFE conversions, ESOP top-ups, warrants, and 2-step rounds.',
+    placement: 'right',
+    onEnter: () => openAdvanced && openAdvanced(true),
+    waitForTarget: true
+  },
+  {
+    id: 'scenario-controls',
+    target: '[data-tour="scenario-controls"]',
+    title: 'Sensitivity analysis',
+    body: 'Add valuation offsets here — see how the cap table flexes at +20% or −10%. Color-coded by direction and magnitude.',
+    placement: 'top',
+    allowCenterFallback: true
+  },
+  {
+    id: 'exit-math',
+    target: '[data-tour="exit-math-toggle"]',
+    title: 'Project returns to exit',
+    body: 'Toggle Exit Math to project your ownership through future rounds of dilution and compute MOIC at various exit valuations.',
+    placement: 'bottom',
+    onEnter: () => openExitMath && openExitMath(true),
+    waitForTarget: true
+  },
+  {
+    id: 'permalink',
+    target: '[data-tour="permalink-btn"]',
+    title: 'Share without a database',
+    body: 'Hit the link icon to copy a permalink. The entire scenario is encoded in the URL — share with founders, LPs, or co-investors.',
+    placement: 'top'
+  }
+]
+
+export const TOUR_SEEN_KEY = 'valuationFrameworkTourSeen'


### PR DESCRIPTION
## Summary
- New 9-step **Walkthrough** component with spotlight + tooltip, replayable from a header **Tour** button. Auto-launches once on first visit. Steps 6 and 8 programmatically open Advanced Features and Exit Math so partners actually see them in context.
- First-impression polish for someone who has never seen the app: subtitle under the logo, FDO spelled out inline, tooltips on Other Portion / Your firm / pre-post toggle, and rewritten empty-state copy explaining *why* each section is useful.
- All 371 existing tests pass; calc engine and data shape untouched.

## Test plan
- [ ] Open in a fresh browser (or clear \`localStorage\`) — tour auto-launches with the welcome card
- [ ] Step through all 9 steps; confirm spotlights land on tabs / inputs / money toggle / base card / advanced toggle / sensitivity / Exit Math / permalink button
- [ ] Confirm step 6 auto-opens Advanced and step 8 auto-opens Exit Math
- [ ] Skip mid-tour, refresh — tour does not relaunch
- [ ] Click the header **Tour** button — tour replays
- [ ] Hover the FDO column header, Other Portion label, Your firm label, money toggle — tooltips appear
- [ ] With Advanced open and no founders/investors/SAFEs/warrants — confirm the new empty-state copy reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)