### PR TITLE
Add show/hide animations across the app

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -473,6 +473,9 @@ body {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
+  transition:
+    grid-template-columns 0.4s var(--ease-out-quart),
+    max-width 0.4s var(--ease-out-quart);
 }
 
 .top-row.with-exit-math {
@@ -3615,6 +3618,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   flex-direction: column;
   gap: var(--space-4);
   box-shadow: var(--shadow-sm);
+  animation: section-grow-in 0.4s var(--ease-out-quart);
+  transform-origin: top right;
 }
 
 .exit-math-header h3 {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -57,7 +57,7 @@
 
 /* Reusable show/hide keyframes */
 @keyframes fade-slide-in {
-  from { opacity: 0; transform: translateY(-4px); }
+  from { opacity: 0; transform: translateY(-14px); }
   to   { opacity: 1; transform: none; }
 }
 
@@ -67,8 +67,15 @@
 }
 
 @keyframes section-grow-in {
-  from { opacity: 0; transform: translateY(-2px) scale(0.995); }
-  to   { opacity: 1; transform: none; }
+  0%   { opacity: 0; transform: translateY(-12px) scale(0.94); }
+  60%  { opacity: 1; }
+  100% { opacity: 1; transform: none; }
+}
+
+@keyframes pop-in {
+  0%   { opacity: 0; transform: scale(0.85); }
+  60%  { opacity: 1; transform: scale(1.04); }
+  100% { opacity: 1; transform: scale(1); }
 }
 
 /* Reset and base styles */
@@ -546,7 +553,7 @@ body {
   transition: box-shadow var(--transition-base), border-color var(--transition-base), background var(--transition-base);
   font: inherit;
   color: var(--color-fg-muted);
-  animation: fade-slide-in 0.22s var(--ease-out-quart);
+  animation: fade-slide-in 0.32s var(--ease-out-quart);
 }
 
 .input-form.collapsed-rail:hover,
@@ -853,7 +860,7 @@ body {
 }
 
 .input-form:not(.collapsed-rail) {
-  animation: section-grow-in 0.28s var(--ease-out-quart);
+  animation: section-grow-in 0.4s var(--ease-out-quart);
   transform-origin: top left;
 }
 
@@ -998,7 +1005,7 @@ body {
   border-radius: var(--radius-md);
   padding: var(--space-4);
   transition: box-shadow var(--transition-base), border-color var(--transition-base);
-  animation: section-grow-in 0.26s var(--ease-out-quart);
+  animation: section-grow-in 0.36s var(--ease-out-quart);
   transform-origin: top center;
 }
 
@@ -1061,8 +1068,31 @@ body {
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-4);
   margin-top: var(--space-2);
-  animation: section-grow-in 0.28s var(--ease-out-quart);
+  display: grid;
+  grid-template-rows: 1fr;
+  transition:
+    grid-template-rows 0.36s var(--ease-out-quart),
+    opacity 0.28s ease,
+    margin-top 0.32s var(--ease-out-quart),
+    padding 0.32s var(--ease-out-quart),
+    border-width 0.2s ease;
+  overflow: hidden;
   transform-origin: top center;
+}
+
+.advanced-section > .advanced-section-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.advanced-section.is-collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top-width: 0;
+  border-bottom-width: 0;
 }
 
 .advanced-section h4 {
@@ -1947,11 +1977,11 @@ body {
   justify-content: center;
   width: 1rem;
   height: 1rem;
-  font-size: 0.65rem;
+  font-size: 0.7rem;
   color: var(--color-fg-subtle);
   margin-right: var(--space-2);
   transform-origin: center;
-  transition: color var(--transition-base), transform 0.22s var(--ease-out-quart);
+  transition: color var(--transition-base), transform 0.32s var(--ease-out-quart);
 }
 
 .collapse-indicator.is-collapsed {
@@ -1961,7 +1991,7 @@ body {
 .chevron-icon {
   display: inline-block;
   transform-origin: center;
-  transition: transform 0.22s var(--ease-out-quart);
+  transition: transform 0.32s var(--ease-out-quart);
 }
 
 .chevron-icon.is-collapsed {
@@ -2003,7 +2033,7 @@ body {
 .scenario-table > .table-row.sub-sub-row,
 .scenario-table > .table-row.step-sub-header,
 .scenario-table > .table-row.combined-total-row {
-  animation: fade-slide-in 0.26s var(--ease-out-soft) both;
+  animation: fade-slide-in 0.36s var(--ease-out-soft) both;
 }
 
 .investor-row {
@@ -3629,13 +3659,31 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   padding-top: 0.6rem;
 }
 
+.exit-math-overrides-wrapper {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition:
+    grid-template-rows 0.34s var(--ease-out-quart),
+    opacity 0.26s ease,
+    margin-top 0.3s var(--ease-out-quart);
+}
+
+.exit-math-overrides-wrapper > .exit-math-overrides-grid {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.exit-math-overrides-wrapper.is-collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  margin-top: 0;
+}
+
 .exit-math-overrides-grid {
   margin-top: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  animation: section-grow-in 0.26s var(--ease-out-quart);
-  transform-origin: top center;
 }
 
 .exit-math-reset-btn {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -50,6 +50,25 @@
   /* Transitions */
   --transition-fast: 0.15s ease;
   --transition-base: 0.2s ease;
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+  --transition-collapse: 0.28s var(--ease-out-quart);
+}
+
+/* Reusable show/hide keyframes */
+@keyframes fade-slide-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes section-grow-in {
+  from { opacity: 0; transform: translateY(-2px) scale(0.995); }
+  to   { opacity: 1; transform: none; }
 }
 
 /* Reset and base styles */
@@ -527,6 +546,7 @@ body {
   transition: box-shadow var(--transition-base), border-color var(--transition-base), background var(--transition-base);
   font: inherit;
   color: var(--color-fg-muted);
+  animation: fade-slide-in 0.22s var(--ease-out-quart);
 }
 
 .input-form.collapsed-rail:hover,
@@ -832,6 +852,11 @@ body {
   transition: box-shadow var(--transition-base);
 }
 
+.input-form:not(.collapsed-rail) {
+  animation: section-grow-in 0.28s var(--ease-out-quart);
+  transform-origin: top left;
+}
+
 .input-form:hover {
   box-shadow: var(--shadow-md);
 }
@@ -973,6 +998,8 @@ body {
   border-radius: var(--radius-md);
   padding: var(--space-4);
   transition: box-shadow var(--transition-base), border-color var(--transition-base);
+  animation: section-grow-in 0.26s var(--ease-out-quart);
+  transform-origin: top center;
 }
 
 .step2-card:hover {
@@ -1034,6 +1061,8 @@ body {
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-4);
   margin-top: var(--space-2);
+  animation: section-grow-in 0.28s var(--ease-out-quart);
+  transform-origin: top center;
 }
 
 .advanced-section h4 {
@@ -1921,7 +1950,22 @@ body {
   font-size: 0.65rem;
   color: var(--color-fg-subtle);
   margin-right: var(--space-2);
-  transition: color var(--transition-base);
+  transform-origin: center;
+  transition: color var(--transition-base), transform 0.22s var(--ease-out-quart);
+}
+
+.collapse-indicator.is-collapsed {
+  transform: rotate(-90deg);
+}
+
+.chevron-icon {
+  display: inline-block;
+  transform-origin: center;
+  transition: transform 0.22s var(--ease-out-quart);
+}
+
+.chevron-icon.is-collapsed {
+  transform: rotate(-90deg);
 }
 
 .table-row.header-row.clickable:hover .collapse-indicator {
@@ -1952,6 +1996,14 @@ body {
   padding-left: 1.5rem;
   font-size: 0.85rem;
   color: #64748b;
+}
+
+/* Entrance animation for revealed rows when a scenario section expands */
+.scenario-table > .table-row.sub-row,
+.scenario-table > .table-row.sub-sub-row,
+.scenario-table > .table-row.step-sub-header,
+.scenario-table > .table-row.combined-total-row {
+  animation: fade-slide-in 0.26s var(--ease-out-soft) both;
 }
 
 .investor-row {
@@ -3582,6 +3634,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  animation: section-grow-in 0.26s var(--ease-out-quart);
+  transform-origin: top center;
 }
 
 .exit-math-reset-btn {
@@ -4105,5 +4159,14 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   .walkthrough-tooltip {
     width: calc(100vw - 32px) !important;
     left: 16px !important;
+  }
+}
+
+/* Honor users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
   }
 }

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -310,7 +310,7 @@ function App() {
           onClick={() => updateCompany(activeCompany, { showExitMath: !(companies[activeCompany]?.showExitMath) })}
           aria-pressed={companies[activeCompany]?.showExitMath || false}
         >
-          {companies[activeCompany]?.showExitMath ? '▼' : '▶'} Exit Math
+          <span className={`chevron-icon${companies[activeCompany]?.showExitMath ? '' : ' is-collapsed'}`}>▼</span> Exit Math
         </button>
       </header>
 

--- a/react-app/src/components/ExitMathModule.jsx
+++ b/react-app/src/components/ExitMathModule.jsx
@@ -201,7 +201,7 @@ const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate,
               className="toggle-advanced-btn"
               onClick={() => setShowOverrides((v) => !v)}
             >
-              {showOverrides ? '▼' : '▶'} Per-round overrides
+              <span className={`chevron-icon${showOverrides ? '' : ' is-collapsed'}`}>▼</span> Per-round overrides
             </button>
             {showOverrides && (
               <div className="exit-math-overrides-grid">

--- a/react-app/src/components/ExitMathModule.jsx
+++ b/react-app/src/components/ExitMathModule.jsx
@@ -203,7 +203,11 @@ const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate,
             >
               <span className={`chevron-icon${showOverrides ? '' : ' is-collapsed'}`}>▼</span> Per-round overrides
             </button>
-            {showOverrides && (
+            <div
+              className={`exit-math-overrides-wrapper${showOverrides ? '' : ' is-collapsed'}`}
+              aria-hidden={!showOverrides}
+              {...(!showOverrides ? { inert: true } : {})}
+            >
               <div className="exit-math-overrides-grid">
                 {Array.from({ length: numRounds }).map((_, i) => (
                   <FormInput
@@ -223,7 +227,7 @@ const ExitMathModule = ({ baseScenario, investorName = 'US', exitMath, onUpdate,
                   Reset to uniform
                 </button>
               </div>
-            )}
+            </div>
           </div>
         )}
       </div>

--- a/react-app/src/components/InputForm-twostep.test.jsx
+++ b/react-app/src/components/InputForm-twostep.test.jsx
@@ -32,9 +32,11 @@ describe('InputForm - Two-Step Round', () => {
     expect(screen.getByRole('checkbox', { name: /enable/i })).toBeInTheDocument()
   })
 
-  it('should not render 2-Step Round section when advanced is hidden', () => {
-    render(<InputForm company={{ ...defaultCompany, showAdvanced: false }} onUpdate={mockOnUpdate} />)
-    expect(screen.queryByText('2-Step Round')).not.toBeInTheDocument()
+  it('should hide 2-Step Round section when advanced is hidden', () => {
+    const { container } = render(<InputForm company={{ ...defaultCompany, showAdvanced: false }} onUpdate={mockOnUpdate} />)
+    const advancedSection = container.querySelector('.advanced-section')
+    expect(advancedSection).toHaveClass('is-collapsed')
+    expect(advancedSection.getAttribute('aria-hidden')).toBe('true')
   })
 
   it('should not show step 2 inputs when disabled', () => {

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -417,7 +417,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
           data-tour="advanced-toggle"
           onClick={() => handleChange('showAdvanced', !values.showAdvanced)}
         >
-          {values.showAdvanced ? '▼' : '▶'} Advanced Features
+          <span className={`chevron-icon${values.showAdvanced ? '' : ' is-collapsed'}`}>▼</span> Advanced Features
         </button>
       </div>
 

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -422,8 +422,12 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
       </div>
 
       {/* Advanced Features Section */}
-      {values.showAdvanced && (
-        <div className="advanced-section">
+      <div
+        className={`advanced-section${values.showAdvanced ? '' : ' is-collapsed'}`}
+        aria-hidden={!values.showAdvanced}
+        {...(!values.showAdvanced ? { inert: true } : {})}
+      >
+        <div className="advanced-section-inner">
           <h4>Cap Table Modeling</h4>
 
           <div className="advanced-split">
@@ -905,7 +909,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
           />
 
         </div>
-      )}
+      </div>
 
       <div className="validation-info">
         {!isNaN(values.investorPortion) && !isNaN(values.otherPortion) && !isNaN(values.roundSize) && 

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -330,7 +330,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
           onClick={() => toggleCollapse('newRound')}
         >
           <div className="label">
-            <span className="collapse-indicator">{collapsed.newRound ? '▶' : '▼'}</span>
+            <span className={`collapse-indicator${collapsed.newRound ? ' is-collapsed' : ''}`}>▼</span>
             <strong>New Round Total</strong>
           </div>
           <div className="amount amount-positive">+{formatDollar(scenario.roundSize)}</div>
@@ -460,7 +460,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               onClick={() => toggleCollapse('founders')}
             >
               <div className="label">
-                <span className="collapse-indicator">{collapsed.founders ? '▶' : '▼'}</span>
+                <span className={`collapse-indicator${collapsed.founders ? ' is-collapsed' : ''}`}>▼</span>
                 <strong>Founders Total</strong>
               </div>
               <div className="amount amount-negative">
@@ -470,7 +470,11 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
             </div>
             {/* Individual founders */}
             {!collapsed.founders && scenario.founders && scenario.founders.map((founder, idx) => (
-              <div key={founder.id || idx} className="table-row sub-row">
+              <div
+                key={founder.id || idx}
+                className="table-row sub-row"
+                style={{ animationDelay: `${Math.min(idx, 6) * 0.035}s` }}
+              >
                 <div className="label">{idx === scenario.founders.length - 1 ? '└─' : '├─'} {founder.name || `Founder ${idx + 1}`}</div>
                 <div className="amount amount-negative">-{founder.dilution.toFixed(1)}%</div>
                 <div className="percent">{formatPercent(founder.postRoundPercent)}</div>
@@ -496,7 +500,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               onClick={() => toggleCollapse('priorInvestors')}
             >
               <div className="label">
-                <span className="collapse-indicator">{collapsed.priorInvestors ? '▶' : '▼'}</span>
+                <span className={`collapse-indicator${collapsed.priorInvestors ? ' is-collapsed' : ''}`}>▼</span>
                 <strong>Prior Investors Total</strong>
               </div>
               <div className="amount amount-negative">
@@ -512,7 +516,11 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                   const hasCombinedPrior = combinedInvestor && combinedInvestor.priorDilutedPercent > 0.01
                   const isLast = idx === displayPriorInvestors.length - 1 && scenario.unknownOwnership <= 0.01 && !hasCombinedPrior
                   return (
-                    <div key={investor.id || idx} className="table-row sub-row">
+                    <div
+                      key={investor.id || idx}
+                      className="table-row sub-row"
+                      style={{ animationDelay: `${Math.min(idx, 6) * 0.035}s` }}
+                    >
                       <div className="label">{isLast ? '└─' : '├─'} {investor.name}</div>
                       <div className="amount">
                         {investor.proRataAmount > 0 ? (
@@ -559,7 +567,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               onClick={() => toggleCollapse('safes')}
             >
               <div className="label">
-                <span className="collapse-indicator">{collapsed.safes ? '▶' : '▼'}</span>
+                <span className={`collapse-indicator${collapsed.safes ? ' is-collapsed' : ''}`}>▼</span>
                 <strong>SAFEs Total</strong>
               </div>
               <div className="amount amount-neutral">converts</div>
@@ -569,9 +577,10 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
             {!collapsed.safes && scenario.safeDetails.map((safe, safeIndex) => {
               const isLast = safeIndex === scenario.safeDetails.length - 1
               const showProRata = (safe.proRataAmount || 0) > 0
+              const safeDelay = `${Math.min(safeIndex, 6) * 0.035}s`
               return (
                 <div key={safe.id || safeIndex} style={{ display: 'contents' }}>
-                  <div className="table-row sub-row">
+                  <div className="table-row sub-row" style={{ animationDelay: safeDelay }}>
                     <div className="label">{isLast && !showProRata ? '└─' : '├─'} SAFE #{safe.index}{safe.investorName && <span className="safe-attribution"> ({safe.investorName})</span>}</div>
                     <div className="amount amount-neutral">
                       <span style={{ fontSize: '0.85rem' }}>${safe.amount}M @ ${safe.conversionPrice}M</span>


### PR DESCRIPTION
## Summary
- Introduces a small set of harmonious motion primitives (eased keyframes, CSS variables, `prefers-reduced-motion` support) and applies them across every collapsible surface in the app.
- Bidirectional collapse for the Advanced Features panel and Exit Math overrides via the `grid-template-rows: 0fr→1fr` trick (always-mounted wrappers, `is-collapsed` class), plus entrance animations for ScenarioCard sub-rows with a small per-row stagger.
- Smooth `grid-template-columns` transition on `.top-row` so toggling the Investment Parameters rail or Exit Math panel resizes the layout columns over 0.4s, with chevrons rotating via CSS transform instead of unicode swaps.

## Test plan
- [x] `npx vitest run` — 371 tests pass (one updated test reflects the new always-mounted Advanced section)
- [x] `npm run build` clean
- [x] Browser smoke test: toggle each ScenarioCard section, Advanced Features, Exit Math header button, Per-round overrides, and Investment Parameters rail — chevrons rotate, sections collapse/expand smoothly in both directions, no console errors
- [ ] Verify with macOS Reduce Motion enabled (animations should be effectively instant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)