### PR TITLE
Add iPhone mobile navigation and sharing

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1966,6 +1966,11 @@ body {
   align-items: center;
 }
 
+.mobile-share-btn,
+.mobile-bottom-nav {
+  display: none;
+}
+
 /* 2-Step Round - Scenario Card */
 .step-sub-header {
   background: rgba(99, 91, 255, 0.04) !important;
@@ -4606,6 +4611,373 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   .walkthrough-tooltip {
     width: calc(100vw - 32px) !important;
     left: 16px !important;
+  }
+}
+
+/* Phone-first app shell: switch between sections with the bottom nav while
+   preserving the desktop DOM and layout above the mobile breakpoint. */
+@media (max-width: 768px) {
+  body {
+    overflow-x: hidden;
+  }
+
+  .app {
+    min-width: 0;
+  }
+
+  .app-header {
+    padding: 0.65rem 3.25rem;
+  }
+
+  .app-header .logo svg,
+  .app-header .logo-mark {
+    width: 30px;
+    height: 30px;
+  }
+
+  .logo-title {
+    font-size: 1.15rem;
+    letter-spacing: 0;
+  }
+
+  .app-subtitle {
+    display: none;
+  }
+
+  .header-tour-btn,
+  .header-exit-math-toggle {
+    padding: 0.35rem 0.55rem;
+    min-height: 34px;
+  }
+
+  .header-tour-label {
+    display: none;
+  }
+
+  .app-main {
+    padding: 0.75rem;
+    padding-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
+    overflow-x: hidden;
+  }
+
+  .company-tabs {
+    margin-bottom: 0.75rem;
+    max-width: none;
+  }
+
+  .tabs-container {
+    flex-direction: row;
+    align-items: stretch;
+    border-radius: var(--radius-md);
+  }
+
+  .tabs-scroll {
+    width: auto;
+    flex: 1 1 auto;
+  }
+
+  .tabs-list {
+    flex-direction: row;
+    width: max-content;
+    min-width: 100%;
+  }
+
+  .tab {
+    width: auto;
+    min-width: 150px;
+    max-width: 220px;
+    border-right: 1px solid var(--color-border);
+    border-bottom: none;
+    padding: 0.6rem 0.85rem;
+    font-size: 0.82rem;
+  }
+
+  .tab:hover .tab-name {
+    padding-right: 0;
+  }
+
+  .tab-actions {
+    display: none;
+  }
+
+  .tabs-actions {
+    flex: 0 0 auto;
+    flex-direction: row;
+  }
+
+  .compare-count-chip,
+  .tabs-actions > .load-example-btn,
+  .tabs-actions > .add-company-btn {
+    width: auto;
+    border-top: none;
+    border-left: 1px solid var(--color-border);
+  }
+
+  .load-example-text,
+  .add-text {
+    display: none;
+  }
+
+  .top-row,
+  .top-row.with-exit-math,
+  .top-row.inputs-collapsed,
+  .top-row.inputs-collapsed.with-exit-math,
+  .top-row.advanced-open,
+  .top-row.advanced-open.inputs-collapsed,
+  .top-row.compare-mode {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: none;
+    margin-bottom: 0.75rem;
+    padding-inline: 0;
+  }
+
+  .top-row > .input-form,
+  .top-row > .base-result,
+  .top-row > .exit-math-module,
+  .mobile-scenarios-panel {
+    display: none;
+  }
+
+  .mobile-view-results .top-row > .base-result,
+  .mobile-view-inputs .top-row > .input-form,
+  .mobile-view-exit .top-row > .exit-math-module {
+    display: block;
+    width: 100%;
+  }
+
+  .mobile-view-results .top-row > .base-result {
+    display: flex;
+  }
+
+  .mobile-view-scenarios .top-row {
+    display: none;
+  }
+
+  .mobile-view-scenarios .mobile-scenarios-panel {
+    display: block;
+  }
+
+  .mobile-view-scenarios .scenarios-rows.mobile-scenarios-panel {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .base-result > .scenario-card,
+  .scenarios-rows > .scenario-card,
+  .exit-math-module,
+  .input-form {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .input-form {
+    padding: 0.85rem;
+  }
+
+  .form-header {
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
+    padding-bottom: 0.75rem;
+  }
+
+  .form-header h3 {
+    font-size: 1rem;
+  }
+
+  .input-form-collapse-btn {
+    display: none;
+  }
+
+  .header-controls {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .investor-name-input {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .investor-name-input input {
+    width: min(92px, 38vw);
+  }
+
+  .calculated-money-toggle {
+    flex: 0 1 auto;
+    min-width: 0;
+    padding: 0.45rem 0.55rem;
+    font-size: 0.76rem;
+    white-space: nowrap;
+  }
+
+  .scenario-card {
+    padding: 0.8rem;
+    border-radius: var(--radius-md);
+  }
+
+  .base-quick-edit,
+  .scenario-headline {
+    grid-template-columns: 1fr;
+  }
+
+  .scenario-table {
+    overflow-x: hidden;
+  }
+
+  .table-header,
+  .table-row {
+    grid-template-columns: minmax(0, 1.35fr) minmax(64px, 0.9fr) minmax(58px, 0.75fr);
+    gap: 0.35rem;
+  }
+
+  .table-row .label,
+  .table-row .amount,
+  .table-row .percent,
+  .table-header .label,
+  .table-header .amount,
+  .table-header .percent {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .valuation-footer {
+    align-items: stretch;
+    gap: 0.65rem;
+  }
+
+  .valuation-items {
+    min-width: 0;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+
+  .share-buttons {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .permalink-btn-inline {
+    display: none;
+  }
+
+  .mobile-share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    border-radius: 7px;
+    border: 1px solid var(--color-border);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
+  }
+
+  .mobile-share-btn-primary {
+    color: #ffffff;
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .mobile-share-btn-secondary {
+    color: var(--color-accent-hover);
+    background: var(--color-accent-soft);
+    border-color: color-mix(in srgb, var(--color-accent) 28%, var(--color-border));
+  }
+
+  .mobile-share-btn.is-copied {
+    color: var(--color-success-hover);
+    background: color-mix(in srgb, var(--color-success) 10%, #ffffff);
+    border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+  }
+
+  .mobile-share-btn:disabled {
+    opacity: 0.72;
+    cursor: not-allowed;
+  }
+
+  .mobile-bottom-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 40;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.25rem;
+    padding: 0.45rem 0.55rem calc(0.45rem + env(safe-area-inset-bottom, 0px));
+    background: rgba(255, 255, 255, 0.96);
+    border-top: 1px solid var(--color-border);
+    box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(12px);
+  }
+
+  .mobile-bottom-nav button {
+    min-width: 0;
+    min-height: 48px;
+    padding: 0.35rem 0.25rem;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--color-fg-subtle);
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1.1;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+    cursor: pointer;
+  }
+
+  .mobile-bottom-nav button.active {
+    color: var(--color-accent-hover);
+    background: var(--color-accent-soft);
+    border-color: color-mix(in srgb, var(--color-accent) 28%, var(--color-border));
+  }
+
+  .mobile-nav-icon {
+    font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
+    font-size: 0.9rem;
+    line-height: 1;
+  }
+}
+
+@media (max-width: 480px) {
+  .app-header {
+    padding-left: 2.8rem;
+    padding-right: 2.8rem;
+  }
+
+  .header-exit-math-toggle {
+    max-width: 38px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .tabs-container {
+    margin-inline: -0.15rem;
+  }
+
+  .tab {
+    min-width: 136px;
+    max-width: 190px;
+  }
+
+  .table-header,
+  .table-row {
+    grid-template-columns: minmax(0, 1.28fr) minmax(56px, 0.85fr) minmax(54px, 0.72fr);
   }
 }
 

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -11,7 +11,7 @@ import Walkthrough from './components/Walkthrough'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
-import { copyPermalinkToClipboard, loadScenarioFromURL } from './utils/permalink'
+import { copyPermalinkToClipboard, loadScenarioFromURL, sharePermalink } from './utils/permalink'
 import { updateSocialSharingMeta } from './utils/socialSharing'
 import { createDefaultCompany, nextUniqueName, normalizeStoredCompanies } from './utils/dataStructures'
 import { createExampleScenario, createExampleCompareVariant, EXAMPLE_PRIMARY_NAME, EXAMPLE_VARIANT_NAME } from './utils/exampleScenario'
@@ -42,6 +42,8 @@ function App() {
   const [scenarios, setScenarios] = useState([])
   const [baseScenariosById, setBaseScenariosById] = useState({})
   const [tourActive, setTourActive] = useState(false)
+  const [mobileView, setMobileView] = useState('results')
+  const [isPhoneLayout, setIsPhoneLayout] = useState(false)
   const [tabActivity, setTabActivity] = useState(null)
   const [inputHighlightToken, setInputHighlightToken] = useState(0)
   const { notifications, removeNotification, showSuccess, showError } = useNotifications()
@@ -71,6 +73,39 @@ function App() {
       showError('Failed to copy permalink', 2200)
     }
     return result
+  }
+
+  const handleSharePermalink = async (scenarioData) => {
+    const result = await sharePermalink(scenarioData)
+    if (result.success) {
+      const label = scenarioData?.name ? ` for ${scenarioData.name}` : ''
+      showSuccess(`${result.fallback ? 'Permalink copied' : 'Scenario shared'}${label}`, 1800)
+    } else {
+      showError('Failed to share scenario', 2200)
+    }
+    return result
+  }
+
+  const handleMobileViewChange = (view) => {
+    if (view === 'exit') {
+      if (!companies[activeCompany]?.showExitMath) {
+        updateCompany(activeCompany, { showExitMath: true })
+      }
+      setMobileView('exit')
+      return
+    }
+
+    setMobileView(view)
+  }
+
+  const toggleExitMath = () => {
+    const next = !companies[activeCompany]?.showExitMath
+    updateCompany(activeCompany, { showExitMath: next })
+    if (next) {
+      setMobileView('exit')
+    } else if (mobileView === 'exit') {
+      setMobileView('results')
+    }
   }
 
 
@@ -163,6 +198,22 @@ function App() {
   }
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return undefined
+
+    const media = window.matchMedia('(max-width: 768px)')
+    const update = () => setIsPhoneLayout(media.matches)
+    update()
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', update)
+      return () => media.removeEventListener('change', update)
+    }
+
+    media.addListener(update)
+    return () => media.removeListener(update)
+  }, [])
+
+  useEffect(() => {
     const raw = JSON.stringify(storedCompanies)
     const normalized = JSON.stringify(companies)
 
@@ -209,6 +260,7 @@ function App() {
         }))
         setNextCompanyId(prev => prev + 1)
         setActiveCompany(newCompanyId)
+        setMobileView('results')
         showSuccess(decodedName
           ? `Loaded "${decodedName}" from shared link`
           : 'Loaded scenario from shared link')
@@ -312,9 +364,12 @@ function App() {
   const cardIds = isCompareMode ? compareIds : [activeCompany]
   const showExitMath = Boolean(companies[activeCompany]?.showExitMath)
   const advancedOpen = !isCompareMode && !showExitMath && Boolean(companies[activeCompany]?.showAdvanced)
+  const inputFormCollapsed = isPhoneLayout && mobileView === 'inputs'
+    ? false
+    : Boolean(companies[activeCompany]?.inputsCollapsed)
 
   return (
-    <div className="app">
+    <div className={`app mobile-view-${mobileView}`}>
       <NotificationContainer
         notifications={notifications}
         onRemove={removeNotification}
@@ -337,7 +392,7 @@ function App() {
           type="button"
           className="exit-math-toggle header-exit-math-toggle"
           data-tour="exit-math-toggle"
-          onClick={() => updateCompany(activeCompany, { showExitMath: !(companies[activeCompany]?.showExitMath) })}
+          onClick={toggleExitMath}
           aria-pressed={companies[activeCompany]?.showExitMath || false}
         >
           <span className={`chevron-icon${companies[activeCompany]?.showExitMath ? '' : ' is-collapsed'}`}>▼</span> Exit Math
@@ -363,7 +418,7 @@ function App() {
           <InputForm
             company={companies[activeCompany]}
             onUpdate={(data) => updateCompany(activeCompany, data)}
-            collapsed={Boolean(companies[activeCompany]?.inputsCollapsed)}
+            collapsed={inputFormCollapsed}
             onToggleCollapsed={() => updateCompany(activeCompany, { inputsCollapsed: !companies[activeCompany]?.inputsCollapsed })}
             highlightToken={inputHighlightToken}
           />
@@ -402,6 +457,7 @@ function App() {
                   isBase={true}
                   onApplyScenario={(data) => updateCompany(cid, data)}
                   onCopyPermalink={handleCopyPermalink}
+                  onSharePermalink={handleSharePermalink}
                   investorName={companies[cid]?.investorName || 'US'}
                   showAdvanced={companies[cid]?.showAdvanced || false}
                   percentPrecision={companies[cid]?.percentPrecision || 2}
@@ -428,14 +484,16 @@ function App() {
         </div>
 
         {!isCompareMode && scenarios.length > 1 && (
-          <ScenarioControls
-            offsets={companies[activeCompany]?.scenarioOffsets || []}
-            onChange={(next) => updateCompany(activeCompany, { scenarioOffsets: next })}
-          />
+          <div className="mobile-scenarios-panel">
+            <ScenarioControls
+              offsets={companies[activeCompany]?.scenarioOffsets || []}
+              onChange={(next) => updateCompany(activeCompany, { scenarioOffsets: next })}
+            />
+          </div>
         )}
 
         {!isCompareMode && (
-          <div className="scenarios-rows">
+          <div className="scenarios-rows mobile-scenarios-panel">
             {scenarios.slice(1).map((scenario, index) => (
               <ScenarioCard
                 key={scenario.offsetPercent ?? index + 1}
@@ -454,6 +512,45 @@ function App() {
           </div>
         )}
       </main>
+
+      <nav className="mobile-bottom-nav" aria-label="Mobile sections">
+        <button
+          type="button"
+          className={mobileView === 'results' ? 'active' : ''}
+          onClick={() => handleMobileViewChange('results')}
+          aria-pressed={mobileView === 'results'}
+        >
+          <span className="mobile-nav-icon" aria-hidden="true">%</span>
+          <span>Results</span>
+        </button>
+        <button
+          type="button"
+          className={mobileView === 'inputs' ? 'active' : ''}
+          onClick={() => handleMobileViewChange('inputs')}
+          aria-pressed={mobileView === 'inputs'}
+        >
+          <span className="mobile-nav-icon" aria-hidden="true">$</span>
+          <span>Inputs</span>
+        </button>
+        <button
+          type="button"
+          className={mobileView === 'scenarios' ? 'active' : ''}
+          onClick={() => handleMobileViewChange('scenarios')}
+          aria-pressed={mobileView === 'scenarios'}
+        >
+          <span className="mobile-nav-icon" aria-hidden="true">±</span>
+          <span>Scenarios</span>
+        </button>
+        <button
+          type="button"
+          className={mobileView === 'exit' ? 'active' : ''}
+          onClick={() => handleMobileViewChange('exit')}
+          aria-pressed={mobileView === 'exit'}
+        >
+          <span className="mobile-nav-icon" aria-hidden="true">×</span>
+          <span>Exit</span>
+        </button>
+      </nav>
 
       <Walkthrough
         open={tourActive}

--- a/react-app/src/App.test.jsx
+++ b/react-app/src/App.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import App from './App'
 
 // Mock the child components to focus on App's permalink functionality
@@ -63,6 +64,28 @@ describe('App with Permalink Loading', () => {
     expect(screen.getByTestId('input-form')).toBeInTheDocument()
   })
 
+  it('should default the phone shell to results and switch sections from bottom nav', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<App />)
+
+    expect(container.firstChild).toHaveClass('mobile-view-results')
+
+    await user.click(screen.getByRole('button', { name: /inputs/i }))
+
+    expect(container.firstChild).toHaveClass('mobile-view-inputs')
+    expect(screen.getByRole('button', { name: /inputs/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('should enable Exit Math when the phone Exit nav item is selected', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /^exit$/i }))
+
+    expect(container.firstChild).toHaveClass('mobile-view-exit')
+    expect(screen.getByRole('button', { name: /exit math/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
   it('should load scenario from URL parameters on mount', async () => {
     // Mock URL with scenario parameters
     Object.defineProperty(window, 'location', {
@@ -76,13 +99,14 @@ describe('App with Permalink Loading', () => {
       writable: true,
     })
 
-    render(<App />)
+    const { container } = render(<App />)
 
     await waitFor(() => {
       // Check that the input form received the loaded data
       const postMoneyInput = screen.getByTestId('post-money-input')
       expect(postMoneyInput.value).toBe('15')
     })
+    expect(container.firstChild).toHaveClass('mobile-view-results')
   })
 
   it('should handle invalid URL parameters gracefully', async () => {

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 
-const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName, compareActive, compareIndex, baseScenario }) => {
+const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalink, onSharePermalink, investorName = 'US', showAdvanced = false, percentPrecision = 2, onPercentPrecisionChange, company, onUpdateBase, companyName, compareActive, compareIndex, baseScenario }) => {
   const [copyFeedback, setCopyFeedback] = useState('')
+  const [shareFeedback, setShareFeedback] = useState('')
   const [applyFeedback, setApplyFeedback] = useState(false)
   const [precisionHint, setPrecisionHint] = useState(false)
   const [pressedSection, setPressedSection] = useState(null)
@@ -103,6 +104,25 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     } catch {
       setCopyFeedback('Failed to copy')
       setTimeout(() => setCopyFeedback(''), 3000)
+    }
+  }
+
+  const handleSharePermalink = async () => {
+    if (!onSharePermalink) return
+
+    try {
+      const result = await onSharePermalink(buildScenarioData())
+
+      if (result.success) {
+        setShareFeedback(result.fallback ? 'Copied!' : 'Shared!')
+      } else {
+        setShareFeedback('Failed to share')
+      }
+
+      setTimeout(() => setShareFeedback(''), 3000)
+    } catch {
+      setShareFeedback('Failed to share')
+      setTimeout(() => setShareFeedback(''), 3000)
     }
   }
 
@@ -799,17 +819,39 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
           )}
         </div>
 
-        {isBase && onCopyPermalink && (
+        {isBase && (onCopyPermalink || onSharePermalink) && (
           <div className="share-buttons">
-            <button
-              className={`permalink-btn-inline${copyFeedback ? ' is-copied' : ''}`}
-              data-tour="permalink-btn"
-              onClick={handleCopyPermalink}
-              title="Share permalink for this scenario"
-              disabled={!!copyFeedback}
-            >
-              {copyFeedback || '🔗'}
-            </button>
+            {onCopyPermalink && (
+              <button
+                className={`permalink-btn-inline${copyFeedback ? ' is-copied' : ''}`}
+                data-tour="permalink-btn"
+                onClick={handleCopyPermalink}
+                title="Copy permalink for this scenario"
+                disabled={!!copyFeedback}
+              >
+                {copyFeedback || '🔗'}
+              </button>
+            )}
+            {onSharePermalink && (
+              <button
+                type="button"
+                className={`mobile-share-btn mobile-share-btn-primary${shareFeedback ? ' is-copied' : ''}`}
+                onClick={handleSharePermalink}
+                disabled={!!shareFeedback}
+              >
+                {shareFeedback || 'Share'}
+              </button>
+            )}
+            {onCopyPermalink && (
+              <button
+                type="button"
+                className={`mobile-share-btn mobile-share-btn-secondary${copyFeedback ? ' is-copied' : ''}`}
+                onClick={handleCopyPermalink}
+                disabled={!!copyFeedback}
+              >
+                {copyFeedback || 'Copy'}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/react-app/src/components/ScenarioCard.test.jsx
+++ b/react-app/src/components/ScenarioCard.test.jsx
@@ -28,6 +28,7 @@ describe('ScenarioCard with Permalink', () => {
 
   const mockOnApplyScenario = vi.fn()
   const mockOnCopyPermalink = vi.fn()
+  const mockOnSharePermalink = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -48,10 +49,13 @@ describe('ScenarioCard with Permalink', () => {
         isBase={false}
         onApplyScenario={mockOnApplyScenario}
         onCopyPermalink={mockOnCopyPermalink}
+        onSharePermalink={mockOnSharePermalink}
       />
     )
 
     expect(screen.queryByRole('button', { name: /🔗/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^share$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^copy$/i })).not.toBeInTheDocument()
   })
 
   it('should render permalink button for base scenario', () => {
@@ -66,6 +70,21 @@ describe('ScenarioCard with Permalink', () => {
     )
 
     expect(screen.getByRole('button', { name: /🔗/ })).toBeInTheDocument()
+  })
+
+  it('should render explicit mobile share and copy controls for base scenario', () => {
+    render(
+      <ScenarioCard
+        scenario={mockScenario}
+        index={0}
+        isBase={true}
+        onCopyPermalink={mockOnCopyPermalink}
+        onSharePermalink={mockOnSharePermalink}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /^share$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^copy$/i })).toBeInTheDocument()
   })
 
   it('should call onCopyPermalink when permalink button is clicked on base scenario', async () => {
@@ -95,6 +114,52 @@ describe('ScenarioCard with Permalink', () => {
     }))
   })
 
+  it('should call onCopyPermalink when mobile copy button is clicked on base scenario', async () => {
+    mockOnCopyPermalink.mockResolvedValue({ success: true })
+    const user = userEvent.setup()
+
+    render(
+      <ScenarioCard
+        scenario={mockScenario}
+        index={0}
+        isBase={true}
+        onCopyPermalink={mockOnCopyPermalink}
+        onSharePermalink={mockOnSharePermalink}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /^copy$/i }))
+
+    expect(mockOnCopyPermalink).toHaveBeenCalledOnce()
+  })
+
+  it('should call onSharePermalink when mobile share button is clicked on base scenario', async () => {
+    mockOnSharePermalink.mockResolvedValue({ success: true })
+    const user = userEvent.setup()
+
+    render(
+      <ScenarioCard
+        scenario={mockScenario}
+        index={0}
+        isBase={true}
+        onCopyPermalink={mockOnCopyPermalink}
+        onSharePermalink={mockOnSharePermalink}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /^share$/i }))
+
+    expect(mockOnSharePermalink).toHaveBeenCalledOnce()
+    expect(mockOnSharePermalink).toHaveBeenCalledWith(expect.objectContaining({
+      postMoneyVal: mockScenario.postMoneyVal,
+      roundSize: mockScenario.roundSize,
+      investorPortion: mockScenario.investorAmount,
+      otherPortion: mockScenario.otherAmount,
+      investorName: 'US',
+      showAdvanced: false
+    }))
+  })
+
   it('should show success feedback after successful permalink copy', async () => {
     mockOnCopyPermalink.mockResolvedValue({ success: true })
     const user = userEvent.setup()
@@ -113,7 +178,7 @@ describe('ScenarioCard with Permalink', () => {
     await user.click(permalinkButton)
 
     await waitFor(() => {
-      expect(screen.getByText(/copied!/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/copied!/i).length).toBeGreaterThan(0)
     })
   })
 
@@ -154,7 +219,7 @@ describe('ScenarioCard with Permalink', () => {
     await user.click(permalinkButton)
 
     await waitFor(() => {
-      expect(screen.getByText(/failed to copy/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/failed to copy/i).length).toBeGreaterThan(0)
     })
   })
 

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -475,6 +475,46 @@ export async function copyPermalinkToClipboard(scenarioData) {
 }
 
 /**
+ * Shares a permalink through the native share sheet when available, falling
+ * back to clipboard copy for browsers that do not support Web Share.
+ * @param {Object} scenarioData - The scenario data to encode and share
+ * @returns {Promise<Object>} - Result object with success boolean and optional error
+ */
+export async function sharePermalink(scenarioData) {
+  try {
+    const permalink = generatePermalink(scenarioData)
+    const name = scenarioData?.name ? String(scenarioData.name).trim() : ''
+    const title = name ? `ValuFrame: ${name}` : 'ValuFrame scenario'
+    const text = 'Review this ValuFrame valuation scenario.'
+
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, text, url: permalink })
+        return {
+          success: true,
+          url: permalink
+        }
+      } catch {
+        const fallback = await copyPermalinkToClipboard(scenarioData)
+        return fallback.success
+          ? { ...fallback, fallback: true }
+          : fallback
+      }
+    }
+
+    const fallback = await copyPermalinkToClipboard(scenarioData)
+    return fallback.success
+      ? { ...fallback, fallback: true }
+      : fallback
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message
+    }
+  }
+}
+
+/**
  * Loads scenario data from current URL and clears the URL parameters
  * @returns {Object|null} - Loaded scenario data or null if not present/invalid
  */

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -4,6 +4,7 @@ import {
   decodeScenarioFromURL, 
   generatePermalink, 
   copyPermalinkToClipboard,
+  sharePermalink,
   isValidScenarioData 
 } from './permalink'
 
@@ -19,6 +20,14 @@ describe('Permalink Utilities', () => {
   const setExecCommand = (execCommand) => {
     Object.defineProperty(document, 'execCommand', {
       value: execCommand,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  const setNativeShare = (share) => {
+    Object.defineProperty(navigator, 'share', {
+      value: share,
       configurable: true,
       writable: true,
     })
@@ -55,6 +64,7 @@ describe('Permalink Utilities', () => {
     vi.clearAllMocks()
     setClipboard({ writeText: vi.fn(() => Promise.resolve()) })
     setExecCommand(undefined)
+    setNativeShare(undefined)
   })
 
   describe('encodeScenarioToURL', () => {
@@ -325,6 +335,61 @@ describe('Permalink Utilities', () => {
       expect(result.fallback).toBe(true)
       expect(mockWriteText).toHaveBeenCalledOnce()
       expect(mockExecCommand).toHaveBeenCalledWith('copy')
+    })
+  })
+
+  describe('sharePermalink', () => {
+    it('should use native share when available', async () => {
+      const mockShare = vi.fn(() => Promise.resolve())
+      setNativeShare(mockShare)
+
+      const result = await sharePermalink(mockScenario)
+
+      expect(result.success).toBe(true)
+      expect(mockShare).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'ValuFrame scenario',
+        text: expect.any(String),
+        url: expect.stringMatching(/^http:\/\/localhost:3000\/\?/)
+      }))
+    })
+
+    it('should fall back to clipboard copy when native share is unavailable', async () => {
+      const mockWriteText = vi.fn(() => Promise.resolve())
+      setNativeShare(undefined)
+      setClipboard({ writeText: mockWriteText })
+
+      const result = await sharePermalink(mockScenario)
+
+      expect(result.success).toBe(true)
+      expect(result.fallback).toBe(true)
+      expect(mockWriteText).toHaveBeenCalledOnce()
+    })
+
+    it('should fall back to clipboard copy when native share rejects', async () => {
+      const mockShare = vi.fn(() => Promise.reject(new Error('Share cancelled')))
+      const mockWriteText = vi.fn(() => Promise.resolve())
+      setNativeShare(mockShare)
+      setClipboard({ writeText: mockWriteText })
+
+      const result = await sharePermalink(mockScenario)
+
+      expect(result.success).toBe(true)
+      expect(result.fallback).toBe(true)
+      expect(mockShare).toHaveBeenCalledOnce()
+      expect(mockWriteText).toHaveBeenCalledOnce()
+    })
+
+    it('should return failure when native share and copy fallback fail', async () => {
+      setNativeShare(vi.fn(() => Promise.reject(new Error('Share cancelled'))))
+      setClipboard({
+        writeText: vi.fn(() => Promise.reject(new Error('Clipboard denied')))
+      })
+      setExecCommand(vi.fn(() => false))
+
+      const result = await sharePermalink(mockScenario)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Clipboard denied')
     })
   })
 


### PR DESCRIPTION
## Summary
- add a phone-only Results/Inputs/Scenarios/Exit bottom nav with results-first default
- add native Web Share permalink support with copy fallback and explicit mobile Share/Copy actions
- tighten mobile layout, tabs, cards, forms, and safe-area bottom spacing

## Tests
- npm run test:run
- npm run lint
- npm run build
- .conductor/run.sh smoke check via curl http://localhost:5173/