### PR TITLE
Import cap tables and SAFE notes

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -4901,6 +4901,347 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   }
 }
 
+/* =======================================================================
+   Import Cap Table button + modal
+   ======================================================================= */
+
+.import-company-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  background: var(--color-bg);
+  color: var(--color-fg-muted);
+  border: none;
+  border-left: 1px solid var(--color-border);
+  padding: var(--space-2) var(--space-3);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast), gap 0.2s ease, padding 0.2s ease;
+}
+
+.import-company-btn:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  gap: 6px;
+  padding-right: var(--space-4);
+}
+
+.import-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--color-accent);
+}
+
+.import-text {
+  display: inline-block;
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease;
+}
+
+.import-company-btn:hover .import-text,
+.import-company-btn:focus-visible .import-text {
+  max-width: 120px;
+  opacity: 1;
+}
+
+.import-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 5vh 16px 16px;
+  z-index: 10500;
+  overflow-y: auto;
+  animation: import-modal-fade-in 0.18s ease-out;
+}
+
+@keyframes import-modal-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.import-modal {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35), 0 4px 12px rgba(15, 23, 42, 0.15);
+  border: 1px solid rgba(99, 91, 255, 0.18);
+  width: min(720px, 100%);
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: import-modal-slide-in 0.22s ease-out;
+}
+
+@keyframes import-modal-slide-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.import-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.import-modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-fg);
+}
+
+.import-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--color-fg-faint);
+  padding: 0 6px;
+  border-radius: 6px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.import-modal-close:hover {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.import-modal-intro {
+  margin: 14px 22px 12px;
+  font-size: 0.875rem;
+  color: var(--color-fg-muted);
+  line-height: 1.45;
+}
+
+.import-modal-prompts {
+  margin: 0 22px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.import-prompt-disclosure {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg);
+  overflow: hidden;
+}
+
+.import-prompt-disclosure.open {
+  border-color: rgba(99, 91, 255, 0.35);
+  background: var(--color-accent-soft);
+}
+
+.import-prompt-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 8px 6px;
+}
+
+.import-prompt-toggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--color-fg);
+  padding: 4px 6px;
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.import-prompt-toggle:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.import-prompt-title {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.import-prompt-description {
+  color: var(--color-fg-muted);
+  font-size: 0.8rem;
+  font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.import-prompt-copy {
+  flex: 0 0 auto;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--color-fg-muted);
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.import-prompt-copy:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-color: rgba(99, 91, 255, 0.4);
+}
+
+.import-prompt-body {
+  margin: 0;
+  padding: 12px 16px 14px;
+  background: #ffffff;
+  border-top: 1px solid var(--color-border);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--color-fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.import-modal-textarea-label {
+  margin: 4px 22px 6px;
+  font-size: 0.825rem;
+  font-weight: 600;
+  color: var(--color-fg-muted);
+}
+
+.import-modal-textarea {
+  margin: 0 22px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-height: 180px;
+  resize: vertical;
+  color: var(--color-fg);
+  background: #ffffff;
+}
+
+.import-modal-textarea:focus {
+  outline: none;
+  border-color: rgba(99, 91, 255, 0.5);
+  box-shadow: 0 0 0 3px rgba(99, 91, 255, 0.15);
+}
+
+.import-modal-errors,
+.import-modal-warnings {
+  margin: 4px 22px 8px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.import-modal-errors {
+  background: #fff1f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+
+.import-modal-warnings {
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+}
+
+.import-modal-errors ul,
+.import-modal-warnings ul {
+  margin: 4px 0 0;
+  padding-left: 20px;
+}
+
+.import-modal-errors li,
+.import-modal-warnings li {
+  margin: 2px 0;
+}
+
+.import-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 22px 18px;
+  border-top: 1px solid var(--color-border);
+  margin-top: auto;
+}
+
+.import-modal-btn {
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.import-modal-btn-secondary {
+  background: var(--color-bg);
+  color: var(--color-fg-muted);
+  border-color: var(--color-border);
+}
+
+.import-modal-btn-secondary:hover {
+  background: var(--color-bg-muted);
+  color: var(--color-fg);
+}
+
+.import-modal-btn-primary {
+  background: #635bff;
+  color: #ffffff;
+  border-color: #635bff;
+}
+
+.import-modal-btn-primary:hover:not(:disabled) {
+  background: #4f46e5;
+  border-color: #4f46e5;
+}
+
+.import-modal-btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .import-modal-backdrop {
+    padding: 0;
+  }
+  .import-modal {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+  .import-prompt-description {
+    display: none;
+  }
+}
+
 /* Honor users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -3705,7 +3705,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
     flex-direction: column;
   }
   .tabs-actions > .add-company-btn,
-  .tabs-actions > .load-example-btn {
+  .tabs-actions > .load-example-btn,
+  .tabs-actions > .import-company-btn {
     width: 100%;
     justify-content: center;
     border-left: none;
@@ -4706,7 +4707,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
   .compare-count-chip,
   .tabs-actions > .load-example-btn,
-  .tabs-actions > .add-company-btn {
+  .tabs-actions > .add-company-btn,
+  .tabs-actions > .import-company-btn {
     width: auto;
     border-top: none;
     border-left: 1px solid var(--color-border);

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -4931,6 +4931,15 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   padding-right: var(--space-4);
 }
 
+.import-company-btn:focus-visible {
+  outline: 2px solid rgba(99, 91, 255, 0.45);
+  outline-offset: -2px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  gap: 6px;
+  padding-right: var(--space-4);
+}
+
 .import-icon {
   display: inline-flex;
   align-items: center;
@@ -5019,6 +5028,14 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .import-modal-close:hover {
   background: var(--color-bg-muted);
   color: var(--color-fg);
+}
+
+.import-modal-close:focus-visible,
+.import-prompt-toggle:focus-visible,
+.import-prompt-copy:focus-visible,
+.import-modal-btn:focus-visible {
+  outline: 2px solid rgba(99, 91, 255, 0.45);
+  outline-offset: 2px;
 }
 
 .import-modal-intro {
@@ -5181,6 +5198,57 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .import-modal-errors li,
 .import-modal-warnings li {
   margin: 2px 0;
+}
+
+.import-modal-destination {
+  margin: 4px 22px 8px;
+  padding: 12px 14px;
+  border: 1px solid rgba(99, 91, 255, 0.28);
+  border-radius: 8px;
+  background: var(--color-accent-soft);
+  color: var(--color-fg);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.import-modal-destination p {
+  margin: 2px 0 10px;
+  color: var(--color-fg-muted);
+}
+
+.import-destination-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.65);
+  cursor: pointer;
+}
+
+.import-destination-option + .import-destination-option {
+  margin-top: 6px;
+}
+
+.import-destination-option:hover {
+  border-color: rgba(99, 91, 255, 0.24);
+  background: #ffffff;
+}
+
+.import-destination-option input {
+  flex: 0 0 auto;
+  accent-color: #635bff;
+}
+
+.import-destination-option:has(input:checked) {
+  border-color: rgba(99, 91, 255, 0.45);
+  background: #ffffff;
+}
+
+.import-destination-option:has(input:focus-visible) {
+  outline: 2px solid rgba(99, 91, 255, 0.45);
+  outline-offset: 2px;
 }
 
 .import-modal-actions {

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -30,6 +30,10 @@ function getNextCompanyNumber(companies) {
   return Math.max(2, maxExisting + 1)
 }
 
+function formatSafeCount(count) {
+  return `${count} SAFE${count === 1 ? '' : 's'}`
+}
+
 function App() {
   const [storedCompanies, setStoredCompanies] = useLocalStorage('valuationFramework', {
     company1: createDefaultCompany('Scenario 1')
@@ -103,12 +107,43 @@ function App() {
     setTabActivity({ companyId: newCompanyId, type: 'add', nonce: Date.now() })
   }
 
-  const handleImportCompany = (importedCompany) => {
+  const handleImportCompany = (importResult) => {
+    const importKind = importResult?.importKind || 'company'
+    const importedCompany = importResult?.company || importResult
+    const importedSafes = importResult?.safes || importedCompany?.safes || []
+
+    if (importKind === 'safe-only' && importResult?.destination === 'append') {
+      const safeCount = importedSafes.length
+      if (safeCount === 0) {
+        showError('No SAFEs found to import', 2200)
+        return
+      }
+
+      const activeName = companies[activeCompany]?.name || 'active scenario'
+      setStoredCompanies(prev => {
+        const normalizedPrev = normalizeStoredCompanies(prev)
+        const currentCompany = normalizedPrev[activeCompany]
+        if (!currentCompany) return normalizedPrev
+        return {
+          ...normalizedPrev,
+          [activeCompany]: {
+            ...currentCompany,
+            safes: [...(currentCompany.safes || []), ...importedSafes]
+          }
+        }
+      })
+      setInputHighlightToken(Date.now())
+      setImportModalOpen(false)
+      showSuccess(`Appended ${formatSafeCount(safeCount)} to "${activeName}"`, 2200)
+      return
+    }
+
     const desiredName = (importedCompany?.name || '').trim() || 'Imported Scenario'
     const existingNames = new Set(Object.values(companies).map(c => c?.name))
     const finalName = existingNames.has(desiredName)
       ? nextUniqueName(desiredName, companies)
       : desiredName
+    const safeCount = importKind === 'safe-only' ? importedSafes.length : null
 
     const newCompanyId = `company${nextCompanyId}`
     setStoredCompanies(prev => ({
@@ -119,7 +154,12 @@ function App() {
     setNextCompanyId(prev => prev + 1)
     setTabActivity({ companyId: newCompanyId, type: 'add', nonce: Date.now() })
     setImportModalOpen(false)
-    showSuccess(`Imported "${finalName}"`, 2200)
+    showSuccess(
+      safeCount === null
+        ? `Imported "${finalName}"`
+        : `Imported "${finalName}" with ${formatSafeCount(safeCount)}`,
+      2200
+    )
   }
 
   const ensureExample = useCallback(() => {
@@ -506,6 +546,7 @@ function App() {
 
       <ImportModal
         open={importModalOpen}
+        activeCompanyName={companies[activeCompany]?.name || 'active scenario'}
         onClose={() => setImportModalOpen(false)}
         onImport={handleImportCompany}
         onShowSuccess={showSuccess}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -8,6 +8,7 @@ import Logo from './components/Logo'
 import NotificationContainer from './components/NotificationContainer'
 import ExitMathModule from './components/ExitMathModule'
 import Walkthrough from './components/Walkthrough'
+import ImportModal from './components/ImportModal'
 import { useLocalStorage } from './hooks/useLocalStorage'
 import { useNotifications } from './hooks/useNotifications'
 import { calculateEnhancedScenarios } from './utils/multiPartyCalculations'
@@ -44,6 +45,7 @@ function App() {
   const [tourActive, setTourActive] = useState(false)
   const [tabActivity, setTabActivity] = useState(null)
   const [inputHighlightToken, setInputHighlightToken] = useState(0)
+  const [importModalOpen, setImportModalOpen] = useState(false)
   const { notifications, removeNotification, showSuccess, showError } = useNotifications()
 
   const updateCompany = useCallback((companyId, data) => {
@@ -99,6 +101,25 @@ function App() {
     setActiveCompany(newCompanyId)
     setNextCompanyId(prev => prev + 1)
     setTabActivity({ companyId: newCompanyId, type: 'add', nonce: Date.now() })
+  }
+
+  const handleImportCompany = (importedCompany) => {
+    const desiredName = (importedCompany?.name || '').trim() || 'Imported Scenario'
+    const existingNames = new Set(Object.values(companies).map(c => c?.name))
+    const finalName = existingNames.has(desiredName)
+      ? nextUniqueName(desiredName, companies)
+      : desiredName
+
+    const newCompanyId = `company${nextCompanyId}`
+    setStoredCompanies(prev => ({
+      ...normalizeStoredCompanies(prev),
+      [newCompanyId]: { ...importedCompany, name: finalName }
+    }))
+    setActiveCompany(newCompanyId)
+    setNextCompanyId(prev => prev + 1)
+    setTabActivity({ companyId: newCompanyId, type: 'add', nonce: Date.now() })
+    setImportModalOpen(false)
+    showSuccess(`Imported "${finalName}"`, 2200)
   }
 
   const ensureExample = useCallback(() => {
@@ -371,6 +392,7 @@ function App() {
           onUpdateCompany={updateCompany}
           onDuplicateCompany={duplicateCompany}
           onLoadExample={loadExample}
+          onImportCompany={() => setImportModalOpen(true)}
           selectedCompanyIds={selectedCompanyIds}
           onToggleCompareSelection={toggleCompareSelection}
           tabActivity={tabActivity}
@@ -480,6 +502,14 @@ function App() {
         steps={tourSteps}
         onClose={closeTour}
         onComplete={closeTour}
+      />
+
+      <ImportModal
+        open={importModalOpen}
+        onClose={() => setImportModalOpen(false)}
+        onImport={handleImportCompany}
+        onShowSuccess={showSuccess}
+        onShowError={showError}
       />
     </div>
   )

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import App from './App'
 
 describe('App Component - Local Storage Integration', () => {
   beforeEach(() => {
     // Clear localStorage before each test
     window.localStorage.clear()
+    window.localStorage.setItem('valuationFrameworkTourSeen', '1')
     
     // Mock console.error to suppress expected error logs during testing
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -282,6 +284,94 @@ describe('App Component - Local Storage Integration', () => {
       
       // Should handle unicode gracefully
       expect(screen.getByText('测试公司 🚀')).toBeInTheDocument()
+    })
+  })
+
+  describe('Import Integration', () => {
+    it('should append SAFE-only imports to the active company', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem('valuationFramework', JSON.stringify({
+        company1: {
+          name: 'Active Scenario',
+          postMoneyVal: 20,
+          roundSize: 5,
+          investorPortion: 4,
+          otherPortion: 1,
+          investorName: 'US',
+          showAdvanced: true,
+          founders: [{ name: 'Founder Team', ownershipPercent: 85 }],
+          priorInvestors: [{ name: 'Seed Investors', ownershipPercent: 15 }],
+          safes: [],
+          currentEsopPercent: 0,
+          targetEsopPercent: 0,
+          esopTiming: 'pre-close'
+        }
+      }))
+
+      render(<App />)
+
+      await user.click(screen.getByRole('button', { name: /import/i }))
+      fireEvent.change(screen.getByLabelText(/paste json/i), {
+        target: {
+          value: JSON.stringify({
+            safes: [{ investorName: 'Bridge Investor', amount: 1, cap: 20 }]
+          })
+        }
+      })
+      await user.click(
+        within(screen.getByRole('dialog', { name: /import cap table/i }))
+          .getByRole('button', { name: 'Import' })
+      )
+      await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('valuationFramework'))
+        expect(stored.company1.safes).toHaveLength(1)
+        expect(stored.company1.safes[0].investorName).toBe('Bridge Investor')
+      })
+    })
+
+    it('should create a uniquely named scenario for full cap-table imports', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem('valuationFramework', JSON.stringify({
+        company1: {
+          name: 'Acme',
+          postMoneyVal: 13,
+          roundSize: 3,
+          investorPortion: 2.75,
+          otherPortion: 0.25,
+          investorName: 'US',
+          showAdvanced: true,
+          founders: [{ name: 'Founder Team', ownershipPercent: 85 }],
+          priorInvestors: [{ name: 'Seed Investors', ownershipPercent: 15 }],
+          safes: [],
+          currentEsopPercent: 0,
+          targetEsopPercent: 0,
+          esopTiming: 'pre-close'
+        }
+      }))
+
+      render(<App />)
+
+      await user.click(screen.getByRole('button', { name: /import/i }))
+      fireEvent.change(screen.getByLabelText(/paste json/i), {
+        target: {
+          value: JSON.stringify({
+            name: 'Acme',
+            founders: [{ name: 'CEO', ownershipPercent: 80 }],
+            priorInvestors: [{ name: 'Seed Fund', ownershipPercent: 20 }]
+          })
+        }
+      })
+      await user.click(
+        within(screen.getByRole('dialog', { name: /import cap table/i }))
+          .getByRole('button', { name: 'Import' })
+      )
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('valuationFramework'))
+        expect(Object.values(stored).map(company => company.name)).toContain('Acme 2')
+      })
     })
   })
 })

--- a/react-app/src/components/CompanyTabs.jsx
+++ b/react-app/src/components/CompanyTabs.jsx
@@ -9,6 +9,7 @@ const CompanyTabs = ({
   onUpdateCompany,
   onDuplicateCompany,
   onLoadExample,
+  onImportCompany,
   selectedCompanyIds = [],
   onToggleCompareSelection,
   tabActivity,
@@ -248,6 +249,17 @@ const CompanyTabs = ({
             >
               <span className="load-example-icon" aria-hidden="true">★</span>
               <span className="load-example-text">Load Example</span>
+            </button>
+          )}
+          {onImportCompany && (
+            <button
+              type="button"
+              className="import-company-btn"
+              onClick={onImportCompany}
+              title="Import a cap table from JSON (paste the output of the Claude prompt)"
+            >
+              <span className="import-icon" aria-hidden="true">⇪</span>
+              <span className="import-text">Import</span>
             </button>
           )}
           <button className="add-company-btn" onClick={onAddCompany} title="Add new scenario">

--- a/react-app/src/components/ImportModal.jsx
+++ b/react-app/src/components/ImportModal.jsx
@@ -2,12 +2,17 @@ import { useEffect, useRef, useState } from 'react'
 import { parseImportJson } from '../utils/importCompany'
 import { XLS_IMPORT_PROMPT, SAFE_PDF_IMPORT_PROMPT } from '../utils/importPrompts'
 
-function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
+function formatSafeCount(count) {
+  return `${count} SAFE${count === 1 ? '' : 's'}`
+}
+
+function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onImport, onShowError, onShowSuccess }) {
   const [jsonText, setJsonText] = useState('')
   const [errors, setErrors] = useState([])
   // pendingPreview holds a validated result so the user can review warnings
   // before committing the import.
   const [pendingPreview, setPendingPreview] = useState(null)
+  const [safeDestination, setSafeDestination] = useState('append')
   const [openPrompt, setOpenPrompt] = useState(null) // 'xls' | 'safe' | null
   const [copiedPrompt, setCopiedPrompt] = useState(null)
   const textareaRef = useRef(null)
@@ -18,6 +23,7 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
       setJsonText('')
       setErrors([])
       setPendingPreview(null)
+      setSafeDestination('append')
       setOpenPrompt(null)
       setCopiedPrompt(null)
     }
@@ -28,6 +34,7 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
   useEffect(() => {
     if (pendingPreview && pendingPreview.sourceText !== jsonText) {
       setPendingPreview(null)
+      setSafeDestination('append')
     }
   }, [jsonText, pendingPreview])
 
@@ -48,10 +55,23 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
 
   if (!open) return null
 
+  const commitImport = (result, destination) => {
+    onImport({
+      importKind: result.importKind,
+      company: result.company,
+      safes: result.safes || [],
+      warnings: result.warnings || [],
+      destination
+    })
+  }
+
   const handleImport = () => {
     // Two-step UX so the user can review warnings before committing.
     if (pendingPreview && pendingPreview.sourceText === jsonText) {
-      onImport(pendingPreview.company, pendingPreview.warnings)
+      commitImport(
+        pendingPreview,
+        pendingPreview.importKind === 'safe-only' ? safeDestination : 'new'
+      )
       return
     }
     const result = parseImportJson(jsonText)
@@ -62,11 +82,16 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
     }
     setErrors([])
     const warnings = result.warnings || []
-    if (warnings.length === 0) {
-      onImport(result.company, [])
+    if (result.importKind === 'safe-only') {
+      setSafeDestination('append')
+      setPendingPreview({ ...result, warnings, sourceText: jsonText })
       return
     }
-    setPendingPreview({ company: result.company, warnings, sourceText: jsonText })
+    if (warnings.length === 0) {
+      commitImport(result, 'new')
+      return
+    }
+    setPendingPreview({ ...result, warnings, sourceText: jsonText })
   }
 
   const handleCopyPrompt = async (kind, text) => {
@@ -83,6 +108,16 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
   const handleBackdropClick = (e) => {
     if (e.target === e.currentTarget) onClose()
   }
+
+  const isSafeOnlyPreview = pendingPreview?.importKind === 'safe-only'
+  const previewSafeCount = pendingPreview?.safes?.length || 0
+  const importButtonLabel = pendingPreview && pendingPreview.sourceText === jsonText
+    ? isSafeOnlyPreview
+      ? safeDestination === 'append'
+        ? `Append ${formatSafeCount(previewSafeCount)}`
+        : 'Create scenario'
+      : 'Import anyway'
+    : 'Import'
 
   return (
     <div className="import-modal-backdrop" onClick={handleBackdropClick}>
@@ -163,6 +198,35 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
           </div>
         )}
 
+        {isSafeOnlyPreview && (
+          <div className="import-modal-destination" role="group" aria-labelledby="import-destination-title">
+            <strong id="import-destination-title">Found {formatSafeCount(previewSafeCount)}</strong>
+            <p>Choose where to import these SAFE notes.</p>
+            <label className="import-destination-option">
+              <input
+                type="radio"
+                name="safe-import-destination"
+                value="append"
+                checked={safeDestination === 'append'}
+                onChange={() => setSafeDestination('append')}
+              />
+              <span>
+                Append to <strong>{activeCompanyName}</strong>
+              </span>
+            </label>
+            <label className="import-destination-option">
+              <input
+                type="radio"
+                name="safe-import-destination"
+                value="new"
+                checked={safeDestination === 'new'}
+                onChange={() => setSafeDestination('new')}
+              />
+              <span>Create a new imported scenario</span>
+            </label>
+          </div>
+        )}
+
         <div className="import-modal-actions">
           <button
             type="button"
@@ -177,7 +241,7 @@ function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
             onClick={handleImport}
             disabled={jsonText.trim() === ''}
           >
-            {pendingPreview && pendingPreview.sourceText === jsonText ? 'Import anyway' : 'Import'}
+            {importButtonLabel}
           </button>
         </div>
       </div>

--- a/react-app/src/components/ImportModal.jsx
+++ b/react-app/src/components/ImportModal.jsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from 'react'
+import { parseImportJson } from '../utils/importCompany'
+import { XLS_IMPORT_PROMPT, SAFE_PDF_IMPORT_PROMPT } from '../utils/importPrompts'
+
+function ImportModal({ open, onClose, onImport, onShowError, onShowSuccess }) {
+  const [jsonText, setJsonText] = useState('')
+  const [errors, setErrors] = useState([])
+  // pendingPreview holds a validated result so the user can review warnings
+  // before committing the import.
+  const [pendingPreview, setPendingPreview] = useState(null)
+  const [openPrompt, setOpenPrompt] = useState(null) // 'xls' | 'safe' | null
+  const [copiedPrompt, setCopiedPrompt] = useState(null)
+  const textareaRef = useRef(null)
+  const closeBtnRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) {
+      setJsonText('')
+      setErrors([])
+      setPendingPreview(null)
+      setOpenPrompt(null)
+      setCopiedPrompt(null)
+    }
+  }, [open])
+
+  // If the user edits the textarea after a validation, drop the pending preview
+  // so they revalidate.
+  useEffect(() => {
+    if (pendingPreview && pendingPreview.sourceText !== jsonText) {
+      setPendingPreview(null)
+    }
+  }, [jsonText, pendingPreview])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (open && textareaRef.current) {
+      setTimeout(() => textareaRef.current?.focus(), 50)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleImport = () => {
+    // Two-step UX so the user can review warnings before committing.
+    if (pendingPreview && pendingPreview.sourceText === jsonText) {
+      onImport(pendingPreview.company, pendingPreview.warnings)
+      return
+    }
+    const result = parseImportJson(jsonText)
+    if (!result.ok) {
+      setErrors(result.errors)
+      setPendingPreview(null)
+      return
+    }
+    setErrors([])
+    const warnings = result.warnings || []
+    if (warnings.length === 0) {
+      onImport(result.company, [])
+      return
+    }
+    setPendingPreview({ company: result.company, warnings, sourceText: jsonText })
+  }
+
+  const handleCopyPrompt = async (kind, text) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedPrompt(kind)
+      setTimeout(() => setCopiedPrompt((c) => (c === kind ? null : c)), 1500)
+      onShowSuccess?.('Prompt copied to clipboard', 1500)
+    } catch {
+      onShowError?.('Could not copy — your browser blocked clipboard access', 2200)
+    }
+  }
+
+  const handleBackdropClick = (e) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div className="import-modal-backdrop" onClick={handleBackdropClick}>
+      <div
+        className="import-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="import-modal-title"
+      >
+        <div className="import-modal-header">
+          <h2 id="import-modal-title">Import cap table</h2>
+          <button
+            type="button"
+            className="import-modal-close"
+            onClick={onClose}
+            ref={closeBtnRef}
+            aria-label="Close import dialog"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="import-modal-intro">
+          Paste a JSON cap table below. Get one by sending your XLS or SAFE PDF to Claude with the prompt below.
+        </p>
+
+        <div className="import-modal-prompts">
+          <PromptDisclosure
+            kind="xls"
+            title="Prompt for XLS cap tables"
+            description="Use with the company's cap table spreadsheet."
+            prompt={XLS_IMPORT_PROMPT}
+            isOpen={openPrompt === 'xls'}
+            isCopied={copiedPrompt === 'xls'}
+            onToggle={() => setOpenPrompt((p) => (p === 'xls' ? null : 'xls'))}
+            onCopy={() => handleCopyPrompt('xls', XLS_IMPORT_PROMPT)}
+          />
+          <PromptDisclosure
+            kind="safe"
+            title="Prompt for SAFE PDFs"
+            description="Use with one or more SAFE PDFs attached."
+            prompt={SAFE_PDF_IMPORT_PROMPT}
+            isOpen={openPrompt === 'safe'}
+            isCopied={copiedPrompt === 'safe'}
+            onToggle={() => setOpenPrompt((p) => (p === 'safe' ? null : 'safe'))}
+            onCopy={() => handleCopyPrompt('safe', SAFE_PDF_IMPORT_PROMPT)}
+          />
+        </div>
+
+        <label className="import-modal-textarea-label" htmlFor="import-json-textarea">
+          Paste JSON
+        </label>
+        <textarea
+          id="import-json-textarea"
+          ref={textareaRef}
+          className="import-modal-textarea"
+          value={jsonText}
+          onChange={(e) => setJsonText(e.target.value)}
+          placeholder={'{\n  "name": "Acme",\n  "founders": [ ... ],\n  "priorInvestors": [ ... ],\n  "safes": [ ... ]\n}'}
+          spellCheck={false}
+        />
+
+        {errors.length > 0 && (
+          <div className="import-modal-errors" role="alert">
+            <strong>Couldn&rsquo;t import:</strong>
+            <ul>
+              {errors.map((e, i) => <li key={i}>{e}</li>)}
+            </ul>
+          </div>
+        )}
+
+        {pendingPreview && pendingPreview.warnings.length > 0 && (
+          <div className="import-modal-warnings">
+            <strong>Looks good — but check these before importing:</strong>
+            <ul>
+              {pendingPreview.warnings.map((w, i) => <li key={i}>{w}</li>)}
+            </ul>
+          </div>
+        )}
+
+        <div className="import-modal-actions">
+          <button
+            type="button"
+            className="import-modal-btn import-modal-btn-secondary"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="import-modal-btn import-modal-btn-primary"
+            onClick={handleImport}
+            disabled={jsonText.trim() === ''}
+          >
+            {pendingPreview && pendingPreview.sourceText === jsonText ? 'Import anyway' : 'Import'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PromptDisclosure({ title, description, prompt, isOpen, isCopied, onToggle, onCopy }) {
+  return (
+    <div className={`import-prompt-disclosure${isOpen ? ' open' : ''}`}>
+      <div className="import-prompt-header">
+        <button
+          type="button"
+          className="import-prompt-toggle"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+        >
+          <span className={`chevron-icon${isOpen ? '' : ' is-collapsed'}`}>▼</span>
+          <span className="import-prompt-title">{title}</span>
+          <span className="import-prompt-description">{description}</span>
+        </button>
+        <button
+          type="button"
+          className="import-prompt-copy"
+          onClick={onCopy}
+          title="Copy prompt to clipboard"
+        >
+          {isCopied ? '✓ Copied' : 'Copy'}
+        </button>
+      </div>
+      {isOpen && (
+        <pre className="import-prompt-body">{prompt}</pre>
+      )}
+    </div>
+  )
+}
+
+export default ImportModal

--- a/react-app/src/components/ImportModal.test.jsx
+++ b/react-app/src/components/ImportModal.test.jsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ImportModal from './ImportModal'
+
+function renderImportModal(props = {}) {
+  const user = userEvent.setup()
+  const onImport = vi.fn()
+  const onClose = vi.fn()
+  render(
+    <ImportModal
+      open={true}
+      activeCompanyName="Scenario 1"
+      onClose={onClose}
+      onImport={onImport}
+      onShowError={vi.fn()}
+      onShowSuccess={vi.fn()}
+      {...props}
+    />
+  )
+  return { user, onImport, onClose }
+}
+
+function pasteJson(payload) {
+  fireEvent.change(screen.getByLabelText(/paste json/i), {
+    target: {
+      value: typeof payload === 'string' ? payload : JSON.stringify(payload)
+    }
+  })
+}
+
+describe('ImportModal', () => {
+  it('shows malformed JSON errors without importing', async () => {
+    const { user, onImport } = renderImportModal()
+
+    pasteJson('{ not json')
+    await user.click(screen.getByRole('button', { name: 'Import' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/invalid json/i)
+    expect(onImport).not.toHaveBeenCalled()
+  })
+
+  it('imports full cap-table JSON as a new scenario', async () => {
+    const { user, onImport } = renderImportModal()
+
+    pasteJson({
+      name: 'Acme',
+      founders: [{ name: 'Founder Team', ownershipPercent: 85 }],
+      priorInvestors: [{ name: 'Seed Investors', ownershipPercent: 15 }]
+    })
+    await user.click(screen.getByRole('button', { name: 'Import' }))
+
+    expect(onImport).toHaveBeenCalledWith(expect.objectContaining({
+      importKind: 'company',
+      destination: 'new',
+      company: expect.objectContaining({ name: 'Acme' })
+    }))
+  })
+
+  it('previews SAFE-only JSON and appends to the active scenario by default', async () => {
+    const { user, onImport } = renderImportModal()
+
+    pasteJson({
+      safes: [{ investorName: 'Bridge Investor', amount: 1, cap: 20 }]
+    })
+    await user.click(screen.getByRole('button', { name: 'Import' }))
+
+    expect(screen.getByText('Found 1 SAFE')).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /append to scenario 1/i })).toBeChecked()
+    expect(onImport).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
+
+    expect(onImport).toHaveBeenCalledWith(expect.objectContaining({
+      importKind: 'safe-only',
+      destination: 'append',
+      safes: [expect.objectContaining({ investorName: 'Bridge Investor' })]
+    }))
+  })
+
+  it('can create a new scenario from SAFE-only JSON', async () => {
+    const { user, onImport } = renderImportModal()
+
+    pasteJson({
+      safes: [
+        { investorName: 'Bridge Investor', amount: 1, cap: 20 },
+        { investorName: 'Angel', amount: 0.5, discount: 20 }
+      ]
+    })
+    await user.click(screen.getByRole('button', { name: 'Import' }))
+    await user.click(screen.getByRole('radio', { name: /create a new imported scenario/i }))
+    await user.click(screen.getByRole('button', { name: 'Create scenario' }))
+
+    expect(onImport).toHaveBeenCalledWith(expect.objectContaining({
+      importKind: 'safe-only',
+      destination: 'new',
+      safes: [
+        expect.objectContaining({ investorName: 'Bridge Investor' }),
+        expect.objectContaining({ investorName: 'Angel' })
+      ]
+    }))
+  })
+})

--- a/react-app/src/utils/importCompany.js
+++ b/react-app/src/utils/importCompany.js
@@ -1,0 +1,228 @@
+import { migrateLegacyCompany } from './dataStructures'
+
+// Fields with these names are stripped before normalization. Claude is asked
+// to attach `_safeType` and `_notes` to SAFEs as metadata for the human user,
+// and may emit a top-level `_warning` if the cap table looked off. We surface
+// those as warnings but never persist them on the company.
+const STRIP_KEYS = new Set(['_safeType', '_notes', '_warning'])
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function getNumber(value) {
+  if (value === null || value === undefined || value === '') return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function checkPercent(label, value, errors) {
+  if (value === null || value === undefined || value === '') return
+  const n = Number(value)
+  if (!Number.isFinite(n)) {
+    errors.push(`${label} is not a number (got ${JSON.stringify(value)})`)
+    return
+  }
+  if (n < 0 || n > 100) {
+    errors.push(`${label} = ${n} is outside 0–100`)
+  }
+}
+
+function checkNonNegative(label, value, errors) {
+  if (value === null || value === undefined || value === '') return
+  const n = Number(value)
+  if (!Number.isFinite(n)) {
+    errors.push(`${label} is not a number (got ${JSON.stringify(value)})`)
+    return
+  }
+  if (n < 0) {
+    errors.push(`${label} = ${n} is negative`)
+  }
+}
+
+// Hard validation — runs before normalization. Returns an array of error strings.
+function hardValidate(raw) {
+  const errors = []
+
+  if (!isPlainObject(raw)) {
+    errors.push('Top-level JSON must be an object')
+    return errors
+  }
+
+  if (typeof raw.name === 'string') {
+    if (raw.name.trim() === '') errors.push('"name" must not be empty')
+  } else if (raw.name !== undefined) {
+    errors.push('"name" must be a string')
+  }
+
+  checkNonNegative('postMoneyVal', raw.postMoneyVal ?? raw.postMoney, errors)
+  checkNonNegative('roundSize', raw.roundSize ?? raw.round, errors)
+  checkNonNegative('investorPortion', raw.investorPortion ?? raw.investor, errors)
+  checkNonNegative('otherPortion', raw.otherPortion ?? raw.other, errors)
+  checkPercent('currentEsopPercent', raw.currentEsopPercent, errors)
+  checkPercent('grantedEsopPercent', raw.grantedEsopPercent, errors)
+  checkPercent('targetEsopPercent', raw.targetEsopPercent, errors)
+
+  if (raw.founders !== undefined) {
+    if (!Array.isArray(raw.founders)) {
+      errors.push('"founders" must be an array')
+    } else {
+      raw.founders.forEach((f, i) => {
+        if (!isPlainObject(f)) {
+          errors.push(`founders[${i}] must be an object`)
+          return
+        }
+        checkPercent(`founders[${i}].ownershipPercent`, f.ownershipPercent, errors)
+      })
+    }
+  }
+
+  if (raw.priorInvestors !== undefined) {
+    if (!Array.isArray(raw.priorInvestors)) {
+      errors.push('"priorInvestors" must be an array')
+    } else {
+      raw.priorInvestors.forEach((p, i) => {
+        if (!isPlainObject(p)) {
+          errors.push(`priorInvestors[${i}] must be an object`)
+          return
+        }
+        checkPercent(`priorInvestors[${i}].ownershipPercent`, p.ownershipPercent, errors)
+        if (p.proRataOverride !== null) {
+          checkNonNegative(`priorInvestors[${i}].proRataOverride`, p.proRataOverride, errors)
+        }
+      })
+    }
+  }
+
+  if (raw.safes !== undefined) {
+    if (!Array.isArray(raw.safes)) {
+      errors.push('"safes" must be an array')
+    } else {
+      raw.safes.forEach((s, i) => {
+        if (!isPlainObject(s)) {
+          errors.push(`safes[${i}] must be an object`)
+          return
+        }
+        checkNonNegative(`safes[${i}].amount`, s.amount, errors)
+        checkNonNegative(`safes[${i}].cap`, s.cap, errors)
+        checkPercent(`safes[${i}].discount`, s.discount, errors)
+      })
+    }
+  }
+
+  if (raw.warrants !== undefined) {
+    if (!Array.isArray(raw.warrants)) {
+      errors.push('"warrants" must be an array')
+    } else {
+      raw.warrants.forEach((w, i) => {
+        if (!isPlainObject(w)) {
+          errors.push(`warrants[${i}] must be an object`)
+          return
+        }
+        checkNonNegative(`warrants[${i}].amount`, w.amount, errors)
+        checkNonNegative(`warrants[${i}].valuation`, w.valuation, errors)
+      })
+    }
+  }
+
+  return errors
+}
+
+// Pull out non-schema metadata Claude may attach (notes, warnings, safe type),
+// returning the cleaned object plus a list of human-readable warning strings.
+function extractMetadata(raw) {
+  const warnings = []
+
+  if (typeof raw._warning === 'string' && raw._warning.trim()) {
+    warnings.push(`Claude flagged: ${raw._warning.trim()}`)
+  }
+
+  const cleaned = { ...raw }
+  for (const key of STRIP_KEYS) delete cleaned[key]
+
+  if (Array.isArray(cleaned.safes)) {
+    cleaned.safes = cleaned.safes.map((s, i) => {
+      if (!isPlainObject(s)) return s
+      const label = (s.investorName || `SAFE #${i + 1}`).trim() || `SAFE #${i + 1}`
+      if (typeof s._notes === 'string' && s._notes.trim()) {
+        warnings.push(`${label}: ${s._notes.trim()}`)
+      }
+      if (s._safeType === 'pre-money') {
+        warnings.push(`${label}: pre-money SAFE — conversion math in this app assumes post-money SAFEs, so the dilution is approximate.`)
+      }
+      const stripped = { ...s }
+      for (const key of STRIP_KEYS) delete stripped[key]
+      return stripped
+    })
+  }
+
+  return { cleaned, warnings }
+}
+
+// Soft warnings — surfaced in the modal but don't block import.
+function softWarnings(company) {
+  const warnings = []
+
+  const founderTotal = (company.founders || []).reduce((s, f) => s + (Number(f.ownershipPercent) || 0), 0)
+  const priorTotal = (company.priorInvestors || []).reduce((s, p) => s + (Number(p.ownershipPercent) || 0), 0)
+  const total = founderTotal + priorTotal + (Number(company.currentEsopPercent) || 0)
+
+  if (founderTotal + priorTotal > 100) {
+    warnings.push(`Founders + prior investors = ${(founderTotal + priorTotal).toFixed(1)}% (over 100%). Calc engine will auto-scale.`)
+  } else if (total > 0 && total < 80) {
+    warnings.push(`Founders + priors + ESOP = ${total.toFixed(1)}% (well under 100%). Cap table may be incomplete.`)
+  }
+
+  ;(company.safes || []).forEach((s, i) => {
+    const amt = Number(s.amount) || 0
+    if (amt <= 0) {
+      warnings.push(`SAFE #${i + 1} (${s.investorName || 'unnamed'}): amount is 0 — will be ignored.`)
+    }
+    const cap = Number(s.cap) || 0
+    const disc = Number(s.discount) || 0
+    if (s.proRata && cap === 0 && disc === 0) {
+      warnings.push(`SAFE #${i + 1} (${s.investorName || 'unnamed'}): pro-rata SAFE with no cap and no discount — double-check the parse.`)
+    }
+  })
+
+  return warnings
+}
+
+// Parses a JSON string and runs validation + normalization. Returns either
+// `{ ok: true, company, warnings }` or `{ ok: false, errors }`.
+export function parseImportJson(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    return { ok: false, errors: ['No JSON provided'] }
+  }
+
+  let raw
+  try {
+    raw = JSON.parse(text)
+  } catch (e) {
+    return { ok: false, errors: [`Invalid JSON: ${e.message}`] }
+  }
+
+  const hardErrors = hardValidate(raw)
+  if (hardErrors.length > 0) {
+    return { ok: false, errors: hardErrors }
+  }
+
+  const { cleaned, warnings: metaWarnings } = extractMetadata(raw)
+
+  // Run through the same migration path as localStorage loading. This handles
+  // legacy field names (postMoney/round/investor/other/proRataAmount) and
+  // applies all defaults via createDefaultCompany().
+  const fallbackName = typeof cleaned.name === 'string' && cleaned.name.trim()
+    ? cleaned.name.trim()
+    : 'Imported Scenario'
+  const company = migrateLegacyCompany(cleaned, fallbackName)
+
+  // normalizeSafe in dataStructures.js preserves but doesn't generate `id`,
+  // so an imported SAFE without an id would cause a React key collision.
+  company.safes = (company.safes || []).map((s, i) => (
+    s && s.id !== undefined ? s : { ...s, id: `imported-safe-${Date.now()}-${i}` }
+  ))
+
+  const warnings = [...metaWarnings, ...softWarnings(company)]
+  return { ok: true, company, warnings }
+}

--- a/react-app/src/utils/importCompany.js
+++ b/react-app/src/utils/importCompany.js
@@ -168,7 +168,7 @@ function softWarnings(company) {
   const total = founderTotal + priorTotal + (Number(company.currentEsopPercent) || 0)
 
   if (founderTotal + priorTotal > 100) {
-    warnings.push(`Founders + prior investors = ${(founderTotal + priorTotal).toFixed(1)}% (over 100%). Calc engine will auto-scale.`)
+    warnings.push(`Founders + prior investors = ${(founderTotal + priorTotal).toFixed(1)}% (over 100%). The scenario won't compute until you trim this in the Inputs panel.`)
   } else if (total > 0 && total < 80) {
     warnings.push(`Founders + priors + ESOP = ${total.toFixed(1)}% (well under 100%). Cap table may be incomplete.`)
   }

--- a/react-app/src/utils/importCompany.js
+++ b/react-app/src/utils/importCompany.js
@@ -5,15 +5,77 @@ import { migrateLegacyCompany } from './dataStructures'
 // and may emit a top-level `_warning` if the cap table looked off. We surface
 // those as warnings but never persist them on the company.
 const STRIP_KEYS = new Set(['_safeType', '_notes', '_warning'])
+const MATERIAL_ARRAY_FIELDS = ['founders', 'priorInvestors', 'warrants']
+const MATERIAL_SCALAR_FIELDS = [
+  'postMoneyVal',
+  'postMoney',
+  'roundSize',
+  'round',
+  'investorPortion',
+  'investor',
+  'otherPortion',
+  'other',
+  'investorName',
+  'currentEsopPercent',
+  'grantedEsopPercent',
+  'targetEsopPercent',
+  'esopTiming',
+  'showAdvanced',
+  'twoStepEnabled',
+  'step2PostMoney',
+  'step2Amount',
+  'step2InvestorPortion',
+  'step2OtherPortion'
+]
+
+let importIdCounter = 0
 
 function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function getNumber(value) {
-  if (value === null || value === undefined || value === '') return undefined
-  const n = Number(value)
-  return Number.isFinite(n) ? n : undefined
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function hasMaterialCapTableData(raw) {
+  return MATERIAL_ARRAY_FIELDS.some((key) => Array.isArray(raw[key]) && raw[key].length > 0) ||
+    MATERIAL_SCALAR_FIELDS.some((key) => (
+      hasOwn(raw, key) &&
+      raw[key] !== null &&
+      raw[key] !== undefined &&
+      raw[key] !== ''
+    ))
+}
+
+function getImportKind(raw) {
+  return Array.isArray(raw.safes) &&
+    raw.safes.length > 0 &&
+    !hasMaterialCapTableData(raw)
+    ? 'safe-only'
+    : 'company'
+}
+
+function createImportId(prefix, index) {
+  importIdCounter += 1
+  return `${prefix}-${Date.now()}-${importIdCounter}-${index}`
+}
+
+function assignFreshIds(items, prefix) {
+  return (items || []).map((item, index) => ({
+    ...item,
+    id: createImportId(prefix, index)
+  }))
+}
+
+function assignFreshRowIds(company) {
+  return {
+    ...company,
+    founders: assignFreshIds(company.founders, 'imported-founder'),
+    priorInvestors: assignFreshIds(company.priorInvestors, 'imported-prior'),
+    safes: assignFreshIds(company.safes, 'imported-safe'),
+    warrants: assignFreshIds(company.warrants, 'imported-warrant')
+  }
 }
 
 function checkPercent(label, value, errors) {
@@ -189,7 +251,7 @@ function softWarnings(company) {
 }
 
 // Parses a JSON string and runs validation + normalization. Returns either
-// `{ ok: true, company, warnings }` or `{ ok: false, errors }`.
+// `{ ok: true, importKind, company, safes, warnings }` or `{ ok: false, errors }`.
 export function parseImportJson(text) {
   if (typeof text !== 'string' || text.trim() === '') {
     return { ok: false, errors: ['No JSON provided'] }
@@ -208,6 +270,7 @@ export function parseImportJson(text) {
   }
 
   const { cleaned, warnings: metaWarnings } = extractMetadata(raw)
+  const importKind = getImportKind(cleaned)
 
   // Run through the same migration path as localStorage loading. This handles
   // legacy field names (postMoney/round/investor/other/proRataAmount) and
@@ -215,14 +278,8 @@ export function parseImportJson(text) {
   const fallbackName = typeof cleaned.name === 'string' && cleaned.name.trim()
     ? cleaned.name.trim()
     : 'Imported Scenario'
-  const company = migrateLegacyCompany(cleaned, fallbackName)
-
-  // normalizeSafe in dataStructures.js preserves but doesn't generate `id`,
-  // so an imported SAFE without an id would cause a React key collision.
-  company.safes = (company.safes || []).map((s, i) => (
-    s && s.id !== undefined ? s : { ...s, id: `imported-safe-${Date.now()}-${i}` }
-  ))
+  const company = assignFreshRowIds(migrateLegacyCompany(cleaned, fallbackName))
 
   const warnings = [...metaWarnings, ...softWarnings(company)]
-  return { ok: true, company, warnings }
+  return { ok: true, importKind, company, safes: company.safes || [], warnings }
 }

--- a/react-app/src/utils/importCompany.test.js
+++ b/react-app/src/utils/importCompany.test.js
@@ -22,6 +22,7 @@ describe('parseImportJson', () => {
   it('accepts a minimal payload (just name)', () => {
     const r = parseImportJson(JSON.stringify({ name: 'Acme' }))
     expect(r.ok).toBe(true)
+    expect(r.importKind).toBe('company')
     expect(r.company.name).toBe('Acme')
     // Defaults applied via migrateLegacyCompany
     expect(r.company.postMoneyVal).toBe(13)
@@ -68,17 +69,42 @@ describe('parseImportJson', () => {
     }
     const r = parseImportJson(JSON.stringify(payload))
     expect(r.ok).toBe(true)
+    expect(r.importKind).toBe('company')
     expect(r.company.founders).toHaveLength(2)
     expect(r.company.founders.every(f => f.id !== undefined)).toBe(true)
     expect(r.company.priorInvestors).toHaveLength(2)
     expect(r.company.priorInvestors[0].hasProRataRights).toBe(true)
     expect(r.company.priorInvestors[0].proRataOverride).toBeNull()
     expect(r.company.safes).toHaveLength(2)
+    expect(r.safes).toHaveLength(2)
     expect(r.company.safes[0].proRata).toBe(true)
     expect(r.company.warrants).toHaveLength(1)
     expect(r.company.warrants[0].amount).toBe(1)
     expect(r.company.currentEsopPercent).toBe(8)
     expect(r.company.grantedEsopPercent).toBe(5)
+  })
+
+  it('classifies SAFE-only payloads separately', () => {
+    const r = parseImportJson(JSON.stringify({
+      safes: [
+        { investorName: 'Bridge', amount: 1.5, cap: 30, discount: 0, proRata: false }
+      ]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.importKind).toBe('safe-only')
+    expect(r.safes).toHaveLength(1)
+    expect(r.company.name).toBe('Imported Scenario')
+    expect(r.company.safes[0].investorName).toBe('Bridge')
+  })
+
+  it('keeps SAFE payloads as company imports when cap-table fields are present', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'Acme',
+      founders: [{ name: 'CEO', ownershipPercent: 70 }],
+      safes: [{ investorName: 'Bridge', amount: 1, cap: 25 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.importKind).toBe('company')
   })
 
   it('rejects ownership > 100', () => {
@@ -209,19 +235,33 @@ describe('parseImportJson', () => {
     expect(r.company.safes[0]._notes).toBeUndefined()
   })
 
-  it('assigns ids to imported SAFEs (required for React keys)', () => {
+  it('replaces imported row ids so React keys stay unique', () => {
     const r = parseImportJson(JSON.stringify({
       name: 'X',
+      founders: [
+        { id: 'duplicate', name: 'Founder A', ownershipPercent: 45 },
+        { id: 'duplicate', name: 'Founder B', ownershipPercent: 35 }
+      ],
+      priorInvestors: [
+        { id: 'duplicate', name: 'Seed', ownershipPercent: 20 }
+      ],
       safes: [
-        { investorName: 'A', amount: 1, cap: 20 },
-        { investorName: 'B', amount: 0.5, cap: 15 }
+        { id: 'duplicate', investorName: 'A', amount: 1, cap: 20 },
+        { id: 'duplicate', investorName: 'B', amount: 0.5, cap: 15 }
+      ],
+      warrants: [
+        { id: 'duplicate', name: 'Lender', amount: 0.2, valuation: 20 }
       ]
     }))
     expect(r.ok).toBe(true)
-    expect(r.company.safes).toHaveLength(2)
-    expect(r.company.safes[0].id).toBeDefined()
-    expect(r.company.safes[1].id).toBeDefined()
-    expect(r.company.safes[0].id).not.toBe(r.company.safes[1].id)
+    const ids = [
+      ...r.company.founders,
+      ...r.company.priorInvestors,
+      ...r.company.safes,
+      ...r.company.warrants
+    ].map(row => row.id)
+    expect(ids.every(id => id && id !== 'duplicate')).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('preserves duplicate investor names verbatim for the rollup engine', () => {

--- a/react-app/src/utils/importCompany.test.js
+++ b/react-app/src/utils/importCompany.test.js
@@ -144,6 +144,7 @@ describe('parseImportJson', () => {
     }))
     expect(r.ok).toBe(true)
     expect(r.warnings.some(w => /over 100/i.test(w))).toBe(true)
+    expect(r.warnings.some(w => /won't compute/i.test(w))).toBe(true)
   })
 
   it('warns when cap table looks incomplete (founders + priors + ESOP < 80%)', () => {

--- a/react-app/src/utils/importCompany.test.js
+++ b/react-app/src/utils/importCompany.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import { parseImportJson } from './importCompany'
+
+describe('parseImportJson', () => {
+  it('rejects empty input', () => {
+    expect(parseImportJson('').ok).toBe(false)
+    expect(parseImportJson('   ').ok).toBe(false)
+  })
+
+  it('rejects malformed JSON', () => {
+    const r = parseImportJson('{ not json')
+    expect(r.ok).toBe(false)
+    expect(r.errors[0]).toMatch(/Invalid JSON/)
+  })
+
+  it('rejects non-object root', () => {
+    expect(parseImportJson('[]').ok).toBe(false)
+    expect(parseImportJson('"a string"').ok).toBe(false)
+    expect(parseImportJson('42').ok).toBe(false)
+  })
+
+  it('accepts a minimal payload (just name)', () => {
+    const r = parseImportJson(JSON.stringify({ name: 'Acme' }))
+    expect(r.ok).toBe(true)
+    expect(r.company.name).toBe('Acme')
+    // Defaults applied via migrateLegacyCompany
+    expect(r.company.postMoneyVal).toBe(13)
+    expect(r.company.roundSize).toBe(3)
+    expect(Array.isArray(r.company.founders)).toBe(true)
+    expect(Array.isArray(r.company.priorInvestors)).toBe(true)
+    expect(Array.isArray(r.company.safes)).toBe(true)
+    expect(Array.isArray(r.company.warrants)).toBe(true)
+  })
+
+  it('rejects empty name', () => {
+    const r = parseImportJson(JSON.stringify({ name: '   ' }))
+    expect(r.ok).toBe(false)
+    expect(r.errors[0]).toMatch(/name/)
+  })
+
+  it('accepts a full valid payload and assigns IDs', () => {
+    const payload = {
+      name: 'Acme',
+      postMoneyVal: 80,
+      roundSize: 20,
+      investorPortion: 14,
+      otherPortion: 6,
+      investorName: 'LSVP',
+      showAdvanced: true,
+      founders: [
+        { name: 'CEO', ownershipPercent: 28 },
+        { name: 'CTO', ownershipPercent: 22 }
+      ],
+      priorInvestors: [
+        { name: 'Seed Lead', ownershipPercent: 18, hasProRataRights: true },
+        { name: 'Angel', ownershipPercent: 4, hasProRataRights: false }
+      ],
+      safes: [
+        { investorName: 'Bridge', amount: 2, cap: 40, discount: 20, proRata: true },
+        { investorName: 'Accelerator', amount: 0.5, cap: 25, discount: 0, proRata: false }
+      ],
+      warrants: [
+        { name: 'SVB', amount: 1, valuation: 50 }
+      ],
+      currentEsopPercent: 8,
+      grantedEsopPercent: 5,
+      esopTiming: 'pre-close'
+    }
+    const r = parseImportJson(JSON.stringify(payload))
+    expect(r.ok).toBe(true)
+    expect(r.company.founders).toHaveLength(2)
+    expect(r.company.founders.every(f => f.id !== undefined)).toBe(true)
+    expect(r.company.priorInvestors).toHaveLength(2)
+    expect(r.company.priorInvestors[0].hasProRataRights).toBe(true)
+    expect(r.company.priorInvestors[0].proRataOverride).toBeNull()
+    expect(r.company.safes).toHaveLength(2)
+    expect(r.company.safes[0].proRata).toBe(true)
+    expect(r.company.warrants).toHaveLength(1)
+    expect(r.company.warrants[0].amount).toBe(1)
+    expect(r.company.currentEsopPercent).toBe(8)
+    expect(r.company.grantedEsopPercent).toBe(5)
+  })
+
+  it('rejects ownership > 100', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      founders: [{ name: 'Bad', ownershipPercent: 150 }]
+    }))
+    expect(r.ok).toBe(false)
+    expect(r.errors.some(e => /ownershipPercent/.test(e))).toBe(true)
+  })
+
+  it('rejects negative ownership', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      priorInvestors: [{ name: 'Bad', ownershipPercent: -5 }]
+    }))
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects discount > 100', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [{ amount: 1, discount: 150 }]
+    }))
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects non-numeric strings like "TBD"', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      postMoneyVal: 'TBD'
+    }))
+    expect(r.ok).toBe(false)
+    expect(r.errors.some(e => /postMoneyVal/.test(e))).toBe(true)
+  })
+
+  it('rejects non-array founders/priorInvestors/safes', () => {
+    expect(parseImportJson(JSON.stringify({ name: 'X', founders: {} })).ok).toBe(false)
+    expect(parseImportJson(JSON.stringify({ name: 'X', priorInvestors: 'oops' })).ok).toBe(false)
+    expect(parseImportJson(JSON.stringify({ name: 'X', safes: 42 })).ok).toBe(false)
+  })
+
+  it('migrates legacy field names (postMoney, round, investor, other)', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'Legacy',
+      postMoney: 50,
+      round: 10,
+      investor: 7,
+      other: 3
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.company.postMoneyVal).toBe(50)
+    expect(r.company.roundSize).toBe(10)
+    expect(r.company.investorPortion).toBe(7)
+    expect(r.company.otherPortion).toBe(3)
+  })
+
+  it('warns when founders + priors exceed 100% but does not block', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'Over',
+      founders: [{ name: 'A', ownershipPercent: 70 }],
+      priorInvestors: [{ name: 'B', ownershipPercent: 50 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.warnings.some(w => /over 100/i.test(w))).toBe(true)
+  })
+
+  it('warns when cap table looks incomplete (founders + priors + ESOP < 80%)', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'Sparse',
+      founders: [{ name: 'A', ownershipPercent: 30 }],
+      priorInvestors: [{ name: 'B', ownershipPercent: 10 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.warnings.some(w => /under 100|incomplete/i.test(w))).toBe(true)
+  })
+
+  it('warns when pro-rata SAFE has no cap and no discount', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [{ investorName: 'Sus', amount: 1, cap: 0, discount: 0, proRata: true }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.warnings.some(w => /no cap and no discount/i.test(w))).toBe(true)
+  })
+
+  it('warns when SAFE amount is 0', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [{ investorName: 'Zero', amount: 0, cap: 20 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.warnings.some(w => /amount is 0/i.test(w))).toBe(true)
+  })
+
+  it('accepts SAFE with neither cap nor discount (uncapped, no discount)', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [{ investorName: 'Free', amount: 1 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.company.safes).toHaveLength(1)
+    expect(r.company.safes[0].cap ?? 0).toBe(0)
+    expect(r.company.safes[0].discount ?? 0).toBe(0)
+  })
+
+  it('strips _warning, _notes, _safeType but surfaces them as warnings', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      _warning: 'Some employee grants were unclear',
+      safes: [
+        {
+          investorName: 'Old SAFE',
+          amount: 1,
+          cap: 10,
+          _safeType: 'pre-money',
+          _notes: 'MFN clause active'
+        }
+      ]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.warnings.some(w => /unclear/.test(w))).toBe(true)
+    expect(r.warnings.some(w => /MFN clause/.test(w))).toBe(true)
+    expect(r.warnings.some(w => /pre-money/i.test(w))).toBe(true)
+    // Should not be persisted on the safe itself
+    expect(r.company.safes[0]._safeType).toBeUndefined()
+    expect(r.company.safes[0]._notes).toBeUndefined()
+  })
+
+  it('assigns ids to imported SAFEs (required for React keys)', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [
+        { investorName: 'A', amount: 1, cap: 20 },
+        { investorName: 'B', amount: 0.5, cap: 15 }
+      ]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.company.safes).toHaveLength(2)
+    expect(r.company.safes[0].id).toBeDefined()
+    expect(r.company.safes[1].id).toBeDefined()
+    expect(r.company.safes[0].id).not.toBe(r.company.safes[1].id)
+  })
+
+  it('preserves duplicate investor names verbatim for the rollup engine', () => {
+    // The calc engine's rollup logic matches on case-insensitive trimmed names.
+    // Import should leave names alone so the engine can do its thing.
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      priorInvestors: [{ name: 'Sequoia', ownershipPercent: 10, hasProRataRights: true }],
+      safes: [{ investorName: 'Sequoia', amount: 2, cap: 40 }]
+    }))
+    expect(r.ok).toBe(true)
+    expect(r.company.priorInvestors[0].name).toBe('Sequoia')
+    expect(r.company.safes[0].investorName).toBe('Sequoia')
+  })
+})

--- a/react-app/src/utils/importPrompts.js
+++ b/react-app/src/utils/importPrompts.js
@@ -1,0 +1,82 @@
+// Prompts the user copies into Claude.ai (or another LLM) alongside an XLS
+// cap table or SAFE PDF. Claude returns JSON matching the app's import schema,
+// which the user then pastes into the in-app import modal.
+
+const SCHEMA_BLOCK = `{
+  "name": "Acme",
+  "founders": [
+    { "name": "CEO", "ownershipPercent": 28 },
+    { "name": "CTO", "ownershipPercent": 22 }
+  ],
+  "priorInvestors": [
+    { "name": "Seed Lead", "ownershipPercent": 18, "hasProRataRights": true },
+    { "name": "Pre-seed Angel", "ownershipPercent": 4, "hasProRataRights": false }
+  ],
+  "safes": [
+    { "investorName": "Bridge Investor", "amount": 2.0, "cap": 40, "discount": 20, "proRata": true },
+    { "investorName": "Accelerator", "amount": 0.5, "cap": 25, "discount": 0, "proRata": false }
+  ],
+  "warrants": [
+    { "name": "Silicon Valley Bank", "amount": 1.0, "valuation": 50 }
+  ],
+  "currentEsopPercent": 8,
+  "grantedEsopPercent": 5,
+  "esopTiming": "pre-close"
+}`
+
+export const XLS_IMPORT_PROMPT = `You are converting a startup cap table (from an Excel/Google Sheet, possibly messy) into a strict JSON format for a valuation modeling tool.
+
+Output rules
+- Return ONLY a single JSON object — no prose, no markdown fence, no comments.
+- All dollar amounts in millions ($2,500,000 → 2.5).
+- All percentages on a 0–100 scale (18% → 18, not 0.18).
+- Omit any field you cannot determine. Do not invent values.
+
+Schema
+${SCHEMA_BLOCK}
+
+Mapping guidance
+- founders: individuals listed as founders / common stockholders. Roll up multiple share classes or grant tranches for the same person into a single entry (sum the percentages). Exclude granted options — those go into grantedEsopPercent.
+- priorInvestors: every existing investor entity (Seed Fund, angel, strategic). Sum across share classes (Pref-A, Pref-A-1, etc.). Set hasProRataRights: true if the cap table indicates pro-rata rights OR if you see a side letter / "MFN+PR" / explicit pro-rata column.
+- safes: any outstanding SAFEs (often on a separate tab or below the main table). cap in $M, discount 0–100. If both blank, set both to 0 (uncapped, no discount).
+- warrants: warrant coverage. valuation is the reference / strike valuation in $M.
+- currentEsopPercent: total authorized option pool. grantedEsopPercent: portion already issued to employees. If only one number is given, assume it's currentEsopPercent and set grantedEsopPercent: 0.
+- Leave postMoneyVal, roundSize, investorPortion, otherPortion, investorName, targetEsopPercent OUT of the JSON — these are the deal terms the user will model afterward, not artifacts of the existing cap.
+- Trim whitespace from names. Keep canonical casing ("Sequoia Capital", not "sequoia").
+
+Sanity check before returning: founders + priorInvestors + currentEsopPercent should sum to roughly 100. If it's wildly off, add a _warning string field explaining what's missing or ambiguous.
+
+Now convert the attached cap table.`
+
+export const SAFE_PDF_IMPORT_PROMPT = `You are extracting SAFE (Simple Agreement for Future Equity) terms from one or more PDFs into a strict JSON format.
+
+Output rules
+- Return ONLY a single JSON object with a "safes" array — no prose, no markdown fence.
+- Dollar amounts in millions ($2,500,000 → 2.5).
+- Discount as a number 0–100 (a 20% discount → 20).
+
+Schema
+{
+  "safes": [
+    {
+      "investorName": "string",
+      "amount": 2.0,
+      "cap": 40,
+      "discount": 20,
+      "proRata": true,
+      "_safeType": "post-money | pre-money | mfn-only",
+      "_notes": "optional human-readable caveat"
+    }
+  ]
+}
+
+Extraction guidance
+- investorName: the "Investor" party named on the cover / signature page.
+- amount: the "Purchase Amount" in $M.
+- cap: the "Valuation Cap" in $M. If MFN-only (no cap), set cap: 0.
+- discount: the "Discount Rate" — a SAFE saying "85% of price" means a 15% discount, so discount: 15. A "20% discount" means discount: 20. If no discount clause, discount: 0.
+- proRata: true if the SAFE or an attached side letter grants pro-rata / participation rights. Otherwise false.
+- _safeType: "post-money" (YC post-money SAFE, most common since 2018), "pre-money" (legacy YC SAFE), or "mfn-only" (no cap, MFN clause only). The app does not yet model the post-vs-pre conversion difference, so flag pre-money SAFEs in _notes so the user knows the conversion math is approximate.
+- _notes: anything unusual — most-favored-nation clauses, side letter terms, "valid until [date]", non-standard conversion triggers, etc.
+
+If multiple SAFE PDFs are attached, return one entry per SAFE. Now process the attached PDF(s).`


### PR DESCRIPTION
Adds an Import action with a modal for pasting JSON generated from cap table spreadsheets or SAFE PDFs, including copyable prompts and validation/warning handling.
Normalizes imported cap table data through the existing migration path, strips LLM metadata, assigns fresh row IDs, and supports SAFE-only imports that append to the active scenario or create a new one.
Covers the parser, modal, and App integration with tests, including duplicate names and SAFE destination behavior.
Verified with npm run lint, npm run test:run, npm run build, and local Vite HTTP 200.