### PR TITLE
Combine cap table import prompt

### DIFF
--- a/react-app/src/components/ImportModal.jsx
+++ b/react-app/src/components/ImportModal.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { parseImportJson } from '../utils/importCompany'
-import { XLS_IMPORT_PROMPT, SAFE_PDF_IMPORT_PROMPT } from '../utils/importPrompts'
+import { IMPORT_PROMPT } from '../utils/importPrompts'
 
 function formatSafeCount(count) {
   return `${count} SAFE${count === 1 ? '' : 's'}`
@@ -13,8 +13,8 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
   // before committing the import.
   const [pendingPreview, setPendingPreview] = useState(null)
   const [safeDestination, setSafeDestination] = useState('append')
-  const [openPrompt, setOpenPrompt] = useState(null) // 'xls' | 'safe' | null
-  const [copiedPrompt, setCopiedPrompt] = useState(null)
+  const [promptOpen, setPromptOpen] = useState(false)
+  const [copiedPrompt, setCopiedPrompt] = useState(false)
   const textareaRef = useRef(null)
   const closeBtnRef = useRef(null)
 
@@ -24,8 +24,8 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
       setErrors([])
       setPendingPreview(null)
       setSafeDestination('append')
-      setOpenPrompt(null)
-      setCopiedPrompt(null)
+      setPromptOpen(false)
+      setCopiedPrompt(false)
     }
   }, [open])
 
@@ -94,11 +94,11 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
     setPendingPreview({ ...result, warnings, sourceText: jsonText })
   }
 
-  const handleCopyPrompt = async (kind, text) => {
+  const handleCopyPrompt = async () => {
     try {
-      await navigator.clipboard.writeText(text)
-      setCopiedPrompt(kind)
-      setTimeout(() => setCopiedPrompt((c) => (c === kind ? null : c)), 1500)
+      await navigator.clipboard.writeText(IMPORT_PROMPT)
+      setCopiedPrompt(true)
+      setTimeout(() => setCopiedPrompt(false), 1500)
       onShowSuccess?.('Prompt copied to clipboard', 1500)
     } catch {
       onShowError?.('Could not copy — your browser blocked clipboard access', 2200)
@@ -141,29 +141,18 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
         </div>
 
         <p className="import-modal-intro">
-          Paste a JSON cap table below. Get one by sending your XLS or SAFE PDF to Claude with the prompt below.
+          Paste a JSON cap table below. Get one by sending the prompt below to Claude with the cap table XLS and any SAFE PDFs attached.
         </p>
 
         <div className="import-modal-prompts">
           <PromptDisclosure
-            kind="xls"
-            title="Prompt for XLS cap tables"
-            description="Use with the company's cap table spreadsheet."
-            prompt={XLS_IMPORT_PROMPT}
-            isOpen={openPrompt === 'xls'}
-            isCopied={copiedPrompt === 'xls'}
-            onToggle={() => setOpenPrompt((p) => (p === 'xls' ? null : 'xls'))}
-            onCopy={() => handleCopyPrompt('xls', XLS_IMPORT_PROMPT)}
-          />
-          <PromptDisclosure
-            kind="safe"
-            title="Prompt for SAFE PDFs"
-            description="Use with one or more SAFE PDFs attached."
-            prompt={SAFE_PDF_IMPORT_PROMPT}
-            isOpen={openPrompt === 'safe'}
-            isCopied={copiedPrompt === 'safe'}
-            onToggle={() => setOpenPrompt((p) => (p === 'safe' ? null : 'safe'))}
-            onCopy={() => handleCopyPrompt('safe', SAFE_PDF_IMPORT_PROMPT)}
+            title="Prompt for cap table + SAFE files"
+            description="Use with the spreadsheet and any SAFE PDFs in one Claude chat."
+            prompt={IMPORT_PROMPT}
+            isOpen={promptOpen}
+            isCopied={copiedPrompt}
+            onToggle={() => setPromptOpen((open) => !open)}
+            onCopy={handleCopyPrompt}
           />
         </div>
 

--- a/react-app/src/components/ImportModal.test.jsx
+++ b/react-app/src/components/ImportModal.test.jsx
@@ -30,6 +30,22 @@ function pasteJson(payload) {
 }
 
 describe('ImportModal', () => {
+  it('shows one combined prompt for spreadsheets and SAFE PDFs', async () => {
+    const { user } = renderImportModal()
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
+
+    expect(screen.getByText('Prompt for cap table + SAFE files')).toBeInTheDocument()
+    expect(screen.queryByText('Prompt for XLS cap tables')).not.toBeInTheDocument()
+    expect(screen.queryByText('Prompt for SAFE PDFs')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /prompt for cap table/i }))
+    expect(screen.getByText(/Read all attached files together/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }))
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('One or more SAFE PDFs'))
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Excel/Google Sheets cap table export'))
+  })
+
   it('shows malformed JSON errors without importing', async () => {
     const { user, onImport } = renderImportModal()
 

--- a/react-app/src/utils/importPrompts.js
+++ b/react-app/src/utils/importPrompts.js
@@ -1,6 +1,6 @@
-// Prompts the user copies into Claude.ai (or another LLM) alongside an XLS
-// cap table or SAFE PDF. Claude returns JSON matching the app's import schema,
-// which the user then pastes into the in-app import modal.
+// Prompt the user copies into Claude.ai (or another LLM) alongside an XLS
+// cap table and any SAFE PDFs. Claude returns JSON matching the app's import
+// schema, which the user then pastes into the in-app import modal.
 
 const SCHEMA_BLOCK = `{
   "name": "Acme",
@@ -13,8 +13,8 @@ const SCHEMA_BLOCK = `{
     { "name": "Pre-seed Angel", "ownershipPercent": 4, "hasProRataRights": false }
   ],
   "safes": [
-    { "investorName": "Bridge Investor", "amount": 2.0, "cap": 40, "discount": 20, "proRata": true },
-    { "investorName": "Accelerator", "amount": 0.5, "cap": 25, "discount": 0, "proRata": false }
+    { "investorName": "Bridge Investor", "amount": 2.0, "cap": 40, "discount": 20, "proRata": true, "_safeType": "post-money", "_notes": "optional caveat" },
+    { "investorName": "Accelerator", "amount": 0.5, "cap": 25, "discount": 0, "proRata": false, "_safeType": "mfn-only" }
   ],
   "warrants": [
     { "name": "Silicon Valley Bank", "amount": 1.0, "valuation": 50 }
@@ -24,13 +24,21 @@ const SCHEMA_BLOCK = `{
   "esopTiming": "pre-close"
 }`
 
-export const XLS_IMPORT_PROMPT = `You are converting a startup cap table (from an Excel/Google Sheet, possibly messy) into a strict JSON format for a valuation modeling tool.
+export const IMPORT_PROMPT = `You are converting startup financing documents into a strict JSON format for a valuation modeling tool.
+
+You may receive any combination of:
+- An Excel/Google Sheets cap table export.
+- One or more SAFE PDFs.
+- Side letters or notes that mention pro-rata rights.
+
+Read all attached files together and return one consolidated JSON object.
 
 Output rules
 - Return ONLY a single JSON object — no prose, no markdown fence, no comments.
 - All dollar amounts in millions ($2,500,000 → 2.5).
 - All percentages on a 0–100 scale (18% → 18, not 0.18).
 - Omit any field you cannot determine. Do not invent values.
+- If only SAFE PDFs are attached and no cap table is available, return a JSON object with just the "safes" array.
 
 Schema
 ${SCHEMA_BLOCK}
@@ -39,44 +47,17 @@ Mapping guidance
 - founders: individuals listed as founders / common stockholders. Roll up multiple share classes or grant tranches for the same person into a single entry (sum the percentages). Exclude granted options — those go into grantedEsopPercent.
 - priorInvestors: every existing investor entity (Seed Fund, angel, strategic). Sum across share classes (Pref-A, Pref-A-1, etc.). Set hasProRataRights: true if the cap table indicates pro-rata rights OR if you see a side letter / "MFN+PR" / explicit pro-rata column.
 - safes: any outstanding SAFEs (often on a separate tab or below the main table). cap in $M, discount 0–100. If both blank, set both to 0 (uncapped, no discount).
+- For each SAFE PDF, investorName is the "Investor" party, amount is the "Purchase Amount", cap is the "Valuation Cap", and discount is the economic discount. A SAFE saying "85% of price" means discount: 15.
+- Set proRata: true if the SAFE or side letter grants pro-rata / participation rights. Otherwise false.
+- Add _safeType: "post-money", "pre-money", or "mfn-only" when the SAFE type is visible. Add _notes for unusual terms such as MFN clauses, side letter caveats, unusual conversion triggers, or unclear extraction.
 - warrants: warrant coverage. valuation is the reference / strike valuation in $M.
 - currentEsopPercent: total authorized option pool. grantedEsopPercent: portion already issued to employees. If only one number is given, assume it's currentEsopPercent and set grantedEsopPercent: 0.
 - Leave postMoneyVal, roundSize, investorPortion, otherPortion, investorName, targetEsopPercent OUT of the JSON — these are the deal terms the user will model afterward, not artifacts of the existing cap.
 - Trim whitespace from names. Keep canonical casing ("Sequoia Capital", not "sequoia").
 
-Sanity check before returning: founders + priorInvestors + currentEsopPercent should sum to roughly 100. If it's wildly off, add a _warning string field explaining what's missing or ambiguous.
+Sanity checks before returning:
+- Founders + priorInvestors + currentEsopPercent should sum to roughly 100 when a cap table is present.
+- SAFEs from PDFs should not duplicate SAFEs already listed in the cap table; merge duplicates into one entry when they clearly refer to the same instrument.
+- If something is wildly off, add a _warning string field explaining what's missing or ambiguous.
 
-Now convert the attached cap table.`
-
-export const SAFE_PDF_IMPORT_PROMPT = `You are extracting SAFE (Simple Agreement for Future Equity) terms from one or more PDFs into a strict JSON format.
-
-Output rules
-- Return ONLY a single JSON object with a "safes" array — no prose, no markdown fence.
-- Dollar amounts in millions ($2,500,000 → 2.5).
-- Discount as a number 0–100 (a 20% discount → 20).
-
-Schema
-{
-  "safes": [
-    {
-      "investorName": "string",
-      "amount": 2.0,
-      "cap": 40,
-      "discount": 20,
-      "proRata": true,
-      "_safeType": "post-money | pre-money | mfn-only",
-      "_notes": "optional human-readable caveat"
-    }
-  ]
-}
-
-Extraction guidance
-- investorName: the "Investor" party named on the cover / signature page.
-- amount: the "Purchase Amount" in $M.
-- cap: the "Valuation Cap" in $M. If MFN-only (no cap), set cap: 0.
-- discount: the "Discount Rate" — a SAFE saying "85% of price" means a 15% discount, so discount: 15. A "20% discount" means discount: 20. If no discount clause, discount: 0.
-- proRata: true if the SAFE or an attached side letter grants pro-rata / participation rights. Otherwise false.
-- _safeType: "post-money" (YC post-money SAFE, most common since 2018), "pre-money" (legacy YC SAFE), or "mfn-only" (no cap, MFN clause only). The app does not yet model the post-vs-pre conversion difference, so flag pre-money SAFEs in _notes so the user knows the conversion math is approximate.
-- _notes: anything unusual — most-favored-nation clauses, side letter terms, "valid until [date]", non-standard conversion triggers, etc.
-
-If multiple SAFE PDFs are attached, return one entry per SAFE. Now process the attached PDF(s).`
+Now convert all attached files into one JSON object.`


### PR DESCRIPTION
Replaces the separate XLS and SAFE PDF prompt disclosures with one combined prompt intended for a single Claude session containing the cap table spreadsheet and any SAFE PDFs.
The combined prompt asks Claude to return one consolidated JSON object, merge duplicate SAFEs across sources, and still supports SAFE-only imports when no cap table is attached.
Updates the import modal copy and adds coverage that only the combined prompt is shown and copied.
Verified with npm run lint, npm run test:run, npm run build, and git diff --check.