### PR TITLE
Open permalinks in a new scenario; tidy up tab actions and SAFE row

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -254,8 +254,7 @@ body {
   transition: padding-right 0.2s ease;
 }
 
-.tab:hover .tab-name,
-.tab.active .tab-name {
+.tab:hover .tab-name {
   padding-right: 64px;
 }
 
@@ -272,8 +271,7 @@ body {
   flex-shrink: 0;
 }
 
-.tab:hover .tab-actions,
-.tab.active .tab-actions {
+.tab:hover .tab-actions {
   opacity: 1;
   pointer-events: auto;
 }
@@ -2896,7 +2894,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  overflow: hidden;
+  overflow-x: auto;
 }
 
 .repeater-header,

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -42,7 +42,7 @@ function App() {
   const [scenarios, setScenarios] = useState([])
   const [baseScenariosById, setBaseScenariosById] = useState({})
   const [tourActive, setTourActive] = useState(false)
-  const { notifications, removeNotification, showSuccess, showInfo, showError } = useNotifications()
+  const { notifications, removeNotification, showSuccess, showError } = useNotifications()
 
   const updateCompany = useCallback((companyId, data) => {
     setStoredCompanies((prev) => {
@@ -185,12 +185,26 @@ function App() {
     if (!hasLoadedFromURL) {
       const urlScenario = loadScenarioFromURL()
       if (urlScenario) {
-        updateCompany(activeCompany, urlScenario)
-        showInfo('Scenario loaded from shared link')
+        const decodedName = (urlScenario.name || '').trim()
+        const tabName = decodedName || `Loaded Scenario ${new Date().toLocaleDateString()}`
+        // Strip the synthetic name field; the company already carries it as `name`.
+        // eslint-disable-next-line no-unused-vars
+        const { name: _ignored, ...scenarioFields } = urlScenario
+        const newCompanyId = `company${nextCompanyId}`
+        const baseCompany = createDefaultCompany(tabName)
+        setStoredCompanies(prev => ({
+          ...normalizeStoredCompanies(prev),
+          [newCompanyId]: { ...baseCompany, ...scenarioFields, name: tabName }
+        }))
+        setNextCompanyId(prev => prev + 1)
+        setActiveCompany(newCompanyId)
+        showSuccess(decodedName
+          ? `Loaded "${decodedName}" from shared link`
+          : 'Loaded scenario from shared link')
       }
       setHasLoadedFromURL(true)
     }
-  }, [hasLoadedFromURL, activeCompany, showInfo, updateCompany])
+  }, [hasLoadedFromURL, nextCompanyId, setStoredCompanies, showSuccess])
 
   // Stable refs so the auto-launch effect runs once without re-firing when companies change
   const ensureExampleRef = useRef(ensureExample)

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -42,6 +42,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     const useCompanyInputs = Boolean(company)
 
     const data = {
+      name: companyName || sourceCompany.name || '',
       postMoneyVal: isTwoStep ? scenario.step1.postMoney : scenario.postMoneyVal,
       roundSize: useCompanyInputs ? (sourceCompany.roundSize || 0) : (isTwoStep ? scenario.step1.amount : scenario.roundSize),
       investorPortion: useCompanyInputs ? (sourceCompany.investorPortion || 0) : (isTwoStep ? scenario.step1.investorAmount : scenario.investorAmount),

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -31,7 +31,9 @@ const URL_PARAM_MAP = {
   step2PostMoney: 's2pm',
   step2Amount: 's2a',
   step2InvestorPortion: 's2ip',
-  step2OtherPortion: 's2op'
+  step2OtherPortion: 's2op',
+  // Optional source company name (used to title the new tab on load)
+  name: 'nm'
 }
 
 const REVERSE_PARAM_MAP = Object.fromEntries(
@@ -203,7 +205,15 @@ export function encodeScenarioToURL(scenarioData) {
       if (field === 'percentPrecision' && value === 2) {
         return // Don't include default value
       }
-      
+
+      // Skip auto-generated default names like "Scenario 1"
+      if (field === 'name') {
+        const trimmed = String(value).trim()
+        if (!trimmed || /^Scenario \d+$/.test(trimmed)) return
+        params.set(param, trimmed)
+        return
+      }
+
       params.set(param, value.toString())
     }
   })
@@ -256,7 +266,7 @@ export function decodeScenarioFromURL(urlParams) {
       const value = params.get(param)
       
       if (value !== null) {
-        if (field === 'investorName') {
+        if (field === 'investorName' || field === 'name') {
           scenarioData[field] = value
         } else if (field === 'showAdvanced' || field === 'twoStepEnabled') {
           scenarioData[field] = value === '1'


### PR DESCRIPTION
## Summary

- Permalink visits now create a new scenario tab (named after the encoded source company, or \`Loaded Scenario {date}\` for legacy/no-name links) and switch focus to it, instead of overwriting the active tab.
- The remove-SAFE button no longer gets clipped — repeater tables switched from \`overflow: hidden\` to \`overflow-x: auto\` so the actions column stays reachable in narrow layouts.
- The active company tab no longer permanently displays its action buttons; they now appear on hover only, matching inactive tabs.

## Test plan

- [ ] Set a tab name like \"Acme Series A\", copy a permalink, open in a new tab → expect a new tab named \"Acme Series A\" to appear and become active without overwriting existing tabs.
- [ ] Hand-craft a permalink without the \`nm\` parameter (or use a legacy URL) → expect a new tab named \`Loaded Scenario {today's date}\`.
- [ ] Add several SAFEs and narrow the input panel → confirm the \`×\` remove button is reachable (visible or via horizontal scroll within the SAFE table).
- [ ] Click between tabs → active tab name displays fully with no action buttons until hover; on hover, edit/duplicate/remove appear as before.
- [ ] \`npx vitest run\` from \`react-app/\` continues to pass (371/371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)