### PR TITLE
Roll up matching names across SAFEs, prior investors, warrants

### DIFF
--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -6,7 +6,8 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     newRound: !isBase,
     founders: !isBase,
     priorInvestors: !isBase,
-    safes: !isBase
+    safes: !isBase,
+    rolledUpInvestors: !isBase
   })
 
   const toggleCollapse = (section) => {
@@ -682,6 +683,38 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                 )
               })
             )}
+          </>
+        )}
+
+        {/* Combined Positions: names appearing in 2+ of priors/SAFEs/warrants */}
+        {showAdvanced && Array.isArray(scenario.rolledUpInvestors) && scenario.rolledUpInvestors.length > 0 && (
+          <>
+            <div
+              className="table-row header-row clickable"
+              onClick={() => toggleCollapse('rolledUpInvestors')}
+            >
+              <div className="label">
+                <span className={`collapse-indicator${collapsed.rolledUpInvestors ? ' is-collapsed' : ''}`}>▼</span>
+                <strong>Combined Positions</strong>
+              </div>
+              <div className="amount amount-neutral">summary</div>
+              <div className="percent percent-bold">
+                {formatPercent(scenario.rolledUpInvestors.reduce((s, r) => s + r.totalPercent, 0))}
+              </div>
+            </div>
+            {!collapsed.rolledUpInvestors && scenario.rolledUpInvestors.map((r, idx) => {
+              const isLast = idx === scenario.rolledUpInvestors.length - 1
+              const sourcesLabel = r.sources
+                .map(s => s === 'prior' ? 'Prior' : s === 'safe' ? 'SAFE' : 'Warrant')
+                .join(' + ')
+              return (
+                <div key={r.name + idx} className="table-row sub-row">
+                  <div className="label">{isLast ? '└─' : '├─'} {r.name} <span className="safe-attribution">({sourcesLabel})</span></div>
+                  <div className="amount amount-neutral">{sourcesLabel}</div>
+                  <div className="percent">{formatPercent(r.totalPercent)}</div>
+                </div>
+              )
+            })}
           </>
         )}
 

--- a/react-app/src/utils/multiParty-calculations.test.js
+++ b/react-app/src/utils/multiParty-calculations.test.js
@@ -1499,4 +1499,103 @@ describe('Hand-computed scenario verification', () => {
       expect(withTopUp.finalWarrantsPercent).toBeLessThan(withoutTopUp.finalWarrantsPercent)
     })
   })
+
+describe('Rolled-up investor positions', () => {
+  const baseInputs = {
+    postMoneyVal: 20,
+    roundSize: 5,
+    investorPortion: 4,
+    otherPortion: 1,
+    investorName: 'LeadCo',
+    showAdvanced: true,
+    priorInvestors: [],
+    founders: [{ id: 1, name: 'CEO', ownershipPercent: 80 }],
+    safes: [],
+    warrants: [],
+    currentEsopPercent: 0,
+    targetEsopPercent: 0
+  }
+
+  it('rolls up a name appearing in priors and SAFEs', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [{ id: 'p1', name: 'Sequoia', ownershipPercent: 10, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: 'Sequoia' }]
+    })
+    expect(r.rolledUpInvestors).toHaveLength(1)
+    const sequoia = r.rolledUpInvestors[0]
+    expect(sequoia.name).toBe('Sequoia')
+    expect(sequoia.sources.sort()).toEqual(['prior', 'safe'])
+    expect(sequoia.totalPercent).toBeCloseTo(sequoia.priorPercent + sequoia.safePercent, 6)
+    expect(sequoia.priorPercent).toBeGreaterThan(0)
+    expect(sequoia.safePercent).toBeGreaterThan(0)
+  })
+
+  it('rolls up a name appearing in priors, SAFEs, and warrants', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [{ id: 'p1', name: 'Acme', ownershipPercent: 5, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: 'Acme' }],
+      warrants: [{ id: 'w1', name: 'Acme', amount: 0.5, valuation: 10 }]
+    })
+    expect(r.rolledUpInvestors).toHaveLength(1)
+    expect(r.rolledUpInvestors[0].sources.sort()).toEqual(['prior', 'safe', 'warrant'])
+    expect(r.rolledUpInvestors[0].warrantPercent).toBeGreaterThan(0)
+  })
+
+  it('excludes names that appear in only one source', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [
+        { id: 'p1', name: 'OnlyPrior', ownershipPercent: 5, hasProRataRights: false },
+        { id: 'p2', name: 'Both', ownershipPercent: 5, hasProRataRights: false }
+      ],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: 'Both' }],
+      warrants: [{ id: 'w1', name: 'OnlyWarrant', amount: 0.5, valuation: 10 }]
+    })
+    expect(r.rolledUpInvestors.map(x => x.name)).toEqual(['Both'])
+  })
+
+  it('matches names case-insensitively and preserves first-seen casing', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [{ id: 'p1', name: 'Sequoia', ownershipPercent: 10, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: 'sequoia' }]
+    })
+    expect(r.rolledUpInvestors).toHaveLength(1)
+    expect(r.rolledUpInvestors[0].name).toBe('Sequoia')
+    expect(r.rolledUpInvestors[0].sources.sort()).toEqual(['prior', 'safe'])
+  })
+
+  it('treats whitespace as significant — " Sequoia " ≠ "Sequoia"', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [{ id: 'p1', name: 'Sequoia', ownershipPercent: 5, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: ' Sequoia ' }]
+    })
+    expect(r.rolledUpInvestors).toEqual([])
+  })
+
+  it('excludes the lead investor (combinedInvestor handles that case)', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      investorName: 'LeadCo',
+      priorInvestors: [{ id: 'p1', name: 'LeadCo', ownershipPercent: 10, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0, investorName: 'LeadCo' }]
+    })
+    expect(r.rolledUpInvestors).toEqual([])
+    expect(r.combinedInvestor).toBeTruthy()
+    expect(r.combinedInvestor.name).toBe('LeadCo')
+  })
+
+  it('ignores SAFEs and warrants with blank names', () => {
+    const r = calculateEnhancedScenario({
+      ...baseInputs,
+      priorInvestors: [{ id: 'p1', name: 'NamedCo', ownershipPercent: 5, hasProRataRights: false }],
+      safes: [{ id: 's1', amount: 1, cap: 8, discount: 0 /* no investorName */ }],
+      warrants: [{ id: 'w1', name: '', amount: 0.5, valuation: 10 }]
+    })
+    expect(r.rolledUpInvestors).toEqual([])
+  })
+})
 })

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -640,6 +640,12 @@ function calculateTwoStepScenario(inputs) {
     priorInvestors: postRoundPriorInvestors,
     founders: postRoundFounders,
     combinedInvestor,
+    rolledUpInvestors: buildRolledUpInvestors({
+      priorInvestors: postRoundPriorInvestors,
+      safeDetails: dilutedSafeDetails,
+      warrantDetails,
+      leadInvestorName: investorName,
+    }),
 
     // Legacy compatibility
     postRoundFounderPercent: rp(postRoundFounders.reduce((sum, f) => sum + (f.postRoundPercent || 0), 0)),
@@ -692,6 +698,68 @@ function calculateTwoStepScenario(inputs) {
       headlineValuation: V2,
     }
   }
+}
+
+/**
+ * Group prior investors, SAFEs, and warrants by case-insensitive name and return only
+ * names that appear in 2+ sources. The lead investor is excluded — `combinedInvestor`
+ * already rolls them up in the "New Round Total" section.
+ */
+function buildRolledUpInvestors({ priorInvestors, safeDetails, warrantDetails, leadInvestorName }) {
+  const leadKey = (leadInvestorName || '').toLowerCase()
+  const groups = new Map()
+
+  const ensure = (rawName) => {
+    if (!rawName) return null
+    const key = rawName.toLowerCase()
+    if (key === leadKey) return null
+    if (!groups.has(key)) {
+      groups.set(key, {
+        name: rawName,
+        sources: new Set(),
+        priorPercent: 0,
+        safePercent: 0,
+        safeAmount: 0,
+        warrantPercent: 0,
+        warrantAmount: 0,
+        proRataAmount: 0,
+      })
+    }
+    return groups.get(key)
+  }
+
+  priorInvestors.forEach(p => {
+    const g = ensure(p.name)
+    if (!g) return
+    g.sources.add('prior')
+    g.priorPercent = rp(g.priorPercent + (p.postRoundPercent || 0))
+    g.proRataAmount = r$(g.proRataAmount + (p.proRataAmount || 0))
+  })
+
+  safeDetails.forEach(s => {
+    const g = ensure(s.investorName)
+    if (!g) return
+    g.sources.add('safe')
+    g.safePercent = rp(g.safePercent + (s.totalPercent || s.percent || 0))
+    g.safeAmount = r$(g.safeAmount + (s.amount || 0))
+    g.proRataAmount = r$(g.proRataAmount + (s.proRataAmount || 0))
+  })
+
+  warrantDetails.forEach(w => {
+    const g = ensure(w.name)
+    if (!g) return
+    g.sources.add('warrant')
+    g.warrantPercent = rp(g.warrantPercent + (w.postRoundPercent || 0))
+    g.warrantAmount = r$(g.warrantAmount + (w.amount || 0))
+  })
+
+  return Array.from(groups.values())
+    .filter(g => g.sources.size >= 2)
+    .map(g => ({
+      ...g,
+      sources: Array.from(g.sources),
+      totalPercent: rp(g.priorPercent + g.safePercent + g.warrantPercent),
+    }))
 }
 
 /**
@@ -1077,6 +1145,12 @@ export function calculateEnhancedScenario(inputs) {
     priorInvestors: postRoundPriorInvestors || [],
     founders: postRoundFounders || [],
     combinedInvestor: combinedInvestor,
+    rolledUpInvestors: buildRolledUpInvestors({
+      priorInvestors: postRoundPriorInvestors || [],
+      safeDetails: enrichedSafeDetails,
+      warrantDetails: warrantDetails || [],
+      leadInvestorName: investorName,
+    }),
     
     // Legacy compatibility (aggregate founder data) - ensure no undefined
     postRoundFounderPercent: rp(postRoundFounders.reduce((sum, f) => sum + (f.postRoundPercent || 0), 0)),


### PR DESCRIPTION
## Summary
- When the same name appears in 2+ of priors / SAFEs / warrants, scenario cards now show a "Combined Positions" section summarizing that investor's total post-round position.
- Names that appear in only one source still render exclusively in their original section. The lead investor is excluded — `combinedInvestor` already rolls them up in "New Round Total".
- Names match case-insensitively; whitespace is significant. Wired into both single-step and two-step scenarios via a new `buildRolledUpInvestors` helper.

## Test plan
- [x] `npx vitest run` from `react-app/` — 378 passed (7 new cases for 2-source, 3-source, case-insensitive, whitespace-sensitive, single-source excluded, lead excluded, blank names ignored)
- [x] Live verification: added a prior investor "Bridge Round" matching the existing SAFE #1 investorName; Combined Positions row showed `Bridge Round (Prior + SAFE) — 9.14%` (2.89% prior + 5.00% SAFE conversion + 1.25% SAFE pro-rata) across all sensitivity scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)