### PR TITLE
Make Investment Parameters panel collapsible

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -492,6 +492,97 @@ body {
   flex: 0 0 clamp(280px, 22vw, 380px);
 }
 
+/* Collapsed Inputs — narrows the input column to a thin rail and
+   reclaims the freed grid track for scenarios / Exit Math. */
+.top-row.inputs-collapsed {
+  grid-template-columns: 40px 1fr;
+}
+
+.top-row.inputs-collapsed.with-exit-math {
+  grid-template-columns: 40px 1fr 0.9fr;
+}
+
+.top-row.advanced-open.inputs-collapsed {
+  grid-template-columns: 40px 1fr;
+}
+
+.top-row.compare-mode.inputs-collapsed > .input-form {
+  flex: 0 0 40px;
+}
+
+.input-form.collapsed-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-3);
+  width: 40px;
+  min-height: 220px;
+  padding: var(--space-3) 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: box-shadow var(--transition-base), border-color var(--transition-base), background var(--transition-base);
+  font: inherit;
+  color: var(--color-fg-muted);
+}
+
+.input-form.collapsed-rail:hover,
+.input-form.collapsed-rail:focus-visible {
+  box-shadow: var(--shadow-md);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  outline: none;
+}
+
+.collapsed-rail-icon {
+  font-size: var(--text-sm);
+  line-height: 1;
+}
+
+.collapsed-rail-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.form-header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.input-form-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-subtle);
+  font-size: var(--text-xs);
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--transition-base), border-color var(--transition-base), background var(--transition-base);
+}
+
+.input-form-collapse-btn:hover,
+.input-form-collapse-btn:focus-visible {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  outline: none;
+}
+
 .base-result-compare {
   display: flex;
   flex-direction: row;
@@ -3152,10 +3243,26 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   }
 
   .top-row,
-  .top-row.with-exit-math {
+  .top-row.with-exit-math,
+  .top-row.inputs-collapsed,
+  .top-row.inputs-collapsed.with-exit-math,
+  .top-row.advanced-open.inputs-collapsed {
     grid-template-columns: 1fr;
     gap: 1.5rem;
     margin-bottom: 1.5rem;
+  }
+
+  .input-form.collapsed-rail {
+    flex-direction: row;
+    width: 100%;
+    min-height: 0;
+    padding: var(--space-3);
+    justify-content: center;
+  }
+
+  .input-form.collapsed-rail .collapsed-rail-label {
+    writing-mode: horizontal-tb;
+    transform: none;
   }
 
   .top-row.compare-mode {

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -328,10 +328,12 @@ function App() {
           onToggleCompareSelection={toggleCompareSelection}
         />
 
-        <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}${advancedOpen ? ' advanced-open' : ''}`}>
+        <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}${advancedOpen ? ' advanced-open' : ''}${companies[activeCompany]?.inputsCollapsed ? ' inputs-collapsed' : ''}`}>
           <InputForm
             company={companies[activeCompany]}
             onUpdate={(data) => updateCompany(activeCompany, data)}
+            collapsed={Boolean(companies[activeCompany]?.inputsCollapsed)}
+            onToggleCollapsed={() => updateCompany(activeCompany, { inputsCollapsed: !companies[activeCompany]?.inputsCollapsed })}
           />
 
           <div

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -4,7 +4,7 @@ import FoundersSection from './FoundersSection'
 import FormInput from './FormInput'
 import { migrateLegacyCompany } from '../utils/dataStructures'
 
-const InputForm = ({ company, onUpdate }) => {
+const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) => {
   const roundToCents = (value) => Math.round(Math.max(0, value) * 100) / 100
   const [values, setValues] = useState({
     postMoneyVal: 13,
@@ -302,10 +302,36 @@ const InputForm = ({ company, onUpdate }) => {
     onUpdate(newValues)
   }
 
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="input-form collapsed-rail"
+        onClick={onToggleCollapsed}
+        title="Show Investment Parameters"
+        aria-label="Show Investment Parameters"
+      >
+        <span className="collapsed-rail-icon" aria-hidden="true">▶</span>
+        <span className="collapsed-rail-label">Investment Parameters</span>
+      </button>
+    )
+  }
+
   return (
     <div className="input-form">
       <div className="form-header">
-        <h3>Investment Parameters</h3>
+        <div className="form-header-title">
+          <button
+            type="button"
+            className="input-form-collapse-btn"
+            onClick={onToggleCollapsed}
+            title="Hide Investment Parameters"
+            aria-label="Hide Investment Parameters"
+          >
+            ◀
+          </button>
+          <h3>Investment Parameters</h3>
+        </div>
         <div className="header-controls">
           <div className="investor-name-input">
             <label htmlFor="investor-name" title="Your firm's name. Used as a label throughout the model.">Your firm:</label>


### PR DESCRIPTION
## Summary
- Adds a per-company `inputsCollapsed` flag so users can hide the Investment Parameters panel into a 40px vertical rail when they don't need to edit it, freeing horizontal space for scenarios and Exit Math.
- Click the ◀ button in the form header to collapse; click the rail (vertical "INVESTMENT PARAMETERS" label + ▶) to expand. State persists in localStorage alongside the existing `showExitMath`/`showAdvanced` toggles.
- Grid overrides handle the default, with-exit-math, advanced-open, and compare-mode layouts; mobile falls back to a horizontal pill so the rail doesn't waste a row.

## Test plan
- [x] `npx vitest run` — 371/371 pass
- [x] Browser-verified default → collapsed → re-expanded → collapsed + Exit Math (rail stays 40px, scenarios + Exit Math share remaining space)
- [ ] Spot-check compare mode with 2+ companies + collapsed inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)