### PR TITLE
Restore single long scroll on iPhone

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1966,8 +1966,7 @@ body {
   align-items: center;
 }
 
-.mobile-share-btn,
-.mobile-bottom-nav {
+.mobile-share-btn {
   display: none;
 }
 
@@ -4656,7 +4655,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
   .app-main {
     padding: 0.75rem;
-    padding-bottom: calc(5.5rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
     overflow-x: hidden;
   }
 
@@ -4732,37 +4731,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     max-width: none;
     margin-bottom: 0.75rem;
     padding-inline: 0;
-  }
-
-  .top-row > .input-form,
-  .top-row > .base-result,
-  .top-row > .exit-math-module,
-  .mobile-scenarios-panel {
-    display: none;
-  }
-
-  .mobile-view-results .top-row > .base-result,
-  .mobile-view-inputs .top-row > .input-form,
-  .mobile-view-exit .top-row > .exit-math-module {
-    display: block;
-    width: 100%;
-  }
-
-  .mobile-view-results .top-row > .base-result {
-    display: flex;
-  }
-
-  .mobile-view-scenarios .top-row {
-    display: none;
-  }
-
-  .mobile-view-scenarios .mobile-scenarios-panel {
-    display: block;
-  }
-
-  .mobile-view-scenarios .scenarios-rows.mobile-scenarios-panel {
-    display: grid;
-    grid-template-columns: 1fr;
   }
 
   .base-result > .scenario-card,
@@ -4903,54 +4871,6 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   .mobile-share-btn:disabled {
     opacity: 0.72;
     cursor: not-allowed;
-  }
-
-  .mobile-bottom-nav {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 40;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.25rem;
-    padding: 0.45rem 0.55rem calc(0.45rem + env(safe-area-inset-bottom, 0px));
-    background: rgba(255, 255, 255, 0.96);
-    border-top: 1px solid var(--color-border);
-    box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.08);
-    backdrop-filter: blur(12px);
-  }
-
-  .mobile-bottom-nav button {
-    min-width: 0;
-    min-height: 48px;
-    padding: 0.35rem 0.25rem;
-    border: 1px solid transparent;
-    border-radius: 8px;
-    background: transparent;
-    color: var(--color-fg-subtle);
-    font: inherit;
-    font-size: 0.72rem;
-    font-weight: 700;
-    line-height: 1.1;
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.2rem;
-    cursor: pointer;
-  }
-
-  .mobile-bottom-nav button.active {
-    color: var(--color-accent-hover);
-    background: var(--color-accent-soft);
-    border-color: color-mix(in srgb, var(--color-accent) 28%, var(--color-border));
-  }
-
-  .mobile-nav-icon {
-    font-family: 'JetBrains Mono', 'Consolas', 'Monaco', monospace;
-    font-size: 0.9rem;
-    line-height: 1;
   }
 }
 

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -42,8 +42,6 @@ function App() {
   const [scenarios, setScenarios] = useState([])
   const [baseScenariosById, setBaseScenariosById] = useState({})
   const [tourActive, setTourActive] = useState(false)
-  const [mobileView, setMobileView] = useState('results')
-  const [isPhoneLayout, setIsPhoneLayout] = useState(false)
   const [tabActivity, setTabActivity] = useState(null)
   const [inputHighlightToken, setInputHighlightToken] = useState(0)
   const { notifications, removeNotification, showSuccess, showError } = useNotifications()
@@ -86,26 +84,9 @@ function App() {
     return result
   }
 
-  const handleMobileViewChange = (view) => {
-    if (view === 'exit') {
-      if (!companies[activeCompany]?.showExitMath) {
-        updateCompany(activeCompany, { showExitMath: true })
-      }
-      setMobileView('exit')
-      return
-    }
-
-    setMobileView(view)
-  }
-
   const toggleExitMath = () => {
     const next = !companies[activeCompany]?.showExitMath
     updateCompany(activeCompany, { showExitMath: next })
-    if (next) {
-      setMobileView('exit')
-    } else if (mobileView === 'exit') {
-      setMobileView('results')
-    }
   }
 
 
@@ -198,22 +179,6 @@ function App() {
   }
 
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return undefined
-
-    const media = window.matchMedia('(max-width: 768px)')
-    const update = () => setIsPhoneLayout(media.matches)
-    update()
-
-    if (typeof media.addEventListener === 'function') {
-      media.addEventListener('change', update)
-      return () => media.removeEventListener('change', update)
-    }
-
-    media.addListener(update)
-    return () => media.removeListener(update)
-  }, [])
-
-  useEffect(() => {
     const raw = JSON.stringify(storedCompanies)
     const normalized = JSON.stringify(companies)
 
@@ -260,7 +225,6 @@ function App() {
         }))
         setNextCompanyId(prev => prev + 1)
         setActiveCompany(newCompanyId)
-        setMobileView('results')
         showSuccess(decodedName
           ? `Loaded "${decodedName}" from shared link`
           : 'Loaded scenario from shared link')
@@ -364,12 +328,10 @@ function App() {
   const cardIds = isCompareMode ? compareIds : [activeCompany]
   const showExitMath = Boolean(companies[activeCompany]?.showExitMath)
   const advancedOpen = !isCompareMode && !showExitMath && Boolean(companies[activeCompany]?.showAdvanced)
-  const inputFormCollapsed = isPhoneLayout && mobileView === 'inputs'
-    ? false
-    : Boolean(companies[activeCompany]?.inputsCollapsed)
+  const inputFormCollapsed = Boolean(companies[activeCompany]?.inputsCollapsed)
 
   return (
-    <div className={`app mobile-view-${mobileView}`}>
+    <div className="app">
       <NotificationContainer
         notifications={notifications}
         onRemove={removeNotification}
@@ -512,45 +474,6 @@ function App() {
           </div>
         )}
       </main>
-
-      <nav className="mobile-bottom-nav" aria-label="Mobile sections">
-        <button
-          type="button"
-          className={mobileView === 'results' ? 'active' : ''}
-          onClick={() => handleMobileViewChange('results')}
-          aria-pressed={mobileView === 'results'}
-        >
-          <span className="mobile-nav-icon" aria-hidden="true">%</span>
-          <span>Results</span>
-        </button>
-        <button
-          type="button"
-          className={mobileView === 'inputs' ? 'active' : ''}
-          onClick={() => handleMobileViewChange('inputs')}
-          aria-pressed={mobileView === 'inputs'}
-        >
-          <span className="mobile-nav-icon" aria-hidden="true">$</span>
-          <span>Inputs</span>
-        </button>
-        <button
-          type="button"
-          className={mobileView === 'scenarios' ? 'active' : ''}
-          onClick={() => handleMobileViewChange('scenarios')}
-          aria-pressed={mobileView === 'scenarios'}
-        >
-          <span className="mobile-nav-icon" aria-hidden="true">±</span>
-          <span>Scenarios</span>
-        </button>
-        <button
-          type="button"
-          className={mobileView === 'exit' ? 'active' : ''}
-          onClick={() => handleMobileViewChange('exit')}
-          aria-pressed={mobileView === 'exit'}
-        >
-          <span className="mobile-nav-icon" aria-hidden="true">×</span>
-          <span>Exit</span>
-        </button>
-      </nav>
 
       <Walkthrough
         open={tourActive}

--- a/react-app/src/App.test.jsx
+++ b/react-app/src/App.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import App from './App'
 
 // Mock the child components to focus on App's permalink functionality
@@ -64,28 +63,6 @@ describe('App with Permalink Loading', () => {
     expect(screen.getByTestId('input-form')).toBeInTheDocument()
   })
 
-  it('should default the phone shell to results and switch sections from bottom nav', async () => {
-    const user = userEvent.setup()
-    const { container } = render(<App />)
-
-    expect(container.firstChild).toHaveClass('mobile-view-results')
-
-    await user.click(screen.getByRole('button', { name: /inputs/i }))
-
-    expect(container.firstChild).toHaveClass('mobile-view-inputs')
-    expect(screen.getByRole('button', { name: /inputs/i })).toHaveAttribute('aria-pressed', 'true')
-  })
-
-  it('should enable Exit Math when the phone Exit nav item is selected', async () => {
-    const user = userEvent.setup()
-    const { container } = render(<App />)
-
-    await user.click(screen.getByRole('button', { name: /^exit$/i }))
-
-    expect(container.firstChild).toHaveClass('mobile-view-exit')
-    expect(screen.getByRole('button', { name: /exit math/i })).toHaveAttribute('aria-pressed', 'true')
-  })
-
   it('should load scenario from URL parameters on mount', async () => {
     // Mock URL with scenario parameters
     Object.defineProperty(window, 'location', {
@@ -99,14 +76,13 @@ describe('App with Permalink Loading', () => {
       writable: true,
     })
 
-    const { container } = render(<App />)
+    render(<App />)
 
     await waitFor(() => {
       // Check that the input form received the loaded data
       const postMoneyInput = screen.getByTestId('post-money-input')
       expect(postMoneyInput.value).toBe('15')
     })
-    expect(container.firstChild).toHaveClass('mobile-view-results')
   })
 
   it('should handle invalid URL parameters gracefully', async () => {


### PR DESCRIPTION
## Summary
- Drops the mobile bottom-nav added in #41 that split the page into Results / Inputs / Scenarios / Exit panels — on iPhone this made each "view" show only one panel and the page felt stuck.
- Mobile now scrolls top-to-bottom like desktop, just stacked in one column. Mobile-friendly typography, padding, horizontal tabs, and the touch-friendly share buttons in `ScenarioCard` are kept.

## Test plan
- [x] `npx vitest run` — 396 passed
- [x] iPhone SE viewport (375×812) in headless Chromium: full page scrolls (3651px content), no fixed nav, share buttons render
- [ ] Verify on a real iPhone: scrolls all the way through tabs → input form → base scenario → alt scenarios → (exit math when toggled)
- [ ] Resize past 768px → desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)