### PR TITLE
Add first-class YC SAFE support

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -5115,7 +5115,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35), 0 4px 12px rgba(15, 23, 42, 0.15);
   border: 1px solid rgba(99, 91, 255, 0.18);
   width: min(720px, 100%);
-  max-height: calc(100vh - 80px);
+  max-height: min(820px, calc(100vh - 32px));
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -5131,6 +5131,7 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex: 0 0 auto;
   padding: 18px 22px 12px;
   border-bottom: 1px solid var(--color-border);
 }
@@ -5165,6 +5166,13 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .import-modal-btn:focus-visible {
   outline: 2px solid rgba(99, 91, 255, 0.45);
   outline-offset: 2px;
+}
+
+.import-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .import-modal-intro {
@@ -5429,10 +5437,12 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 .import-modal-actions {
   display: flex;
   justify-content: flex-end;
+  flex: 0 0 auto;
   gap: 8px;
   padding: 12px 22px 18px;
   border-top: 1px solid var(--color-border);
-  margin-top: auto;
+  background: #ffffff;
+  box-shadow: 0 -8px 18px rgba(15, 23, 42, 0.05);
 }
 
 .import-modal-btn {

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -2056,9 +2056,28 @@ body {
 
 /* SAFE attribution label */
 .safe-attribution {
-  font-size: 0.75rem;
+  display: inline-flex;
+  margin-left: 0.35rem;
+  font-size: 0.72rem;
   color: #64748b;
-  font-style: italic;
+  font-weight: 500;
+}
+
+.section-row-meta {
+  display: inline-flex;
+  margin-left: 0.45rem;
+  color: var(--color-fg-subtle);
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+.safe-conversion-summary {
+  display: inline-block;
+  max-width: 100%;
+  font-size: 0.82rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .scenario-card:hover {
@@ -2103,6 +2122,30 @@ body {
   margin-bottom: var(--space-3);
   background: var(--color-bg-subtle);
   border-radius: var(--radius-sm);
+}
+
+.base-headline {
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: calc(var(--space-2) * -1);
+}
+
+.base-case-warning {
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 251, 235, 0.78);
+  padding: 0.55rem 0.7rem;
+  margin-bottom: var(--space-3);
+  color: #78350f;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.base-case-warning p {
+  margin: 0;
+}
+
+.base-case-warning p + p {
+  margin-top: 0.35rem;
 }
 
 .headline-metric {
@@ -3238,8 +3281,8 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 .repeater-table--safes .repeater-header,
 .repeater-table--safes .repeater-row {
-  /* Investor | Amount | Cap | Discount | Pro-rata | Actions */
-  grid-template-columns: minmax(96px, 1.4fr) 84px 88px 72px 46px 44px;
+  /* Investor | Amount | Type | Cap/Fixed % | Discount | Pro-rata | Actions */
+  grid-template-columns: minmax(96px, 1.4fr) 84px 96px 88px 72px 46px 44px;
 }
 
 .repeater-table--warrants .repeater-header,
@@ -3271,6 +3314,92 @@ input.investor-name-input:focus, input.founder-name-input:focus {
 
 .repeater-col {
   min-width: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.repeater-select {
+  width: 100%;
+  min-height: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.42);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--text-primary);
+  font-size: 0.76rem;
+  padding: 0 0.35rem;
+}
+
+.repeater-select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(99, 91, 255, 0.12);
+}
+
+.repeater-muted-cell {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
+
+.safe-import-context {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.safe-summary-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.safe-summary-strip span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 0 8px;
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  border-radius: 6px;
+  background: rgba(248, 250, 252, 0.9);
+  color: var(--color-fg-muted);
+  font-size: 0.75rem;
+}
+
+.safe-summary-strip strong {
+  color: var(--color-fg);
+  font-weight: 700;
+}
+
+.safe-import-warning {
+  border: 1px solid rgba(245, 158, 11, 0.34);
+  border-radius: 7px;
+  background: rgba(255, 251, 235, 0.78);
+  padding: 8px 10px;
+  color: #78350f;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.safe-import-warning p {
+  margin: 0;
+}
+
+.safe-import-warning p + p {
+  margin-top: 6px;
 }
 
 .repeater-col--actions {
@@ -5139,6 +5268,52 @@ input.investor-name-input:focus, input.founder-name-input:focus {
   word-break: break-word;
   max-height: 260px;
   overflow-y: auto;
+}
+
+.safe-row-explainer {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  flex: 1;
+}
+
+.safe-term-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.safe-term-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 7px;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--color-fg-muted);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.safe-term-pill--positive {
+  border-color: rgba(34, 197, 94, 0.32);
+  background: rgba(240, 253, 244, 0.88);
+  color: #166534;
+}
+
+.safe-term-pill--note {
+  border-color: rgba(99, 102, 241, 0.28);
+  background: rgba(238, 242, 255, 0.88);
+  color: #3730a3;
+}
+
+.safe-row-note {
+  color: var(--color-fg-muted);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 0.76rem;
+  line-height: 1.4;
 }
 
 .import-modal-textarea-label {

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -34,6 +34,52 @@ function formatSafeCount(count) {
   return `${count} SAFE${count === 1 ? '' : 's'}`
 }
 
+function hasAdvancedImportData(company) {
+  if (!company || typeof company !== 'object') return false
+  const hasRows = ['founders', 'priorInvestors', 'safes', 'warrants'].some((field) =>
+    Array.isArray(company[field]) && company[field].length > 0
+  )
+  if (hasRows) return true
+
+  const numericAdvancedFields = [
+    'currentEsopPercent',
+    'grantedEsopPercent',
+    'targetEsopPercent',
+    'proRataPercent',
+    'step2PostMoney',
+    'step2Amount',
+    'step2InvestorPortion',
+    'step2OtherPortion'
+  ]
+  return Boolean(company.twoStepEnabled) || numericAdvancedFields.some((field) => Number(company[field]) > 0)
+}
+
+function focusImportedCompany(company, roundConstructEntered = false) {
+  const shouldOpenAdvanced = hasAdvancedImportData(company)
+  return {
+    ...company,
+    showAdvanced: shouldOpenAdvanced ? true : Boolean(company?.showAdvanced),
+    inputsCollapsed: false,
+    roundConstructPending: !roundConstructEntered,
+    ...(shouldOpenAdvanced ? { showExitMath: false } : {})
+  }
+}
+
+function patchTouchesRoundConstruct(patch) {
+  if (!patch || typeof patch !== 'object') return false
+  return [
+    'postMoneyVal',
+    'roundSize',
+    'investorPortion',
+    'otherPortion',
+    'twoStepEnabled',
+    'step2PostMoney',
+    'step2Amount',
+    'step2InvestorPortion',
+    'step2OtherPortion'
+  ].some((field) => Object.prototype.hasOwnProperty.call(patch, field))
+}
+
 function App() {
   const [storedCompanies, setStoredCompanies] = useLocalStorage('valuationFramework', {
     company1: createDefaultCompany('Scenario 1')
@@ -62,8 +108,15 @@ function App() {
     })
   }, [setStoredCompanies])
 
+  const updateCompanyFromInputs = useCallback((companyId, data) => {
+    updateCompany(companyId, {
+      ...data,
+      ...(patchTouchesRoundConstruct(data) ? { roundConstructPending: false } : {})
+    })
+  }, [updateCompany])
+
   const applyScenario = (scenarioData) => {
-    updateCompany(activeCompany, scenarioData)
+    updateCompanyFromInputs(activeCompany, scenarioData)
     setInputHighlightToken(Date.now())
     showSuccess('Scenario applied successfully')
   }
@@ -111,6 +164,7 @@ function App() {
     const importKind = importResult?.importKind || 'company'
     const importedCompany = importResult?.company || importResult
     const importedSafes = importResult?.safes || importedCompany?.safes || []
+    const roundConstructEntered = Boolean(importResult?.roundConstructEntered)
 
     if (importKind === 'safe-only' && importResult?.destination === 'append') {
       const safeCount = importedSafes.length
@@ -132,10 +186,16 @@ function App() {
             importWarnings: [
               ...(Array.isArray(currentCompany.importWarnings) ? currentCompany.importWarnings : []),
               ...(Array.isArray(importedCompany.importWarnings) ? importedCompany.importWarnings : [])
-            ]
+            ],
+            showAdvanced: true,
+            inputsCollapsed: false,
+            roundConstructPending: !roundConstructEntered,
+            showExitMath: false
           }
         }
       })
+      setActiveCompany(activeCompany)
+      setSelectedCompanyIds([])
       setInputHighlightToken(Date.now())
       setImportModalOpen(false)
       showSuccess(`Appended ${formatSafeCount(safeCount)} to "${activeName}"`, 2200)
@@ -150,11 +210,14 @@ function App() {
     const safeCount = importKind === 'safe-only' ? importedSafes.length : null
 
     const newCompanyId = `company${nextCompanyId}`
+    const focusedCompany = focusImportedCompany({ ...importedCompany, name: finalName }, roundConstructEntered)
     setStoredCompanies(prev => ({
       ...normalizeStoredCompanies(prev),
-      [newCompanyId]: { ...importedCompany, name: finalName }
+      [newCompanyId]: focusedCompany
     }))
     setActiveCompany(newCompanyId)
+    setSelectedCompanyIds([])
+    setInputHighlightToken(Date.now())
     setNextCompanyId(prev => prev + 1)
     setTabActivity({ companyId: newCompanyId, type: 'add', nonce: Date.now() })
     setImportModalOpen(false)
@@ -350,7 +413,9 @@ function App() {
 
       // Check if the result is an error object
       if (newScenarios && newScenarios.error) {
-        showError(newScenarios.errorMessage)
+        if (!currentCompany.roundConstructPending) {
+          showError(newScenarios.errorMessage)
+        }
         setScenarios([]) // Clear scenarios
       } else if (!newScenarios || newScenarios.length === 0) {
         // Check if ownership exceeds 100%
@@ -445,7 +510,7 @@ function App() {
         <div className={`top-row${showExitMath ? ' with-exit-math' : ''}${isCompareMode ? ' compare-mode' : ''}${advancedOpen ? ' advanced-open' : ''}${companies[activeCompany]?.inputsCollapsed ? ' inputs-collapsed' : ''}`}>
           <InputForm
             company={companies[activeCompany]}
-            onUpdate={(data) => updateCompany(activeCompany, data)}
+            onUpdate={(data) => updateCompanyFromInputs(activeCompany, data)}
             collapsed={inputFormCollapsed}
             onToggleCollapsed={() => updateCompany(activeCompany, { inputsCollapsed: !companies[activeCompany]?.inputsCollapsed })}
             highlightToken={inputHighlightToken}
@@ -483,7 +548,7 @@ function App() {
                   scenario={base}
                   index={0}
                   isBase={true}
-                  onApplyScenario={(data) => updateCompany(cid, data)}
+                  onApplyScenario={(data) => updateCompanyFromInputs(cid, data)}
                   onCopyPermalink={handleCopyPermalink}
                   onSharePermalink={handleSharePermalink}
                   investorName={companies[cid]?.investorName || 'US'}
@@ -491,7 +556,7 @@ function App() {
                   percentPrecision={companies[cid]?.percentPrecision || 2}
                   onPercentPrecisionChange={(pp) => updateCompany(cid, { percentPrecision: pp })}
                   company={companies[cid]}
-                  onUpdateBase={(patch) => updateCompany(cid, patch)}
+                  onUpdateBase={(patch) => updateCompanyFromInputs(cid, patch)}
                   companyName={isCompareMode ? companies[cid]?.name : undefined}
                   compareActive={isCompareMode ? cid === activeCompany : undefined}
                   compareIndex={isCompareMode ? idx : undefined}

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -128,7 +128,11 @@ function App() {
           ...normalizedPrev,
           [activeCompany]: {
             ...currentCompany,
-            safes: [...(currentCompany.safes || []), ...importedSafes]
+            safes: [...(currentCompany.safes || []), ...importedSafes],
+            importWarnings: [
+              ...(Array.isArray(currentCompany.importWarnings) ? currentCompany.importWarnings : []),
+              ...(Array.isArray(importedCompany.importWarnings) ? importedCompany.importWarnings : [])
+            ]
           }
         }
       })

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -314,7 +314,8 @@ describe('App Component - Local Storage Integration', () => {
       fireEvent.change(screen.getByLabelText(/paste json/i), {
         target: {
           value: JSON.stringify({
-            safes: [{ investorName: 'Bridge Investor', amount: 1, cap: 20 }]
+            _warning: 'No cap table was provided',
+            safes: [{ investorName: 'Bridge Investor', amount: 1, cap: 20, _notes: 'Side letter says pro-rata' }]
           })
         }
       })
@@ -328,6 +329,8 @@ describe('App Component - Local Storage Integration', () => {
         const stored = JSON.parse(localStorage.getItem('valuationFramework'))
         expect(stored.company1.safes).toHaveLength(1)
         expect(stored.company1.safes[0].investorName).toBe('Bridge Investor')
+        expect(stored.company1.safes[0].notes).toBe('Side letter says pro-rata')
+        expect(stored.company1.importWarnings).toEqual(['No cap table was provided'])
       })
     })
 

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -339,6 +339,7 @@ describe('App Component - Local Storage Integration', () => {
         within(screen.getByRole('dialog', { name: /import cap table/i }))
           .getByRole('button', { name: 'Import' })
       )
+      await user.click(screen.getByRole('radio', { name: /append to active scenario/i }))
       await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
 
       await waitFor(() => {
@@ -458,6 +459,7 @@ describe('App Component - Local Storage Integration', () => {
         within(screen.getByRole('dialog', { name: /import cap table/i }))
           .getByRole('button', { name: 'Import' })
       )
+      await user.click(screen.getByRole('radio', { name: /append to default round/i }))
       await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
 
       await waitFor(() => {

--- a/react-app/src/App.localStorage.test.jsx
+++ b/react-app/src/App.localStorage.test.jsx
@@ -298,15 +298,31 @@ describe('App Component - Local Storage Integration', () => {
           investorPortion: 4,
           otherPortion: 1,
           investorName: 'US',
-          showAdvanced: true,
+          showAdvanced: false,
+          inputsCollapsed: true,
+          showExitMath: true,
           founders: [{ name: 'Founder Team', ownershipPercent: 85 }],
           priorInvestors: [{ name: 'Seed Investors', ownershipPercent: 15 }],
           safes: [],
           currentEsopPercent: 0,
           targetEsopPercent: 0,
           esopTiming: 'pre-close'
+        },
+        company2: {
+          name: 'Compare Scenario',
+          postMoneyVal: 20,
+          roundSize: 5,
+          investorPortion: 4,
+          otherPortion: 1,
+          investorName: 'US',
+          showAdvanced: false,
+          safes: [],
+          currentEsopPercent: 0,
+          targetEsopPercent: 0,
+          esopTiming: 'pre-close'
         }
       }))
+      localStorage.setItem('valuationFrameworkSelected', JSON.stringify(['company1', 'company2']))
 
       render(<App />)
 
@@ -331,6 +347,11 @@ describe('App Component - Local Storage Integration', () => {
         expect(stored.company1.safes[0].investorName).toBe('Bridge Investor')
         expect(stored.company1.safes[0].notes).toBe('Side letter says pro-rata')
         expect(stored.company1.importWarnings).toEqual(['No cap table was provided'])
+        expect(stored.company1.showAdvanced).toBe(true)
+        expect(stored.company1.inputsCollapsed).toBe(false)
+        expect(stored.company1.showExitMath).toBe(false)
+        expect(stored.company1.roundConstructPending).toBe(true)
+        expect(JSON.parse(localStorage.getItem('valuationFrameworkSelected'))).toEqual([])
       })
     })
 
@@ -351,8 +372,22 @@ describe('App Component - Local Storage Integration', () => {
           currentEsopPercent: 0,
           targetEsopPercent: 0,
           esopTiming: 'pre-close'
+        },
+        company2: {
+          name: 'Acme Variant',
+          postMoneyVal: 13,
+          roundSize: 3,
+          investorPortion: 2.75,
+          otherPortion: 0.25,
+          investorName: 'US',
+          showAdvanced: false,
+          safes: [],
+          currentEsopPercent: 0,
+          targetEsopPercent: 0,
+          esopTiming: 'pre-close'
         }
       }))
+      localStorage.setItem('valuationFrameworkSelected', JSON.stringify(['company1', 'company2']))
 
       render(<App />)
 
@@ -373,7 +408,73 @@ describe('App Component - Local Storage Integration', () => {
 
       await waitFor(() => {
         const stored = JSON.parse(localStorage.getItem('valuationFramework'))
-        expect(Object.values(stored).map(company => company.name)).toContain('Acme 2')
+        const imported = Object.values(stored).find(company => company.name === 'Acme 2')
+        expect(imported).toBeTruthy()
+        expect(imported.showAdvanced).toBe(true)
+        expect(imported.inputsCollapsed).toBe(false)
+        expect(imported.showExitMath).toBe(false)
+        expect(imported.roundConstructPending).toBe(true)
+        expect(JSON.parse(localStorage.getItem('valuationFrameworkSelected'))).toEqual([])
+      })
+
+      expect(screen.getByDisplayValue('CEO')).toBeInTheDocument()
+    })
+
+    it('should suppress imported round-split errors until round inputs are edited', async () => {
+      const user = userEvent.setup()
+      localStorage.setItem('valuationFramework', JSON.stringify({
+        company1: {
+          name: 'Default Round',
+          postMoneyVal: 13,
+          roundSize: 3,
+          investorPortion: 2.75,
+          otherPortion: 0.25,
+          investorName: 'US',
+          showAdvanced: false,
+          safes: [],
+          currentEsopPercent: 0,
+          targetEsopPercent: 0,
+          esopTiming: 'pre-close'
+        }
+      }))
+
+      render(<App />)
+
+      await user.click(screen.getByRole('button', { name: /import/i }))
+      fireEvent.change(screen.getByLabelText(/paste json/i), {
+        target: {
+          value: JSON.stringify({
+            safes: [{
+              investorName: 'Large Pro-Rata SAFE',
+              amount: 1,
+              conversionType: 'fixed-percent',
+              fixedOwnershipPercent: 50,
+              proRata: true
+            }]
+          })
+        }
+      })
+      await user.click(
+        within(screen.getByRole('dialog', { name: /import cap table/i }))
+          .getByRole('button', { name: 'Import' })
+      )
+      await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('valuationFramework'))
+        expect(stored.company1.roundConstructPending).toBe(true)
+        expect(stored.company1.showAdvanced).toBe(true)
+      })
+
+      expect(screen.queryByText(/Total pro-rata amount/)).not.toBeInTheDocument()
+
+      const otherPortionInputs = screen.getAllByLabelText('Other Portion')
+      await user.clear(otherPortionInputs[0])
+      await user.type(otherPortionInputs[0], '0.2')
+
+      await waitFor(() => {
+        const stored = JSON.parse(localStorage.getItem('valuationFramework'))
+        expect(stored.company1.roundConstructPending).toBe(false)
       })
     })
   })

--- a/react-app/src/components/ImportModal.jsx
+++ b/react-app/src/components/ImportModal.jsx
@@ -61,6 +61,7 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
       company: result.company,
       safes: result.safes || [],
       warnings: result.warnings || [],
+      roundConstructEntered: Boolean(result.roundConstructEntered),
       destination
     })
   }

--- a/react-app/src/components/ImportModal.jsx
+++ b/react-app/src/components/ImportModal.jsx
@@ -12,7 +12,7 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
   // pendingPreview holds a validated result so the user can review warnings
   // before committing the import.
   const [pendingPreview, setPendingPreview] = useState(null)
-  const [safeDestination, setSafeDestination] = useState('append')
+  const [safeDestination, setSafeDestination] = useState('new')
   const [promptOpen, setPromptOpen] = useState(false)
   const [copiedPrompt, setCopiedPrompt] = useState(false)
   const textareaRef = useRef(null)
@@ -23,7 +23,7 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
       setJsonText('')
       setErrors([])
       setPendingPreview(null)
-      setSafeDestination('append')
+      setSafeDestination('new')
       setPromptOpen(false)
       setCopiedPrompt(false)
     }
@@ -34,7 +34,7 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
   useEffect(() => {
     if (pendingPreview && pendingPreview.sourceText !== jsonText) {
       setPendingPreview(null)
-      setSafeDestination('append')
+      setSafeDestination('new')
     }
   }, [jsonText, pendingPreview])
 
@@ -84,7 +84,7 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
     setErrors([])
     const warnings = result.warnings || []
     if (result.importKind === 'safe-only') {
-      setSafeDestination('append')
+      setSafeDestination('new')
       setPendingPreview({ ...result, warnings, sourceText: jsonText })
       return
     }
@@ -141,81 +141,83 @@ function ImportModal({ open, activeCompanyName = 'active scenario', onClose, onI
           </button>
         </div>
 
-        <p className="import-modal-intro">
-          Paste a JSON cap table below. Get one by sending the prompt below to Claude with the cap table XLS and any SAFE PDFs attached.
-        </p>
+        <div className="import-modal-body">
+          <p className="import-modal-intro">
+            Paste a JSON cap table below. Get one by sending the prompt below to Claude with the cap table XLS and any SAFE PDFs attached.
+          </p>
 
-        <div className="import-modal-prompts">
-          <PromptDisclosure
-            title="Prompt for cap table + SAFE files"
-            description="Use with the spreadsheet and any SAFE PDFs in one Claude chat."
-            prompt={IMPORT_PROMPT}
-            isOpen={promptOpen}
-            isCopied={copiedPrompt}
-            onToggle={() => setPromptOpen((open) => !open)}
-            onCopy={handleCopyPrompt}
+          <div className="import-modal-prompts">
+            <PromptDisclosure
+              title="Prompt for cap table + SAFE files"
+              description="Use with the spreadsheet and any SAFE PDFs in one Claude chat."
+              prompt={IMPORT_PROMPT}
+              isOpen={promptOpen}
+              isCopied={copiedPrompt}
+              onToggle={() => setPromptOpen((open) => !open)}
+              onCopy={handleCopyPrompt}
+            />
+          </div>
+
+          <label className="import-modal-textarea-label" htmlFor="import-json-textarea">
+            Paste JSON
+          </label>
+          <textarea
+            id="import-json-textarea"
+            ref={textareaRef}
+            className="import-modal-textarea"
+            value={jsonText}
+            onChange={(e) => setJsonText(e.target.value)}
+            placeholder={'{\n  "name": "Acme",\n  "founders": [ ... ],\n  "priorInvestors": [ ... ],\n  "safes": [ ... ]\n}'}
+            spellCheck={false}
           />
+
+          {errors.length > 0 && (
+            <div className="import-modal-errors" role="alert">
+              <strong>Couldn&rsquo;t import:</strong>
+              <ul>
+                {errors.map((e, i) => <li key={i}>{e}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {pendingPreview && pendingPreview.warnings.length > 0 && (
+            <div className="import-modal-warnings">
+              <strong>Looks good — but check these before importing:</strong>
+              <ul>
+                {pendingPreview.warnings.map((w, i) => <li key={i}>{w}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {isSafeOnlyPreview && (
+            <div className="import-modal-destination" role="group" aria-labelledby="import-destination-title">
+              <strong id="import-destination-title">Found {formatSafeCount(previewSafeCount)}</strong>
+              <p>Choose where to import these SAFE notes.</p>
+              <label className="import-destination-option">
+                <input
+                  type="radio"
+                  name="safe-import-destination"
+                  value="new"
+                  checked={safeDestination === 'new'}
+                  onChange={() => setSafeDestination('new')}
+                />
+                <span>Create a new imported scenario</span>
+              </label>
+              <label className="import-destination-option">
+                <input
+                  type="radio"
+                  name="safe-import-destination"
+                  value="append"
+                  checked={safeDestination === 'append'}
+                  onChange={() => setSafeDestination('append')}
+                />
+                <span>
+                  Append to <strong>{activeCompanyName}</strong>
+                </span>
+              </label>
+            </div>
+          )}
         </div>
-
-        <label className="import-modal-textarea-label" htmlFor="import-json-textarea">
-          Paste JSON
-        </label>
-        <textarea
-          id="import-json-textarea"
-          ref={textareaRef}
-          className="import-modal-textarea"
-          value={jsonText}
-          onChange={(e) => setJsonText(e.target.value)}
-          placeholder={'{\n  "name": "Acme",\n  "founders": [ ... ],\n  "priorInvestors": [ ... ],\n  "safes": [ ... ]\n}'}
-          spellCheck={false}
-        />
-
-        {errors.length > 0 && (
-          <div className="import-modal-errors" role="alert">
-            <strong>Couldn&rsquo;t import:</strong>
-            <ul>
-              {errors.map((e, i) => <li key={i}>{e}</li>)}
-            </ul>
-          </div>
-        )}
-
-        {pendingPreview && pendingPreview.warnings.length > 0 && (
-          <div className="import-modal-warnings">
-            <strong>Looks good — but check these before importing:</strong>
-            <ul>
-              {pendingPreview.warnings.map((w, i) => <li key={i}>{w}</li>)}
-            </ul>
-          </div>
-        )}
-
-        {isSafeOnlyPreview && (
-          <div className="import-modal-destination" role="group" aria-labelledby="import-destination-title">
-            <strong id="import-destination-title">Found {formatSafeCount(previewSafeCount)}</strong>
-            <p>Choose where to import these SAFE notes.</p>
-            <label className="import-destination-option">
-              <input
-                type="radio"
-                name="safe-import-destination"
-                value="append"
-                checked={safeDestination === 'append'}
-                onChange={() => setSafeDestination('append')}
-              />
-              <span>
-                Append to <strong>{activeCompanyName}</strong>
-              </span>
-            </label>
-            <label className="import-destination-option">
-              <input
-                type="radio"
-                name="safe-import-destination"
-                value="new"
-                checked={safeDestination === 'new'}
-                onChange={() => setSafeDestination('new')}
-              />
-              <span>Create a new imported scenario</span>
-            </label>
-          </div>
-        )}
 
         <div className="import-modal-actions">
           <button

--- a/react-app/src/components/ImportModal.test.jsx
+++ b/react-app/src/components/ImportModal.test.jsx
@@ -73,7 +73,7 @@ describe('ImportModal', () => {
     }))
   })
 
-  it('previews SAFE-only JSON and appends to the active scenario by default', async () => {
+  it('previews SAFE-only JSON and creates a new scenario by default', async () => {
     const { user, onImport } = renderImportModal()
 
     pasteJson({
@@ -82,19 +82,19 @@ describe('ImportModal', () => {
     await user.click(screen.getByRole('button', { name: 'Import' }))
 
     expect(screen.getByText('Found 1 SAFE')).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: /append to scenario 1/i })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /create a new imported scenario/i })).toBeChecked()
     expect(onImport).not.toHaveBeenCalled()
 
-    await user.click(screen.getByRole('button', { name: 'Append 1 SAFE' }))
+    await user.click(screen.getByRole('button', { name: 'Create scenario' }))
 
     expect(onImport).toHaveBeenCalledWith(expect.objectContaining({
       importKind: 'safe-only',
-      destination: 'append',
+      destination: 'new',
       safes: [expect.objectContaining({ investorName: 'Bridge Investor' })]
     }))
   })
 
-  it('can create a new scenario from SAFE-only JSON', async () => {
+  it('can append SAFE-only JSON to the active scenario', async () => {
     const { user, onImport } = renderImportModal()
 
     pasteJson({
@@ -104,12 +104,12 @@ describe('ImportModal', () => {
       ]
     })
     await user.click(screen.getByRole('button', { name: 'Import' }))
-    await user.click(screen.getByRole('radio', { name: /create a new imported scenario/i }))
-    await user.click(screen.getByRole('button', { name: 'Create scenario' }))
+    await user.click(screen.getByRole('radio', { name: /append to scenario 1/i }))
+    await user.click(screen.getByRole('button', { name: 'Append 2 SAFEs' }))
 
     expect(onImport).toHaveBeenCalledWith(expect.objectContaining({
       importKind: 'safe-only',
-      destination: 'new',
+      destination: 'append',
       safes: [
         expect.objectContaining({ investorName: 'Bridge Investor' }),
         expect.objectContaining({ investorName: 'Angel' })

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -3,6 +3,7 @@ import PriorInvestorsSection from './PriorInvestorsSection'
 import FoundersSection from './FoundersSection'
 import FormInput from './FormInput'
 import { migrateLegacyCompany } from '../utils/dataStructures'
+import { resolveSafeConversion } from '../utils/multiPartyCalculations'
 
 const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, highlightToken = 0 }) => {
   const roundToCents = (value) => Math.round(Math.max(0, value) * 100) / 100
@@ -191,6 +192,38 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
 
   const preMoneyVal = Math.round((values.postMoneyVal - values.roundSize) * 100) / 100
   const safePreMoneyVal = isNaN(preMoneyVal) ? 0 : preMoneyVal
+  const safeRows = values.safes || []
+  const safeSummary = safeRows.reduce((summary, safe) => {
+    const amount = Number(safe.amount) || 0
+    summary.totalAmount += amount
+    if (safe.proRata) summary.proRataCount += 1
+    if (safe.conversionType === 'fixed-percent') summary.fixedCount += 1
+    if (safe.conversionType === 'mfn') summary.mfnCount += 1
+    if ((safe.notes || '').trim()) summary.noteCount += 1
+    return summary
+  }, { totalAmount: 0, proRataCount: 0, fixedCount: 0, mfnCount: 0, noteCount: 0 })
+  const importWarnings = Array.isArray(values.importWarnings) ? values.importWarnings : []
+
+  const formatSafeAmount = (amount) => {
+    const value = Number(amount) || 0
+    return `$${value.toLocaleString(undefined, { minimumFractionDigits: value < 1 ? 3 : 2, maximumFractionDigits: 3 })}M`
+  }
+
+  const getSafeTermLabel = (safe) => {
+    const conversionType = safe.conversionType || 'cap-discount'
+    if (conversionType === 'fixed-percent') {
+      return `Fixed ${(Number(safe.fixedOwnershipPercent) || 0).toFixed(2)}%`
+    }
+    if (conversionType === 'round-price') return 'Round price'
+
+    const cap = Number(safe.cap) || 0
+    const discount = Number(safe.discount) || 0
+    const pieces = []
+    if (cap > 0) pieces.push(`$${cap.toFixed(cap < 10 ? 1 : 0)}M cap`)
+    if (discount > 0) pieces.push(`${discount}% discount`)
+    const fallback = pieces.length > 0 ? pieces.join(' + ') : 'Round price'
+    return conversionType === 'mfn' ? `MFN - ${fallback}` : fallback
+  }
   
   const handleToggleInputMode = () => {
     setMoneyToggleSwapping(true)
@@ -205,6 +238,8 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
     const newSafe = {
       id, // Simple ID generation
       amount: 0,
+      conversionType: 'cap-discount',
+      fixedOwnershipPercent: 0,
       cap: 0,
       discount: 0,
       investorName: '',
@@ -248,13 +283,13 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
   }
 
   const updateSafe = (safeId, field, value) => {
-    // Handle string fields (investorName)
-    if (field === 'investorName') {
+    // Handle string fields.
+    if (field === 'investorName' || field === 'conversionType') {
       const newValues = {
         ...values,
         safes: (values.safes || []).map(safe =>
           safe.id === safeId
-            ? { ...safe, investorName: value }
+            ? { ...safe, [field]: value }
             : safe
         )
       }
@@ -309,6 +344,8 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
     if (numValue > 1000000) numValue = 1000000
     // Limit discount to 100%
     if (field === 'discount' && numValue > 100) numValue = 100
+    // Limit fixed ownership to 100%
+    if (field === 'fixedOwnershipPercent' && numValue > 100) numValue = 100
 
     const newValues = {
       ...values,
@@ -841,7 +878,32 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
               </div>
             </div>
 
-            {(!values.safes || values.safes.length === 0) ? (
+            {(importWarnings.length > 0 || safeRows.length > 0) && (
+              <div className="safe-import-context">
+                {safeRows.length > 0 && (
+                  <div className="safe-summary-strip" aria-label="SAFE import summary">
+                    <span><strong>{safeRows.length}</strong> SAFEs</span>
+                    <span><strong>{formatSafeAmount(safeSummary.totalAmount)}</strong> total</span>
+                    <span><strong>{safeSummary.proRataCount}</strong> pro-rata</span>
+                    {(safeSummary.fixedCount > 0 || safeSummary.mfnCount > 0) && (
+                      <span><strong>{safeSummary.fixedCount + safeSummary.mfnCount}</strong> non-standard</span>
+                    )}
+                    {safeSummary.noteCount > 0 && (
+                      <span><strong>{safeSummary.noteCount}</strong> notes</span>
+                    )}
+                  </div>
+                )}
+                {importWarnings.length > 0 && (
+                  <div className="safe-import-warning">
+                    {importWarnings.map((warning, index) => (
+                      <p key={index}>{warning}</p>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {safeRows.length === 0 ? (
               <div className="no-safes-message">
                 No SAFE notes. Add convertibles to see how they convert into this round at their cap or discount.
               </div>
@@ -850,51 +912,38 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
                 <div className="repeater-header">
                   <span className="repeater-col repeater-col--name">Investor</span>
                   <span className="repeater-col repeater-col--amount">Amount</span>
+                  <span className="repeater-col repeater-col--type">Type</span>
                   <span className="repeater-col repeater-col--cap">Cap</span>
                   <span className="repeater-col repeater-col--discount">Discount</span>
                   <span className="repeater-col repeater-col--prorata">Pro-rata</span>
                   <span className="repeater-col repeater-col--actions" aria-hidden="true" />
                 </div>
-                {values.safes.map((safe) => {
+                {safeRows.map((safe) => {
+                  const conversionType = safe.conversionType || 'cap-discount'
+                  const isFixedPercentSafe = conversionType === 'fixed-percent'
+                  const isRoundPriceSafe = conversionType === 'round-price'
+                  const safeNotes = (safe.notes || '').trim()
+                  const termLabel = getSafeTermLabel(safe)
                   // Conversion valuation for the caption under the row
                   const conversionInfo = (() => {
-                    if (!(safe.amount > 0 && (safe.cap > 0 || safe.discount > 0))) return null
-                    let val, note
-                    if (safe.cap > 0 && safe.discount > 0) {
-                      const capPrice = safe.cap
-                      const discountPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                      if (capPrice < discountPrice) {
-                        val = capPrice
-                        note = `cap vs ${safe.discount}% discount`
-                      } else {
-                        val = discountPrice
-                        note = `discount vs $${capPrice.toFixed(1)}M cap`
-                      }
-                    } else if (safe.cap > 0) {
-                      val = Math.min(safe.cap, safePreMoneyVal)
-                      note = `cap $${safe.cap.toFixed(1)}M`
-                    } else {
-                      val = safePreMoneyVal * (1 - safe.discount / 100)
-                      note = `${safe.discount}% discount`
+                    if (safe.amount <= 0) return null
+                    const conversion = resolveSafeConversion(safe, safePreMoneyVal)
+                    if (!conversion.percent) return null
+                    if (conversion.conversionType === 'fixed-percent') {
+                      return `Converts at ${conversion.conversionLabel}`
                     }
-                    return `Converts at $${val.toFixed(1)}M (${note})`
+                    if (conversion.conversionType === 'round-price' || conversion.conversionLabel === 'round price') {
+                      return `Converts at round price ($${conversion.conversionPrice.toFixed(1)}M)`
+                    }
+                    return `Converts at $${conversion.conversionPrice.toFixed(1)}M (${conversion.conversionLabel})`
                   })()
 
                   // Pro-rata allocation calculation
                   let proRataBlock = null
                   if (safe.proRata && safe.amount > 0 && values.roundSize > 0) {
-                    let conversionPrice = 0
-                    if (safe.cap > 0 && safe.discount > 0) {
-                      conversionPrice = Math.min(safe.cap, safePreMoneyVal * (1 - safe.discount / 100))
-                    } else if (safe.cap > 0) {
-                      conversionPrice = Math.min(safe.cap, safePreMoneyVal)
-                    } else if (safe.discount > 0) {
-                      conversionPrice = safePreMoneyVal * (1 - safe.discount / 100)
-                    } else {
-                      conversionPrice = safePreMoneyVal
-                    }
-                    if (conversionPrice > 0) {
-                      const safeOwnership = (safe.amount / conversionPrice) * 100
+                    const conversion = resolveSafeConversion(safe, safePreMoneyVal)
+                    if (conversion.percent > 0) {
+                      const safeOwnership = conversion.percent
                       const calculatedProRata = (safeOwnership / 100) * values.roundSize
                       const hasOverride = safe.proRataOverride != null
                       const displayAmount = hasOverride ? safe.proRataOverride : calculatedProRata
@@ -938,34 +987,72 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
                           compact
                         />
                       </div>
+                      <div className="repeater-col repeater-col--type">
+                        <label className="sr-only" htmlFor={`safe-type-${safe.id}`}>SAFE type</label>
+                        <select
+                          id={`safe-type-${safe.id}`}
+                          className="repeater-select"
+                          value={conversionType}
+                          onChange={(e) => updateSafe(safe.id, 'conversionType', e.target.value)}
+                          aria-label="SAFE type"
+                        >
+                          <option value="cap-discount">Cap/Disc.</option>
+                          <option value="fixed-percent">Fixed %</option>
+                          <option value="round-price">Round price</option>
+                          <option value="mfn">MFN</option>
+                        </select>
+                      </div>
                       <div className="repeater-col repeater-col--cap">
-                        <FormInput
-                          label="Cap"
-                          type="number"
-                          value={safe.cap}
-                          onChange={(value) => updateSafe(safe.id, 'cap', value)}
-                          prefix="$"
-                          suffix="M"
-                          step="0.5"
-                          min="0"
-                          placeholder="0 = uncapped"
-                          id={`safe-cap-${safe.id}`}
-                          compact
-                        />
+                        {isFixedPercentSafe ? (
+                          <FormInput
+                            label="Fixed %"
+                            type="number"
+                            value={safe.fixedOwnershipPercent || 0}
+                            onChange={(value) => updateSafe(safe.id, 'fixedOwnershipPercent', value)}
+                            suffix="%"
+                            step="0.1"
+                            min="0"
+                            max="100"
+                            id={`safe-fixed-percent-${safe.id}`}
+                            compact
+                          />
+                        ) : isRoundPriceSafe ? (
+                          <span className="repeater-muted-cell">round</span>
+                        ) : (
+                          <FormInput
+                            label="Cap"
+                            type="number"
+                            value={safe.cap}
+                            onChange={(value) => updateSafe(safe.id, 'cap', value)}
+                            prefix="$"
+                            suffix="M"
+                            step="0.5"
+                            min="0"
+                            placeholder="0 = uncapped"
+                            id={`safe-cap-${safe.id}`}
+                            compact
+                          />
+                        )}
                       </div>
                       <div className="repeater-col repeater-col--discount">
-                        <FormInput
-                          label="Discount"
-                          type="number"
-                          value={safe.discount}
-                          onChange={(value) => updateSafe(safe.id, 'discount', value)}
-                          suffix="%"
-                          step="1"
-                          min="0"
-                          max="100"
-                          id={`safe-discount-${safe.id}`}
-                          compact
-                        />
+                        {isFixedPercentSafe ? (
+                          <span className="repeater-muted-cell">fixed</span>
+                        ) : isRoundPriceSafe ? (
+                          <span className="repeater-muted-cell">price</span>
+                        ) : (
+                          <FormInput
+                            label="Discount"
+                            type="number"
+                            value={safe.discount}
+                            onChange={(value) => updateSafe(safe.id, 'discount', value)}
+                            suffix="%"
+                            step="1"
+                            min="0"
+                            max="100"
+                            id={`safe-discount-${safe.id}`}
+                            compact
+                          />
+                        )}
                       </div>
                       <div className="repeater-col repeater-col--prorata">
                         <label className="repeater-checkbox" title="Pro-rata rights">
@@ -986,12 +1073,22 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
                           ×
                         </button>
                       </div>
-                      {(conversionInfo || proRataBlock) && (
+                      {(conversionInfo || proRataBlock || safeNotes) && (
                         <div className="repeater-row-caption">
-                          <span className="repeater-row-caption-text">
-                            {conversionInfo}
-                            {!conversionInfo && proRataBlock?.matchesLead && `Pro-rata handled via ${values.investorName || 'US'} round portion`}
-                          </span>
+                          <div className="safe-row-explainer">
+                            <div className="safe-term-line">
+                              <span className="safe-term-pill">{termLabel}</span>
+                              {Boolean(safe.proRata) && <span className="safe-term-pill safe-term-pill--positive">Pro-rata</span>}
+                              {safeNotes && <span className="safe-term-pill safe-term-pill--note">Side letter</span>}
+                            </div>
+                            <span className="repeater-row-caption-text">
+                              {conversionInfo}
+                              {!conversionInfo && proRataBlock?.matchesLead && `Pro-rata handled via ${values.investorName || 'US'} round portion`}
+                            </span>
+                            {safeNotes && (
+                              <span className="safe-row-note">{safeNotes}</span>
+                            )}
+                          </div>
                           {proRataBlock && !proRataBlock.matchesLead && (
                             <span className="repeater-row-caption-action">
                               <span className="repeater-row-caption-label">Allocation</span>

--- a/react-app/src/components/InputForm.test.jsx
+++ b/react-app/src/components/InputForm.test.jsx
@@ -207,4 +207,105 @@ describe('InputForm with Pre-Money Toggle', () => {
       expect(document.activeElement).toBe(safeInvestorInput)
     })
   })
+
+  it('shows fixed-percent SAFE controls and caption', () => {
+    render(<InputForm
+      company={{
+        ...defaultCompany,
+        showAdvanced: true,
+        safes: [{
+          id: 1,
+          investorName: 'Y Combinator ES24, LLC',
+          amount: 0.125,
+          conversionType: 'fixed-percent',
+          fixedOwnershipPercent: 7,
+          cap: 0,
+          discount: 0,
+          proRata: true
+        }]
+      }}
+      onUpdate={mockOnUpdate}
+    />)
+
+    expect(screen.getByLabelText('SAFE type')).toHaveValue('fixed-percent')
+    expect(screen.getByLabelText('Fixed %')).toHaveValue(7)
+    expect(screen.getByText(/Converts at fixed 7\.00%/)).toBeInTheDocument()
+  })
+
+  it('summarizes large SAFE imports and keeps side-letter notes visible', () => {
+    render(<InputForm
+      company={{
+        ...defaultCompany,
+        showAdvanced: true,
+        importWarnings: ['No cap table was provided'],
+        safes: [
+          {
+            id: 1,
+            investorName: 'The LegalTech Fund II, L.P.',
+            amount: 0.1,
+            conversionType: 'cap-discount',
+            cap: 8,
+            discount: 0,
+            proRata: true,
+            notes: 'Pro-rata, info rights, and MFN granted via separate side letter'
+          },
+          {
+            id: 2,
+            investorName: 'Y Combinator ES24, LLC',
+            amount: 0.125,
+            conversionType: 'fixed-percent',
+            fixedOwnershipPercent: 7,
+            proRata: false
+          }
+        ]
+      }}
+      onUpdate={mockOnUpdate}
+    />)
+
+    expect(screen.getByLabelText('SAFE import summary')).toHaveTextContent('2 SAFEs')
+    expect(screen.getByLabelText('SAFE import summary')).toHaveTextContent('$0.225M total')
+    expect(screen.getByText('No cap table was provided')).toBeInTheDocument()
+    expect(screen.getByText('Side letter')).toBeInTheDocument()
+    expect(screen.getByText(/Pro-rata, info rights, and MFN granted/)).toBeInTheDocument()
+  })
+
+  it('switches SAFE type selector to MFN and keeps cap/discount controls', async () => {
+    const user = userEvent.setup()
+    render(<InputForm
+      company={{
+        ...defaultCompany,
+        showAdvanced: true,
+        safes: [{ id: 1, investorName: 'YC ESP24, L.P.', amount: 0.375, cap: 0, discount: 0 }]
+      }}
+      onUpdate={mockOnUpdate}
+    />)
+
+    await user.selectOptions(screen.getByLabelText('SAFE type'), 'mfn')
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safes: [expect.objectContaining({ conversionType: 'mfn' })]
+      })
+    )
+    expect(screen.getByLabelText('Cap')).toBeInTheDocument()
+    expect(screen.getByLabelText('Discount')).toBeInTheDocument()
+  })
+
+  it('shows round-price SAFE as non-editable round price fields', () => {
+    render(<InputForm
+      company={{
+        ...defaultCompany,
+        showAdvanced: true,
+        safes: [{ id: 1, investorName: 'Round Price SAFE', amount: 0.1, conversionType: 'round-price' }]
+      }}
+      onUpdate={mockOnUpdate}
+    />)
+
+    expect(screen.getByLabelText('SAFE type')).toHaveValue('round-price')
+    expect(screen.queryByLabelText('Cap')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Discount')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Round price').length).toBeGreaterThan(0)
+    expect(screen.getByText('round')).toBeInTheDocument()
+    expect(screen.getByText('price')).toBeInTheDocument()
+  })
 })

--- a/react-app/src/components/ScenarioCard-display.test.jsx
+++ b/react-app/src/components/ScenarioCard-display.test.jsx
@@ -332,6 +332,81 @@ describe('ScenarioCard Display Logic', () => {
   })
 
   describe('SAFE Display', () => {
+    it('shows base case headline metrics', () => {
+      const scenarioWithSafes = {
+        ...baseScenario,
+        founders: [{ id: 1, name: 'Founders', postRoundPercent: 60, dilution: 20 }],
+        totalSafePercent: 7.5,
+        safeDetails: [{ id: 1, index: 1, investorName: 'YC', amount: 0.125, conversionLabel: 'fixed 7.00%', percent: 7 }]
+      }
+
+      const { getByText, getAllByText } = render(
+        <ScenarioCard
+          scenario={scenarioWithSafes}
+          index={0}
+          isBase={true}
+          showAdvanced={true}
+          investorName="LSVP"
+        />
+      )
+
+      expect(getByText('LSVP')).toBeTruthy()
+      expect(getByText('Founders')).toBeTruthy()
+      expect(getByText('SAFEs')).toBeTruthy()
+      expect(getByText('Pre-Money')).toBeTruthy()
+      expect(getAllByText('7.50%').length).toBeGreaterThan(0)
+    })
+
+    it('shows import warning on the base case card', () => {
+      const { getByText } = render(
+        <ScenarioCard
+          scenario={baseScenario}
+          index={0}
+          isBase={true}
+          showAdvanced={true}
+          investorName="US"
+          company={{ importWarnings: ['No cap table was provided'] }}
+        />
+      )
+
+      expect(getByText('No cap table was provided')).toBeTruthy()
+    })
+
+    it('summarizes and collapses large SAFE lists on the base case card', () => {
+      const manySafes = Array.from({ length: 9 }, (_, index) => ({
+        id: index + 1,
+        index: index + 1,
+        investorName: `Investor ${index + 1}`,
+        amount: 0.1,
+        conversionType: index === 0 ? 'mfn' : 'cap-discount',
+        conversionLabel: index === 0 ? 'MFN at round price' : '$8.0M cap',
+        percent: 1,
+        proRata: index < 2,
+        proRataAmount: 0
+      }))
+      const scenarioWithSafes = {
+        ...baseScenario,
+        safeDetails: manySafes,
+        totalSafeAmount: 0.9,
+        totalSafePercent: 9
+      }
+
+      const { getByText, queryByText } = render(
+        <ScenarioCard
+          scenario={scenarioWithSafes}
+          index={0}
+          isBase={true}
+          showAdvanced={true}
+          investorName="US"
+        />
+      )
+
+      expect(getByText((content, _element) => content.includes('9 notes'))).toBeTruthy()
+      expect(getByText((content, _element) => content.includes('2 pro-rata'))).toBeTruthy()
+      expect(getByText((content, _element) => content.includes('1 non-standard'))).toBeTruthy()
+      expect(queryByText((content, _element) => content.includes('Investor 1'))).toBeNull()
+    })
+
     it('should show individual SAFEs from safeDetails', () => {
       const scenarioWithSafes = {
         ...baseScenario,
@@ -357,6 +432,48 @@ describe('ScenarioCard Display Logic', () => {
       expect(getByText((content, _element) => content.includes('SAFE #2'))).toBeTruthy()
       expect(getByText((content, _element) => content.includes('$1M @'))).toBeTruthy() // SAFE 1 amount display
       expect(getByText((content, _element) => content.includes('$0.5M @'))).toBeTruthy() // SAFE 2 amount display
+    })
+
+    it('should show first-class SAFE conversion labels', () => {
+      const scenarioWithSafes = {
+        ...baseScenario,
+        safeDetails: [
+          {
+            id: 1,
+            index: 1,
+            amount: 0.125,
+            conversionType: 'fixed-percent',
+            fixedOwnershipPercent: 7,
+            conversionPrice: 1.79,
+            conversionLabel: 'fixed 7.00%',
+            percent: 7
+          },
+          {
+            id: 2,
+            index: 2,
+            amount: 0.375,
+            conversionType: 'mfn',
+            conversionPrice: 80,
+            conversionLabel: 'MFN at round price',
+            percent: 0.46875
+          }
+        ],
+        totalSafeAmount: 0.5,
+        totalSafePercent: 7.46875
+      }
+
+      const { getByText } = render(
+        <ScenarioCard
+          scenario={scenarioWithSafes}
+          index={1}
+          isBase={true}
+          showAdvanced={true}
+          investorName="US"
+        />
+      )
+
+      expect(getByText((content, _element) => content.includes('fixed 7.00%'))).toBeTruthy()
+      expect(getByText((content, _element) => content.includes('MFN at round price'))).toBeTruthy()
     })
 
 

--- a/react-app/src/components/ScenarioCard-quickedit.test.jsx
+++ b/react-app/src/components/ScenarioCard-quickedit.test.jsx
@@ -60,7 +60,7 @@ describe('ScenarioCard Base quick-edit', () => {
     )
     expect(screen.getByText('Post-Money')).toBeInTheDocument()
     expect(screen.getByText('Round')).toBeInTheDocument()
-    expect(screen.getByText('LSVP')).toBeInTheDocument()
+    expect(screen.getAllByText('LSVP').length).toBeGreaterThan(0)
   })
 
   it('updates postMoneyVal on valuation edit', () => {

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -8,13 +8,13 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   const [pressedSection, setPressedSection] = useState(null)
   const [recalculated, setRecalculated] = useState(false)
   const firstScenarioRender = useRef(true)
-  const [collapsed, setCollapsed] = useState({
+  const [collapsed, setCollapsed] = useState(() => ({
     newRound: !isBase,
     founders: !isBase,
     priorInvestors: !isBase,
-    safes: !isBase,
+    safes: !isBase || ((scenario.safeDetails || []).length > 8),
     rolledUpInvestors: !isBase
-  })
+  }))
 
   const toggleCollapse = (section) => {
     setPressedSection(section)
@@ -214,6 +214,14 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
   const headlineFoundersPercent = foundersTotal
   const headlinePreMoney = isTwoStep ? scenario.step1.postMoney - scenario.step1.amount : scenario.preMoneyVal
   const headlinePostMoney = isTwoStep ? scenario.step1.postMoney : scenario.postMoneyVal
+  const safeDetails = scenario.safeDetails || []
+  const safeCount = safeDetails.length
+  const safeTotalAmount = Number.isFinite(Number(scenario.totalSafeAmount))
+    ? Number(scenario.totalSafeAmount)
+    : safeDetails.reduce((sum, safe) => sum + (Number(safe.amount) || 0), 0)
+  const safeProRataCount = safeDetails.filter(safe => (safe.proRataAmount || 0) > 0 || safe.proRata).length
+  const nonStandardSafeCount = safeDetails.filter(safe => ['fixed-percent', 'mfn', 'round-price'].includes(safe.conversionType)).length
+  const companyWarnings = Array.isArray(company?.importWarnings) ? company.importWarnings : []
   let deltaLsvp = null
   let deltaFounders = null
   let deltaPreMoney = null
@@ -321,6 +329,35 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               <span className={`headline-delta ${deltaClass(deltaPreMoney)}`}>{formatDollarDelta(deltaPreMoney)}</span>
             )}
           </div>
+        </div>
+      )}
+
+      {isBase && (
+        <div className="scenario-headline base-headline">
+          <div className="headline-metric">
+            <span className="headline-label">{investorName}</span>
+            <span key={headlineLsvpPercent} className="headline-value metric-roll">{formatPercent(headlineLsvpPercent)}</span>
+          </div>
+          <div className="headline-metric">
+            <span className="headline-label">Founders</span>
+            <span key={headlineFoundersPercent} className="headline-value metric-roll">{formatPercent(headlineFoundersPercent)}</span>
+          </div>
+          <div className="headline-metric">
+            <span className="headline-label">SAFEs</span>
+            <span key={scenario.totalSafePercent || 0} className="headline-value metric-roll">{formatPercent(scenario.totalSafePercent || 0)}</span>
+          </div>
+          <div className="headline-metric">
+            <span className="headline-label">Pre-Money</span>
+            <span key={headlinePreMoney} className="headline-value metric-roll">{formatDollar(headlinePreMoney)}</span>
+          </div>
+        </div>
+      )}
+
+      {isBase && companyWarnings.length > 0 && (
+        <div className="base-case-warning">
+          {companyWarnings.map((warning, warningIndex) => (
+            <p key={warningIndex}>{warning}</p>
+          ))}
         </div>
       )}
 
@@ -626,7 +663,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
         )}
         
         {/* SAFEs */}
-        {showAdvanced && scenario.safeDetails && scenario.safeDetails.length > 0 && (
+        {showAdvanced && safeDetails.length > 0 && (
           <>
             {/* SAFEs header row */}
             <div 
@@ -636,21 +673,34 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
               <div className="label">
                 <span className={`collapse-indicator${collapsed.safes ? ' is-collapsed' : ''}`}>▼</span>
                 <strong>SAFEs Total</strong>
+                <span className="section-row-meta">
+                  {safeCount} notes
+                  {safeProRataCount > 0 ? `, ${safeProRataCount} pro-rata` : ''}
+                  {nonStandardSafeCount > 0 ? `, ${nonStandardSafeCount} non-standard` : ''}
+                </span>
               </div>
-              <div className="amount amount-neutral">converts</div>
+              <div className="amount amount-neutral">{formatDollar(safeTotalAmount)} converts</div>
               <div className="percent percent-bold">{formatPercent(scenario.totalSafePercent)}</div>
             </div>
             {/* Individual SAFEs */}
-            {!collapsed.safes && scenario.safeDetails.map((safe, safeIndex) => {
-              const isLast = safeIndex === scenario.safeDetails.length - 1
+            {!collapsed.safes && safeDetails.map((safe, safeIndex) => {
+              const isLast = safeIndex === safeDetails.length - 1
               const showProRata = (safe.proRataAmount || 0) > 0
               const safeDelay = `${Math.min(safeIndex, 6) * 0.035}s`
+              const safeLabel = safe.investorName || `SAFE #${safe.index}`
               return (
                 <div key={safe.id || safeIndex} style={{ display: 'contents' }}>
                   <div className="table-row sub-row" style={{ animationDelay: safeDelay }}>
-                    <div className="label">{isLast && !showProRata ? '└─' : '├─'} SAFE #{safe.index}{safe.investorName && <span className="safe-attribution"> ({safe.investorName})</span>}</div>
+                    <div className="label">
+                      {isLast && !showProRata ? '└─' : '├─'} {safeLabel}
+                      {safe.investorName && <span className="safe-attribution">SAFE #{safe.index}</span>}
+                    </div>
                     <div className="amount amount-neutral">
-                      <span style={{ fontSize: '0.85rem' }}>${safe.amount}M @ ${safe.conversionPrice}M</span>
+                      <span className="safe-conversion-summary">
+                        {safe.conversionLabel
+                          ? `${formatDollar(Number(safe.amount) || 0)} - ${safe.conversionLabel}`
+                          : `$${safe.amount}M @ $${safe.conversionPrice}M`}
+                      </span>
                     </div>
                     <div className="percent">{formatPercent(safe.percent)}</div>
                   </div>

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -1,5 +1,7 @@
 import { buildScenarioOffsets, normalizeScenarioOffsets } from './scenarioOffsets'
 
+export const SAFE_CONVERSION_TYPES = new Set(['cap-discount', 'fixed-percent', 'round-price', 'mfn'])
+
 /**
  * Data structure definitions for the enhanced valuation framework
  * Supporting multiple prior investors and founders
@@ -174,7 +176,12 @@ function normalizeSafe(safe = {}) {
     ...restSafe
   } = safe
   const proRataOverride = getOptionalNumber(restSafe.proRataOverride, safe.proRataAmount)
+  const conversionType = SAFE_CONVERSION_TYPES.has(restSafe.conversionType)
+    ? restSafe.conversionType
+    : 'cap-discount'
   const base = {
+    conversionType: 'cap-discount',
+    fixedOwnershipPercent: 0,
     proRata: false,
     proRataOverride: null
   }
@@ -182,9 +189,18 @@ function normalizeSafe(safe = {}) {
   return {
     ...base,
     ...restSafe,
+    conversionType,
+    fixedOwnershipPercent: clamp(getOptionalNumber(restSafe.fixedOwnershipPercent) ?? 0, 0, 100),
+    notes: typeof restSafe.notes === 'string' ? restSafe.notes.trim() : '',
     proRata: Boolean(restSafe.proRata),
     proRataOverride: proRataOverride === undefined ? null : Math.max(0, proRataOverride)
   }
+}
+
+function normalizeStringArray(value) {
+  return Array.isArray(value)
+    ? value.map((item) => String(item || '').trim()).filter(Boolean)
+    : []
 }
 
 function looksLikeSingleStoredCompany(value) {
@@ -230,6 +246,7 @@ export function createDefaultCompany(companyName = 'New Company') {
     investorName: 'US',
     showAdvanced: false,
     percentPrecision: 2,
+    importWarnings: [],
 
     // 2-Step Round support
     twoStepEnabled: false,
@@ -386,6 +403,7 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   delete migrated.preRoundWarrantsPercent
   delete migrated.fdSharesOutstanding
   migrated.percentPrecision = clamp(getOptionalNumber(migrated.percentPrecision) ?? defaults.percentPrecision, 0, 6)
+  migrated.importWarnings = normalizeStringArray(migrated.importWarnings)
 
   // Ensure scenarioOffsets exist
   migrated.scenarioOffsets = normalizeScenarioOffsets(migrated.scenarioOffsets)

--- a/react-app/src/utils/importCompany.js
+++ b/react-app/src/utils/importCompany.js
@@ -27,6 +27,9 @@ const MATERIAL_SCALAR_FIELDS = [
   'step2InvestorPortion',
   'step2OtherPortion'
 ]
+const ROUND_VALUATION_FIELDS = ['postMoneyVal', 'postMoney']
+const ROUND_SIZE_FIELDS = ['roundSize', 'round']
+const ROUND_ALLOCATION_FIELDS = ['investorPortion', 'investor', 'otherPortion', 'other']
 
 let importIdCounter = 0
 
@@ -54,6 +57,18 @@ function getImportKind(raw) {
     !hasMaterialCapTableData(raw)
     ? 'safe-only'
     : 'company'
+}
+
+function hasExplicitRoundConstruct(raw) {
+  const hasValueFor = (fields) => fields.some((key) => (
+    hasOwn(raw, key) &&
+    raw[key] !== null &&
+    raw[key] !== undefined &&
+    raw[key] !== ''
+  ))
+  return hasValueFor(ROUND_VALUATION_FIELDS) &&
+    hasValueFor(ROUND_SIZE_FIELDS) &&
+    hasValueFor(ROUND_ALLOCATION_FIELDS)
 }
 
 function createImportId(prefix, index) {
@@ -301,6 +316,7 @@ export function parseImportJson(text) {
 
   const { cleaned, warnings: metaWarnings } = extractMetadata(raw)
   const importKind = getImportKind(cleaned)
+  const roundConstructEntered = hasExplicitRoundConstruct(cleaned)
 
   // Run through the same migration path as localStorage loading. This handles
   // legacy field names (postMoney/round/investor/other/proRataAmount) and
@@ -311,5 +327,5 @@ export function parseImportJson(text) {
   const company = assignFreshRowIds(migrateLegacyCompany(cleaned, fallbackName))
 
   const warnings = [...metaWarnings, ...softWarnings(company)]
-  return { ok: true, importKind, company, safes: company.safes || [], warnings }
+  return { ok: true, importKind, company, safes: company.safes || [], warnings, roundConstructEntered }
 }

--- a/react-app/src/utils/importCompany.js
+++ b/react-app/src/utils/importCompany.js
@@ -1,4 +1,4 @@
-import { migrateLegacyCompany } from './dataStructures'
+import { SAFE_CONVERSION_TYPES, migrateLegacyCompany } from './dataStructures'
 
 // Fields with these names are stripped before normalization. Claude is asked
 // to attach `_safeType` and `_notes` to SAFEs as metadata for the human user,
@@ -90,6 +90,13 @@ function checkPercent(label, value, errors) {
   }
 }
 
+function checkSafeConversionType(label, value, errors) {
+  if (value === null || value === undefined || value === '') return
+  if (typeof value !== 'string' || !SAFE_CONVERSION_TYPES.has(value)) {
+    errors.push(`${label} must be one of ${Array.from(SAFE_CONVERSION_TYPES).join(', ')}`)
+  }
+}
+
 function checkNonNegative(label, value, errors) {
   if (value === null || value === undefined || value === '') return
   const n = Number(value)
@@ -168,6 +175,16 @@ function hardValidate(raw) {
         checkNonNegative(`safes[${i}].amount`, s.amount, errors)
         checkNonNegative(`safes[${i}].cap`, s.cap, errors)
         checkPercent(`safes[${i}].discount`, s.discount, errors)
+        checkSafeConversionType(`safes[${i}].conversionType`, s.conversionType, errors)
+        checkPercent(`safes[${i}].fixedOwnershipPercent`, s.fixedOwnershipPercent, errors)
+        if (s.conversionType === 'fixed-percent' && (
+          s.fixedOwnershipPercent === null ||
+          s.fixedOwnershipPercent === undefined ||
+          s.fixedOwnershipPercent === '' ||
+          Number(s.fixedOwnershipPercent) <= 0
+        )) {
+          errors.push(`safes[${i}].fixedOwnershipPercent is required for fixed-percent SAFEs`)
+        }
       })
     }
   }
@@ -196,10 +213,17 @@ function extractMetadata(raw) {
   const warnings = []
 
   if (typeof raw._warning === 'string' && raw._warning.trim()) {
-    warnings.push(`Claude flagged: ${raw._warning.trim()}`)
+    const warning = raw._warning.trim()
+    warnings.push(`Claude flagged: ${warning}`)
   }
 
   const cleaned = { ...raw }
+  if (typeof raw._warning === 'string' && raw._warning.trim()) {
+    cleaned.importWarnings = [
+      ...(Array.isArray(raw.importWarnings) ? raw.importWarnings : []),
+      raw._warning.trim()
+    ]
+  }
   for (const key of STRIP_KEYS) delete cleaned[key]
 
   if (Array.isArray(cleaned.safes)) {
@@ -213,6 +237,12 @@ function extractMetadata(raw) {
         warnings.push(`${label}: pre-money SAFE — conversion math in this app assumes post-money SAFEs, so the dilution is approximate.`)
       }
       const stripped = { ...s }
+      if (typeof s._notes === 'string' && s._notes.trim() && !stripped.notes) {
+        stripped.notes = s._notes.trim()
+      }
+      if (stripped._safeType === 'mfn-only' && !stripped.conversionType) {
+        stripped.conversionType = 'mfn'
+      }
       for (const key of STRIP_KEYS) delete stripped[key]
       return stripped
     })

--- a/react-app/src/utils/importCompany.test.js
+++ b/react-app/src/utils/importCompany.test.js
@@ -152,6 +152,26 @@ describe('parseImportJson', () => {
     expect(r.company.safes[0]._safeType).toBeUndefined()
   })
 
+  it('tracks whether the import included a complete round construct', () => {
+    const pending = parseImportJson(JSON.stringify({
+      name: 'Cap Table Only',
+      postMoneyVal: 13,
+      founders: [{ name: 'CEO', ownershipPercent: 80 }]
+    }))
+    expect(pending.ok).toBe(true)
+    expect(pending.roundConstructEntered).toBe(false)
+
+    const entered = parseImportJson(JSON.stringify({
+      name: 'Round Included',
+      postMoneyVal: 13,
+      roundSize: 3,
+      investorPortion: 2.75,
+      founders: [{ name: 'CEO', ownershipPercent: 80 }]
+    }))
+    expect(entered.ok).toBe(true)
+    expect(entered.roundConstructEntered).toBe(true)
+  })
+
   it('keeps SAFE payloads as company imports when cap-table fields are present', () => {
     const r = parseImportJson(JSON.stringify({
       name: 'Acme',

--- a/react-app/src/utils/importCompany.test.js
+++ b/react-app/src/utils/importCompany.test.js
@@ -97,6 +97,61 @@ describe('parseImportJson', () => {
     expect(r.company.safes[0].investorName).toBe('Bridge')
   })
 
+  it('accepts YC fixed-percent and MFN SAFEs', () => {
+    const r = parseImportJson(JSON.stringify({
+      safes: [
+        {
+          investorName: 'Y Combinator ES24, LLC',
+          amount: 0.125,
+          conversionType: 'fixed-percent',
+          fixedOwnershipPercent: 7,
+          proRata: true
+        },
+        {
+          investorName: 'YC ESP24, L.P.',
+          amount: 0.375,
+          conversionType: 'mfn',
+          cap: 0,
+          discount: 0,
+          proRata: true
+        }
+      ]
+    }))
+
+    expect(r.ok).toBe(true)
+    expect(r.importKind).toBe('safe-only')
+    expect(r.company.safes[0].conversionType).toBe('fixed-percent')
+    expect(r.company.safes[0].fixedOwnershipPercent).toBe(7)
+    expect(r.company.safes[1].conversionType).toBe('mfn')
+  })
+
+  it('preserves import warnings and SAFE notes for post-import review', () => {
+    const r = parseImportJson(JSON.stringify({
+      _warning: 'No cap table was provided',
+      safes: [{
+        investorName: 'The LegalTech Fund II, L.P.',
+        amount: 0.1,
+        cap: 8,
+        _notes: 'Pro-rata, info rights, and MFN granted via separate side letter'
+      }]
+    }))
+
+    expect(r.ok).toBe(true)
+    expect(r.company.importWarnings).toEqual(['No cap table was provided'])
+    expect(r.company.safes[0].notes).toBe('Pro-rata, info rights, and MFN granted via separate side letter')
+    expect(r.company.safes[0]._notes).toBeUndefined()
+  })
+
+  it('maps legacy mfn-only SAFE metadata to conversionType', () => {
+    const r = parseImportJson(JSON.stringify({
+      safes: [{ investorName: 'YC ESP', amount: 0.375, _safeType: 'mfn-only' }]
+    }))
+
+    expect(r.ok).toBe(true)
+    expect(r.company.safes[0].conversionType).toBe('mfn')
+    expect(r.company.safes[0]._safeType).toBeUndefined()
+  })
+
   it('keeps SAFE payloads as company imports when cap-table fields are present', () => {
     const r = parseImportJson(JSON.stringify({
       name: 'Acme',
@@ -130,6 +185,15 @@ describe('parseImportJson', () => {
       safes: [{ amount: 1, discount: 150 }]
     }))
     expect(r.ok).toBe(false)
+  })
+
+  it('rejects invalid fixed-percent ownership', () => {
+    const r = parseImportJson(JSON.stringify({
+      name: 'X',
+      safes: [{ amount: 0.125, conversionType: 'fixed-percent', fixedOwnershipPercent: 150 }]
+    }))
+    expect(r.ok).toBe(false)
+    expect(r.errors.some(e => /fixedOwnershipPercent/.test(e))).toBe(true)
   })
 
   it('rejects non-numeric strings like "TBD"', () => {
@@ -230,9 +294,10 @@ describe('parseImportJson', () => {
     expect(r.warnings.some(w => /unclear/.test(w))).toBe(true)
     expect(r.warnings.some(w => /MFN clause/.test(w))).toBe(true)
     expect(r.warnings.some(w => /pre-money/i.test(w))).toBe(true)
-    // Should not be persisted on the safe itself
+    // Warning metadata should not be persisted on the safe itself.
     expect(r.company.safes[0]._safeType).toBeUndefined()
     expect(r.company.safes[0]._notes).toBeUndefined()
+    expect(r.company.safes[0].notes).toBe('MFN clause active')
   })
 
   it('replaces imported row ids so React keys stay unique', () => {

--- a/react-app/src/utils/importPrompts.js
+++ b/react-app/src/utils/importPrompts.js
@@ -13,8 +13,9 @@ const SCHEMA_BLOCK = `{
     { "name": "Pre-seed Angel", "ownershipPercent": 4, "hasProRataRights": false }
   ],
   "safes": [
-    { "investorName": "Bridge Investor", "amount": 2.0, "cap": 40, "discount": 20, "proRata": true, "_safeType": "post-money", "_notes": "optional caveat" },
-    { "investorName": "Accelerator", "amount": 0.5, "cap": 25, "discount": 0, "proRata": false, "_safeType": "mfn-only" }
+    { "investorName": "Bridge Investor", "amount": 2.0, "conversionType": "cap-discount", "cap": 40, "discount": 20, "proRata": true, "_safeType": "post-money", "_notes": "optional caveat" },
+    { "investorName": "Accelerator", "amount": 0.5, "conversionType": "mfn", "cap": 0, "discount": 0, "proRata": false, "_safeType": "mfn-only" },
+    { "investorName": "Y Combinator ES24, LLC", "amount": 0.125, "conversionType": "fixed-percent", "fixedOwnershipPercent": 7, "proRata": true }
   ],
   "warrants": [
     { "name": "Silicon Valley Bank", "amount": 1.0, "valuation": 50 }
@@ -47,7 +48,10 @@ Mapping guidance
 - founders: individuals listed as founders / common stockholders. Roll up multiple share classes or grant tranches for the same person into a single entry (sum the percentages). Exclude granted options — those go into grantedEsopPercent.
 - priorInvestors: every existing investor entity (Seed Fund, angel, strategic). Sum across share classes (Pref-A, Pref-A-1, etc.). Set hasProRataRights: true if the cap table indicates pro-rata rights OR if you see a side letter / "MFN+PR" / explicit pro-rata column.
 - safes: any outstanding SAFEs (often on a separate tab or below the main table). cap in $M, discount 0–100. If both blank, set both to 0 (uncapped, no discount).
-- For each SAFE PDF, investorName is the "Investor" party, amount is the "Purchase Amount", cap is the "Valuation Cap", and discount is the economic discount. A SAFE saying "85% of price" means discount: 15.
+- For each standard cap/discount SAFE PDF, investorName is the "Investor" party, amount is the "Purchase Amount", cap is the "Valuation Cap", and discount is the economic discount. A SAFE saying "85% of price" means discount: 15.
+- Set conversionType to "cap-discount" for normal cap/discount SAFEs, "fixed-percent" when the SAFE converts into a stated ownership percentage (for example, YC Percentage = 7%), "round-price" when it converts at the next round price with no cap/discount economics, or "mfn" for MFN-only SAFEs.
+- For fixed-percent SAFEs, include fixedOwnershipPercent on a 0–100 scale. Example: YC Percentage of seven percent means fixedOwnershipPercent: 7.
+- YC batch packages commonly contain two SAFEs: a $125,000 YC ES SAFE with YC Percentage 7% (conversionType "fixed-percent", fixedOwnershipPercent 7), and a $375,000 YC ESP SAFE with MFN terms (conversionType "mfn", cap 0, discount 0).
 - Set proRata: true if the SAFE or side letter grants pro-rata / participation rights. Otherwise false.
 - Add _safeType: "post-money", "pre-money", or "mfn-only" when the SAFE type is visible. Add _notes for unusual terms such as MFN clauses, side letter caveats, unusual conversion triggers, or unclear extraction.
 - warrants: warrant coverage. valuation is the reference / strike valuation in $M.

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -12,6 +12,73 @@ function rp(v) { return Math.round(v * P) / P }           // round a percentage 
 function r2p(ratio) { return Math.round(ratio * 100 * P) / P } // ratio (0-1) → percentage
 function r$(v) { return Math.round(v * 100) / 100 }        // round a dollar value to cents
 
+function normalizeSafeConversionType(type) {
+  return ['fixed-percent', 'round-price', 'mfn'].includes(type) ? type : 'cap-discount'
+}
+
+export function resolveSafeConversion(safe, preMoneyVal) {
+  const conversionType = normalizeSafeConversionType(safe?.conversionType)
+  const amount = Number(safe?.amount) || 0
+  const cap = Number(safe?.cap) || 0
+  const discount = Number(safe?.discount) || 0
+  const fixedOwnershipPercent = Number(safe?.fixedOwnershipPercent) || 0
+
+  if (conversionType === 'fixed-percent') {
+    if (fixedOwnershipPercent <= 0) {
+      return {
+        conversionType,
+        conversionPrice: 0,
+        percent: 0,
+        conversionLabel: 'fixed percent'
+      }
+    }
+    return {
+      conversionType,
+      conversionPrice: amount > 0 ? r$(amount / (fixedOwnershipPercent / 100)) : 0,
+      percent: rp(fixedOwnershipPercent),
+      conversionLabel: `fixed ${fixedOwnershipPercent.toFixed(2)}%`
+    }
+  }
+
+  let conversionPrice = 0
+  let conversionLabel = 'round price'
+
+  if (conversionType === 'round-price') {
+    conversionPrice = preMoneyVal
+  } else if (cap > 0 && discount > 0) {
+    const capPrice = cap
+    const discountPrice = preMoneyVal * (1 - discount / 100)
+    conversionPrice = Math.min(capPrice, discountPrice)
+    conversionLabel = capPrice < discountPrice
+      ? `cap vs ${discount}% discount`
+      : `discount vs $${capPrice.toFixed(1)}M cap`
+  } else if (cap > 0) {
+    conversionPrice = Math.min(cap, preMoneyVal)
+    conversionLabel = conversionType === 'mfn'
+      ? `MFN, $${cap.toFixed(1)}M cap`
+      : `cap $${cap.toFixed(1)}M`
+  } else if (discount > 0) {
+    conversionPrice = preMoneyVal * (1 - discount / 100)
+    conversionLabel = conversionType === 'mfn'
+      ? `MFN, ${discount}% discount`
+      : `${discount}% discount`
+  } else {
+    conversionPrice = preMoneyVal
+    conversionLabel = conversionType === 'mfn' ? 'MFN at round price' : 'round price'
+  }
+
+  if (conversionType === 'mfn' && cap > 0 && discount > 0) {
+    conversionLabel = `MFN, ${conversionLabel}`
+  }
+
+  return {
+    conversionType,
+    conversionPrice,
+    percent: conversionPrice > 0 ? r2p(amount / conversionPrice) : 0,
+    conversionLabel
+  }
+}
+
 /**
  * Calculate pro-rata allocation for prior investors with pro-rata rights
  * @param {Array} priorInvestors - Array of prior investor objects
@@ -82,23 +149,11 @@ export function calculateSafeConversions(safes, preMoneyVal) {
   if (safes && safes.length > 0) {
     safes.forEach((safe, index) => {
       if (safe.amount > 0) {
-        let conversionPrice = 0
+        const conversion = resolveSafeConversion(safe, preMoneyVal)
+        const conversionPrice = conversion.conversionPrice
+        const safePercent = conversion.percent
 
-        if (safe.cap > 0 && safe.discount > 0) {
-          const capPrice = safe.cap
-          const discountPrice = preMoneyVal * (1 - safe.discount / 100)
-          conversionPrice = Math.min(capPrice, discountPrice)
-        } else if (safe.cap > 0) {
-          conversionPrice = Math.min(safe.cap, preMoneyVal)
-        } else if (safe.discount > 0) {
-          conversionPrice = preMoneyVal * (1 - safe.discount / 100)
-        } else {
-          conversionPrice = preMoneyVal
-        }
-
-        if (conversionPrice > 0) {
-          const safePercent = r2p(safe.amount / conversionPrice)
-
+        if (safePercent > 0) {
           if (safePercent <= 95) {
             totalSafePercent += safePercent
             totalSafeAmount += safe.amount
@@ -109,7 +164,10 @@ export function calculateSafeConversions(safes, preMoneyVal) {
               amount: safe.amount,
               cap: safe.cap,
               discount: safe.discount,
+              conversionType: conversion.conversionType,
+              fixedOwnershipPercent: safe.fixedOwnershipPercent || 0,
               conversionPrice: r$(conversionPrice),
+              conversionLabel: conversion.conversionLabel,
               percent: safePercent,
               investorName: safe.investorName || '',
               proRata: Boolean(safe.proRata),

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -107,6 +107,12 @@ export function encodeScenarioToURL(scenarioData) {
               c: safe.cap || 0,
               d: safe.discount || 0
             }
+            if (safe.conversionType && safe.conversionType !== 'cap-discount') {
+              encoded.t = safe.conversionType
+            }
+            if (safe.conversionType === 'fixed-percent' && safe.fixedOwnershipPercent > 0) {
+              encoded.fp = safe.fixedOwnershipPercent
+            }
             if (safe.investorName && safe.investorName.trim()) {
               encoded.n = safe.investorName.trim()
             }
@@ -285,6 +291,8 @@ export function decodeScenarioFromURL(urlParams) {
                 amount: safe.a || 0,
                 cap: safe.c || 0,
                 discount: safe.d || 0,
+                conversionType: safe.t || 'cap-discount',
+                fixedOwnershipPercent: safe.fp || 0,
                 investorName: safe.n || '',
                 proRata: safe.p === 1 || safe.p === true,
                 proRataOverride: (typeof safe.po === 'number' && safe.po >= 0) ? safe.po : null

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -107,6 +107,38 @@ describe('Permalink Utilities', () => {
       expect(safesData[1]).toEqual({ a: 0.5, c: 0, d: 20 })
     })
 
+    it('should round-trip SAFE conversion type fields', () => {
+      const encoded = encodeScenarioToURL({
+        ...mockScenario,
+        safes: [
+          {
+            id: 1,
+            investorName: 'Y Combinator ES24, LLC',
+            amount: 0.125,
+            conversionType: 'fixed-percent',
+            fixedOwnershipPercent: 7,
+            proRata: true
+          },
+          {
+            id: 2,
+            investorName: 'YC ESP24, L.P.',
+            amount: 0.375,
+            conversionType: 'mfn',
+            cap: 0,
+            discount: 0,
+            proRata: true
+          }
+        ]
+      })
+      const decoded = decodeScenarioFromURL(encoded)
+
+      expect(decoded.safes).toHaveLength(2)
+      expect(decoded.safes[0].conversionType).toBe('fixed-percent')
+      expect(decoded.safes[0].fixedOwnershipPercent).toBe(7)
+      expect(decoded.safes[0].proRata).toBe(true)
+      expect(decoded.safes[1].conversionType).toBe('mfn')
+    })
+
     it('should handle special characters in investor name', () => {
       const scenarioWithSpecialName = { ...mockScenario, investorName: 'US & Partners' }
       const encoded = encodeScenarioToURL(scenarioWithSpecialName)

--- a/react-app/src/utils/safe-pro-rata.test.js
+++ b/react-app/src/utils/safe-pro-rata.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calculateEnhancedScenario, calculateEnhancedScenarios } from './multiPartyCalculations'
+import { calculateEnhancedScenario, calculateEnhancedScenarios, calculateSafeConversions } from './multiPartyCalculations'
 
 const baseInputs = {
   postMoneyVal: 100,
@@ -22,6 +22,69 @@ const baseInputs = {
 }
 
 describe('SAFE Pro-Rata', () => {
+  it('supports fixed-percent SAFEs', () => {
+    const result = calculateSafeConversions([
+      { id: 1, amount: 0.125, conversionType: 'fixed-percent', fixedOwnershipPercent: 7, investorName: 'YC ES' }
+    ], 80)
+
+    expect(result.totalSafePercent).toBe(7)
+    expect(result.safeDetails[0].conversionType).toBe('fixed-percent')
+    expect(result.safeDetails[0].conversionLabel).toBe('fixed 7.00%')
+  })
+
+  it('treats MFN with no cap or discount like round-price conversion', () => {
+    const mfn = calculateSafeConversions([
+      { id: 1, amount: 4, conversionType: 'mfn', cap: 0, discount: 0 }
+    ], 80)
+    const roundPrice = calculateSafeConversions([
+      { id: 1, amount: 4, conversionType: 'round-price', cap: 0, discount: 0 }
+    ], 80)
+
+    expect(mfn.totalSafePercent).toBe(roundPrice.totalSafePercent)
+    expect(mfn.totalSafePercent).toBe(5)
+    expect(mfn.safeDetails[0].conversionLabel).toBe('MFN at round price')
+  })
+
+  it('uses the most favorable MFN cap or discount economics', () => {
+    const result = calculateSafeConversions([
+      { id: 1, amount: 4, conversionType: 'mfn', cap: 40, discount: 20 }
+    ], 80)
+
+    expect(result.totalSafePercent).toBe(10)
+    expect(result.safeDetails[0].conversionPrice).toBe(40)
+    expect(result.safeDetails[0].conversionLabel).toContain('MFN')
+  })
+
+  it('counts YC fixed-percent and MFN SAFEs toward SAFE pro-rata', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      safes: [
+        {
+          id: 1,
+          investorName: 'Y Combinator ES24, LLC',
+          amount: 0.125,
+          conversionType: 'fixed-percent',
+          fixedOwnershipPercent: 7,
+          proRata: true
+        },
+        {
+          id: 2,
+          investorName: 'YC ESP24, L.P.',
+          amount: 0.375,
+          conversionType: 'mfn',
+          cap: 0,
+          discount: 0,
+          proRata: true
+        }
+      ]
+    })
+
+    expect(result.error).toBeFalsy()
+    expect(result.totalSafeProRataAmount).toBeCloseTo(1.49, 2)
+    expect(result.safeDetails[0].proRataAmount).toBeCloseTo(1.4, 2)
+    expect(result.safeDetails[1].proRataAmount).toBeCloseTo(0.09, 2)
+  })
+
   it('does not change results when no SAFE has proRata enabled', () => {
     const result = calculateEnhancedScenario({
       ...baseInputs,


### PR DESCRIPTION
Adds SAFE conversion types for cap/discount, fixed ownership, round price, and MFN so YC batch instruments import and calculate without fake caps. Updates import validation, migration, localStorage persistence, prompt guidance, and permalink encoding for conversionType and fixedOwnershipPercent. Improves the SAFE and base-case displays with type-specific controls, import warnings, side-letter notes, summarized SAFE totals, and clearer scenario labels. Tests cover SAFE math, import parsing, permalink round trips, localStorage append behavior, and focused UI display states.