### PR TITLE
Skip walkthrough and example load on permalink visits

### DIFF
--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -198,6 +198,11 @@ function App() {
 
   // Auto-launch the tour on first visit
   useEffect(() => {
+    // Skip onboarding when arriving via a permalink — the URL scenario
+    // is what the user came to see.
+    if (typeof window !== 'undefined' && window.location.search) {
+      return
+    }
     try {
       const seen = window.localStorage.getItem(TOUR_SEEN_KEY)
       if (!seen) {


### PR DESCRIPTION
## Summary
- Permalink visitors no longer trigger the first-visit auto-tour and example company seed; the shared scenario applies cleanly to the default Scenario 1.
- Single guard added in `App.jsx`'s auto-launch effect: early-return when `window.location.search` is non-empty.

## Test plan
- [ ] Clear localStorage, open the bare app URL → tour auto-launches with Example: Series B (regression check)
- [ ] Clear localStorage, open a permalink in fresh incognito → no tour, no example, shared scenario applied to Scenario 1
- [ ] `npx vitest run` from `react-app/` → all tests pass