### PR TITLE
Stop SAFEs, Prior Investors, and Warrants tables from overflowing

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2678,13 +2678,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border-top: 1px solid var(--color-border);
 }
 
-.warrants-fd-percent {
-  display: block;
-  text-align: right;
-  font-size: 0.85rem;
-  color: var(--color-fg-subtle);
-}
-
 .esop-section .input-grid.esop-input-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-4);
@@ -2895,6 +2888,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow-x: auto;
+  container-type: inline-size;
 }
 
 .repeater-header,
@@ -2933,8 +2927,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 /* Column track templates — each table tunes its own columns */
 .repeater-table--investors .repeater-header,
 .repeater-table--investors .repeater-row {
-  /* Name | Ownership | Pro-rata | Allocation | Actions */
-  grid-template-columns: minmax(120px, 1.6fr) 110px 64px 130px 56px;
+  /* Name | FDO | Pro-rata | Actions */
+  grid-template-columns: minmax(96px, 1.6fr) 84px 46px 44px;
 }
 
 .repeater-table--founders .repeater-header,
@@ -2945,14 +2939,35 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 .repeater-table--safes .repeater-header,
 .repeater-table--safes .repeater-row {
-  /* Investor | Amount | Cap | Discount | Pro-rata | Allocation | Actions */
-  grid-template-columns: minmax(110px, 1.4fr) 100px 110px 92px 64px 120px 56px;
+  /* Investor | Amount | Cap | Discount | Pro-rata | Actions */
+  grid-template-columns: minmax(96px, 1.4fr) 84px 88px 72px 46px 44px;
 }
 
 .repeater-table--warrants .repeater-header,
 .repeater-table--warrants .repeater-row {
-  /* Holder | Amount | Valuation | % of FD | Actions */
-  grid-template-columns: minmax(110px, 1.4fr) 110px 110px 90px 56px;
+  /* Holder | Amount | Valuation | Actions */
+  grid-template-columns: minmax(96px, 1.4fr) 84px 84px 44px;
+}
+
+/* Stack rows when the table's container is very narrow (compare mode, etc.) */
+@container (max-width: 360px) {
+  .repeater-header {
+    display: none;
+  }
+
+  .repeater-row {
+    grid-template-columns: 1fr 1fr 1fr 1fr 32px !important;
+    row-gap: 4px;
+  }
+
+  .repeater-col--name {
+    grid-column: 1 / 5;
+  }
+
+  .repeater-col--actions {
+    grid-column: 5 / 6;
+    grid-row: 1;
+  }
 }
 
 .repeater-col {
@@ -3000,11 +3015,40 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 .repeater-row-caption {
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
   font-size: 0.7rem;
   color: var(--color-fg-subtle);
   font-style: italic;
   padding: 2px 0 2px 2px;
   line-height: 1.3;
+}
+
+.repeater-row-caption-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.repeater-row-caption-action {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-style: normal;
+}
+
+.repeater-row-caption-action .form-input-wrapper.compact {
+  width: 124px;
+}
+
+.repeater-row-caption-label {
+  font-size: 0.7rem;
+  color: var(--color-fg-muted);
+  font-style: normal;
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
 /* Read-only rows (SAFE, lead) inside the Investors table — tinted, non-editable */

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -626,7 +626,6 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                   <span className="repeater-col repeater-col--name">Holder</span>
                   <span className="repeater-col repeater-col--amount">Amount</span>
                   <span className="repeater-col repeater-col--valuation">Valuation</span>
-                  <span className="repeater-col repeater-col--alloc">% of FD</span>
                   <span className="repeater-col repeater-col--actions" aria-hidden="true" />
                 </div>
                 {values.warrants.map((warrant) => {
@@ -676,11 +675,6 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                           compact
                         />
                       </div>
-                      <div className="repeater-col repeater-col--alloc">
-                        <span className="warrants-fd-percent">
-                          {fdPercent > 0 ? `${fdPercent.toFixed(2)}%` : '—'}
-                        </span>
-                      </div>
                       <div className="repeater-col repeater-col--actions">
                         <button
                           type="button"
@@ -691,6 +685,13 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                           ×
                         </button>
                       </div>
+                      {fdPercent > 0 && (
+                        <div className="repeater-row-caption">
+                          <span className="repeater-row-caption-text">
+                            {fdPercent.toFixed(2)}% of fully-diluted ownership
+                          </span>
+                        </div>
+                      )}
                     </div>
                   )
                 })}
@@ -725,7 +726,6 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                   <span className="repeater-col repeater-col--cap">Cap</span>
                   <span className="repeater-col repeater-col--discount">Discount</span>
                   <span className="repeater-col repeater-col--prorata">Pro-rata</span>
-                  <span className="repeater-col repeater-col--alloc">Allocation</span>
                   <span className="repeater-col repeater-col--actions" aria-hidden="true" />
                 </div>
                 {values.safes.map((safe) => {
@@ -841,39 +841,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                           />
                         </label>
                       </div>
-                      <div className="repeater-col repeater-col--alloc">
-                        {proRataBlock && !proRataBlock.matchesLead ? (
-                          <FormInput
-                            label="Allocation"
-                            type="number"
-                            value={proRataBlock.displayAmount}
-                            onChange={(value) => updateSafe(safe.id, 'proRataOverride', value)}
-                            prefix="$"
-                            suffix="M"
-                            step="0.01"
-                            min="0"
-                            compact
-                          />
-                        ) : (
-                          <span
-                            className="repeater-alloc-placeholder"
-                            title={proRataBlock?.matchesLead ? `Handled via ${values.investorName || 'US'} round portion` : 'Enable pro-rata to set allocation'}
-                          >
-                            {proRataBlock?.matchesLead ? 'via lead' : '—'}
-                          </span>
-                        )}
-                      </div>
                       <div className="repeater-col repeater-col--actions">
-                        {proRataBlock?.hasOverride && !proRataBlock.matchesLead && (
-                          <button
-                            type="button"
-                            className="reset-pro-rata-btn"
-                            onClick={() => updateSafe(safe.id, 'proRataOverride', null)}
-                            title={`Reset to calculated ($${parseFloat(proRataBlock.calculatedProRata.toPrecision(10))}M)`}
-                          >
-                            ↺
-                          </button>
-                        )}
                         <button
                           type="button"
                           className="remove-safe-btn"
@@ -883,8 +851,39 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed }) 
                           ×
                         </button>
                       </div>
-                      {conversionInfo && (
-                        <div className="repeater-row-caption">{conversionInfo}</div>
+                      {(conversionInfo || proRataBlock) && (
+                        <div className="repeater-row-caption">
+                          <span className="repeater-row-caption-text">
+                            {conversionInfo}
+                            {!conversionInfo && proRataBlock?.matchesLead && `Pro-rata handled via ${values.investorName || 'US'} round portion`}
+                          </span>
+                          {proRataBlock && !proRataBlock.matchesLead && (
+                            <span className="repeater-row-caption-action">
+                              <span className="repeater-row-caption-label">Allocation</span>
+                              <FormInput
+                                label="Allocation"
+                                type="number"
+                                value={proRataBlock.displayAmount}
+                                onChange={(value) => updateSafe(safe.id, 'proRataOverride', value)}
+                                prefix="$"
+                                suffix="M"
+                                step="0.01"
+                                min="0"
+                                compact
+                              />
+                              {proRataBlock.hasOverride && (
+                                <button
+                                  type="button"
+                                  className="reset-pro-rata-btn"
+                                  onClick={() => updateSafe(safe.id, 'proRataOverride', null)}
+                                  title={`Reset to calculated ($${parseFloat(proRataBlock.calculatedProRata.toPrecision(10))}M)`}
+                                >
+                                  ↺
+                                </button>
+                              )}
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
                   )

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -121,7 +121,6 @@ function PriorInvestorsSection({
               className="repeater-col repeater-col--prorata"
               title="Pro-rata: right to invest in this round in proportion to existing ownership, preserving stake."
             >Pro-rata</span>
-            <span className="repeater-col repeater-col--alloc">Allocation</span>
             <span className="repeater-col repeater-col--actions" aria-hidden="true" />
           </div>
 
@@ -167,45 +166,7 @@ function PriorInvestorsSection({
                       />
                     </label>
                   </div>
-                  <div className="repeater-col repeater-col--alloc">
-                    {matchesLead ? (
-                      <span className="repeater-alloc-placeholder" title={`Handled via ${investorName} round portion`}>
-                        via lead
-                      </span>
-                    ) : allocActive ? (
-                      <FormInput
-                        label="Allocation"
-                        type="number"
-                        value={displayAmount}
-                        onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
-                        prefix="$"
-                        suffix="M"
-                        step="0.01"
-                        min="0"
-                        compact
-                      />
-                    ) : calculatedProRata > 0 ? (
-                      <span
-                        className="repeater-prorata-readonly"
-                        title="Calculated pro-rata (not enabled). Toggle the checkbox to commit."
-                      >
-                        ${calculatedProRata.toFixed(2)}M
-                      </span>
-                    ) : (
-                      <span className="repeater-alloc-placeholder">—</span>
-                    )}
-                  </div>
                   <div className="repeater-col repeater-col--actions">
-                    {hasOverride && allocActive && !matchesLead && (
-                      <button
-                        type="button"
-                        className="reset-pro-rata-btn"
-                        onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
-                        title={`Reset to calculated ($${parseFloat(calculatedProRata.toPrecision(10))}M)`}
-                      >
-                        ↺
-                      </button>
-                    )}
                     <button
                       className="remove-investor-btn"
                       onClick={() => removeInvestor(investor.id)}
@@ -215,6 +176,46 @@ function PriorInvestorsSection({
                       ×
                     </button>
                   </div>
+                  {matchesLead ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title={`Handled via ${investorName} round portion`}>
+                        Pro-rata handled via {investorName} round portion
+                      </span>
+                    </div>
+                  ) : allocActive ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text">Pro-rata allocation</span>
+                      <span className="repeater-row-caption-action">
+                        <FormInput
+                          label="Allocation"
+                          type="number"
+                          value={displayAmount}
+                          onChange={(value) => updateInvestor(investor.id, 'proRataOverride', value)}
+                          prefix="$"
+                          suffix="M"
+                          step="0.01"
+                          min="0"
+                          compact
+                        />
+                        {hasOverride && (
+                          <button
+                            type="button"
+                            className="reset-pro-rata-btn"
+                            onClick={() => updateInvestor(investor.id, 'proRataOverride', null)}
+                            title={`Reset to calculated ($${parseFloat(calculatedProRata.toPrecision(10))}M)`}
+                          >
+                            ↺
+                          </button>
+                        )}
+                      </span>
+                    </div>
+                  ) : calculatedProRata > 0 ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title="Calculated pro-rata (not enabled). Toggle the checkbox to commit.">
+                        Calculated pro-rata: ${calculatedProRata.toFixed(2)}M (not enabled)
+                      </span>
+                    </div>
+                  ) : null}
                 </div>
               )
             }
@@ -239,22 +240,26 @@ function PriorInvestorsSection({
                       <input type="checkbox" checked={Boolean(safe.proRata)} readOnly disabled />
                     </label>
                   </div>
-                  <div className="repeater-col repeater-col--alloc">
-                    {matchesLead ? (
-                      <span className="repeater-alloc-placeholder" title={`Handled via ${investorName} round portion`}>via lead</span>
-                    ) : safe.proRata && safeProRata$ > 0 ? (
-                      <span className="repeater-prorata-active" title="SAFE pro-rata (edit in SAFE section)">
-                        ${safeProRata$.toFixed(2)}M
-                      </span>
-                    ) : safeProRata$ > 0 ? (
-                      <span className="repeater-prorata-readonly" title="Calculated pro-rata (SAFE pro-rata disabled)">
-                        ${safeProRata$.toFixed(2)}M
-                      </span>
-                    ) : (
-                      <span className="repeater-alloc-placeholder">—</span>
-                    )}
-                  </div>
                   <div className="repeater-col repeater-col--actions" aria-hidden="true" />
+                  {matchesLead ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title={`Handled via ${investorName} round portion`}>
+                        Pro-rata handled via {investorName} round portion
+                      </span>
+                    </div>
+                  ) : safe.proRata && safeProRata$ > 0 ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title="SAFE pro-rata (edit in SAFE section)">
+                        SAFE pro-rata: ${safeProRata$.toFixed(2)}M
+                      </span>
+                    </div>
+                  ) : safeProRata$ > 0 ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title="Calculated pro-rata (SAFE pro-rata disabled)">
+                        Calculated pro-rata: ${safeProRata$.toFixed(2)}M (disabled)
+                      </span>
+                    </div>
+                  ) : null}
                 </div>
               )
             }
@@ -273,10 +278,10 @@ function PriorInvestorsSection({
                 <div className="repeater-col repeater-col--prorata">
                   <span className="repeater-alloc-placeholder" title="Lead is taking the round">—</span>
                 </div>
-                <div className="repeater-col repeater-col--alloc">
-                  <span className="repeater-alloc-placeholder" title="Lead is taking the round">taking round</span>
-                </div>
                 <div className="repeater-col repeater-col--actions" aria-hidden="true" />
+                <div className="repeater-row-caption">
+                  <span className="repeater-row-caption-text">Taking the round</span>
+                </div>
               </div>
             )
           })}


### PR DESCRIPTION
## Summary
- Each repeater table was a fixed-width CSS grid wider than the input column it lives in, forcing a horizontal scrollbar in compare mode (~355px), exit-math mode (~510px), and the default 2-col layout (~600px).
- Drop the lowest-priority columns from each grid and move that content into the existing per-row caption sub-row: SAFE allocation overrides sit beside conversion info, Prior Investor allocation moves to a labelled caption (handles editable / calculated / "via lead" / "taking round" variants), and Warrants' "% of FD" becomes a caption.
- A `@container (max-width: 360px)` rule stacks each row (name + actions on row 1, inputs on row 2) so nothing overflows even in compare-mode side-by-side layouts.

## Test plan
- [x] `npx vitest run` (371 passed, 1 skipped — same as baseline)
- [x] Browser-measured `scrollWidth === clientWidth` on all four repeater tables in both default mode (680px container) and compare mode (355px container)
- [x] Visual check: stacked rows render cleanly in compare mode; allocation/conversion captions read correctly across SAFE / prior investor / SAFE-readonly / lead row variants