### PR TITLE
Support SAFE round pro-forma modeling

### DIFF
--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1543,6 +1543,22 @@ body {
   min-width: 0;
 }
 
+.form-select-control {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: #2d3748;
+  font-size: 0.9rem;
+  font-weight: 600;
+  outline: none;
+  min-width: 0;
+  padding: 0.35rem 0.25rem;
+}
+
+.round-type-field .form-input-wrapper {
+  min-width: 170px;
+}
+
 .form-input-control {
   flex: 1;
   border: none;

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -72,6 +72,7 @@ function patchTouchesRoundConstruct(patch) {
     'roundSize',
     'investorPortion',
     'otherPortion',
+    'roundInstrument',
     'twoStepEnabled',
     'step2PostMoney',
     'step2Amount',

--- a/react-app/src/components/InputForm.jsx
+++ b/react-app/src/components/InputForm.jsx
@@ -14,6 +14,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
     investorPortion: 2.75,
     otherPortion: 0.25,
     investorName: 'US',
+    roundInstrument: 'priced',
     // Advanced features
     showAdvanced: false,
     proRataPercent: 0,
@@ -28,6 +29,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
   
   // New state for tracking input mode
   const [inputMode, setInputMode] = useState('post-money') // 'post-money' or 'pre-money'
+  const moneySwapTimerRef = useRef(null)
   const [pulseField, setPulseField] = useState(null)
   const [formHighlight, setFormHighlight] = useState(false)
   const [moneyToggleSwapping, setMoneyToggleSwapping] = useState(false)
@@ -71,6 +73,10 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
     return () => clearTimeout(focusTimerRef.current)
   }, [pendingFocusId, values.safes, values.warrants, inputMode])
 
+  useEffect(() => () => {
+    if (moneySwapTimerRef.current) clearTimeout(moneySwapTimerRef.current)
+  }, [])
+
   const pulseComputedField = (field) => {
     setPulseField(field)
     setTimeout(() => {
@@ -105,10 +111,10 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
   }
 
   const handleChange = (field, value) => {
-    let numValue = field === 'investorName' || field === 'showAdvanced' || field === 'twoStepEnabled' || field === 'esopTiming' ? value : parseFloat(value)
+    let numValue = field === 'investorName' || field === 'roundInstrument' || field === 'showAdvanced' || field === 'twoStepEnabled' || field === 'esopTiming' ? value : parseFloat(value)
 
     // Input validation for numeric fields
-    if (field !== 'investorName' && field !== 'showAdvanced' && field !== 'twoStepEnabled' && field !== 'esopTiming') {
+    if (field !== 'investorName' && field !== 'roundInstrument' && field !== 'showAdvanced' && field !== 'twoStepEnabled' && field !== 'esopTiming') {
       // Handle NaN, empty strings, and invalid inputs
       if (isNaN(numValue) || value === '' || value === null || value === undefined) {
         numValue = 0
@@ -193,6 +199,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
   const preMoneyVal = Math.round((values.postMoneyVal - values.roundSize) * 100) / 100
   const safePreMoneyVal = isNaN(preMoneyVal) ? 0 : preMoneyVal
   const safeRows = values.safes || []
+  const isSafeRound = values.roundInstrument === 'safe'
   const safeSummary = safeRows.reduce((summary, safe) => {
     const amount = Number(safe.amount) || 0
     summary.totalAmount += amount
@@ -229,7 +236,8 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
     setMoneyToggleSwapping(true)
     setInputMode(inputMode === 'post-money' ? 'pre-money' : 'post-money')
     setPendingFocusId('core-valuation-input')
-    setTimeout(() => setMoneyToggleSwapping(false), 380)
+    if (moneySwapTimerRef.current) clearTimeout(moneySwapTimerRef.current)
+    moneySwapTimerRef.current = setTimeout(() => setMoneyToggleSwapping(false), 380)
   }
 
   // SAFE management functions
@@ -534,6 +542,27 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
           step="0.1"
           min="0"
         />
+
+        <div className="form-input-group round-type-field">
+          <div className="form-input-wrapper">
+            <label htmlFor="round-instrument" className="form-input-label">
+              Round Type
+            </label>
+            <div className="form-input-field">
+              <select
+                id="round-instrument"
+                className="form-select-control"
+                value={values.roundInstrument || 'priced'}
+                onChange={(e) => handleChange('roundInstrument', e.target.value)}
+                aria-label="Round type"
+                title="SAFE rounds model pro-forma dilution but do not trigger pro-rata participation."
+              >
+                <option value="priced">Priced</option>
+                <option value="safe">SAFE</option>
+              </select>
+            </div>
+          </div>
+        </div>
 
         <FormInput
           label={`${values.investorName || 'US'} Portion`}
@@ -948,7 +977,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
                       const hasOverride = safe.proRataOverride != null
                       const displayAmount = hasOverride ? safe.proRataOverride : calculatedProRata
                       const matchesLead = (safe.investorName || '').trim() === (values.investorName || 'US').trim()
-                      proRataBlock = { calculatedProRata, hasOverride, displayAmount, matchesLead: matchesLead && !!safe.investorName }
+                      proRataBlock = { calculatedProRata, hasOverride, displayAmount, matchesLead: matchesLead && !!safe.investorName, suppressed: isSafeRound }
                     }
                   }
 
@@ -1085,11 +1114,16 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
                               {conversionInfo}
                               {!conversionInfo && proRataBlock?.matchesLead && `Pro-rata handled via ${values.investorName || 'US'} round portion`}
                             </span>
+                            {proRataBlock?.suppressed && (
+                              <span className="repeater-row-caption-text">
+                                Pro-rata suppressed for SAFE round
+                              </span>
+                            )}
                             {safeNotes && (
                               <span className="safe-row-note">{safeNotes}</span>
                             )}
                           </div>
-                          {proRataBlock && !proRataBlock.matchesLead && (
+                          {proRataBlock && !proRataBlock.matchesLead && !proRataBlock.suppressed && (
                             <span className="repeater-row-caption-action">
                               <span className="repeater-row-caption-label">Allocation</span>
                               <FormInput
@@ -1132,6 +1166,7 @@ const InputForm = ({ company, onUpdate, collapsed = false, onToggleCollapsed, hi
             safes={values.safes || []}
             postMoneyVal={values.postMoneyVal}
             investorPortion={values.investorPortion}
+            roundInstrument={values.roundInstrument || 'priced'}
           />
 
           <FoundersSection

--- a/react-app/src/components/InputForm.test.jsx
+++ b/react-app/src/components/InputForm.test.jsx
@@ -151,6 +151,19 @@ describe('InputForm with Pre-Money Toggle', () => {
     )
   })
 
+  it('updates round type when switching to SAFE', async () => {
+    const user = userEvent.setup()
+    render(<InputForm company={defaultCompany} onUpdate={mockOnUpdate} />)
+
+    await user.selectOptions(screen.getByLabelText('Round type'), 'safe')
+
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roundInstrument: 'safe'
+      })
+    )
+  })
+
   it('should maintain compact styling with proper spacing', () => {
     render(<InputForm company={defaultCompany} onUpdate={mockOnUpdate} />)
     
@@ -307,5 +320,37 @@ describe('InputForm with Pre-Money Toggle', () => {
     expect(screen.getAllByText('Round price').length).toBeGreaterThan(0)
     expect(screen.getByText('round')).toBeInTheDocument()
     expect(screen.getByText('price')).toBeInTheDocument()
+  })
+
+  it('shows pro-rata suppression copy for SAFE rounds', () => {
+    render(<InputForm
+      company={{
+        ...defaultCompany,
+        showAdvanced: true,
+        roundInstrument: 'safe',
+        safes: [{
+          id: 1,
+          investorName: 'Seed SAFE',
+          amount: 1,
+          conversionType: 'cap-discount',
+          cap: 10,
+          discount: 0,
+          proRata: true
+        }],
+        priorInvestors: [{
+          id: 2,
+          name: 'Seed Fund',
+          ownershipPercent: 10,
+          hasProRataRights: true,
+          proRataOverride: null
+        }],
+        founders: []
+      }}
+      onUpdate={mockOnUpdate}
+    />)
+
+    expect(screen.getAllByText('Pro-rata suppressed for SAFE round').length).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByText('Pro-rata allocation')).not.toBeInTheDocument()
+    expect(screen.queryByText('SAFE pro-rata:')).not.toBeInTheDocument()
   })
 })

--- a/react-app/src/components/PriorInvestorsSection.jsx
+++ b/react-app/src/components/PriorInvestorsSection.jsx
@@ -10,7 +10,8 @@ function PriorInvestorsSection({
   investorName = '',
   safes = [],
   postMoneyVal = 0,
-  investorPortion = 0
+  investorPortion = 0,
+  roundInstrument = 'priced'
 }) {
   const [recentRowKey, setRecentRowKey] = useState(null)
   const [removingRows, setRemovingRows] = useState({})
@@ -113,6 +114,7 @@ function PriorInvestorsSection({
 
   const totalOwnership = calculateTotalOwnership(priorInvestors)
   const hasProRataInvestors = priorInvestors.some(inv => inv.hasProRataRights)
+  const isSafeRound = roundInstrument === 'safe'
 
   // Build unified row list: prior investors + SAFEs (post-conversion) + new lead
   const preMoneyVal = Math.max(0, (postMoneyVal || 0) - (roundSize || 0))
@@ -253,7 +255,13 @@ function PriorInvestorsSection({
                       ×
                     </button>
                   </div>
-                  {matchesLead ? (
+                  {isSafeRound && investor.hasProRataRights ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title="SAFE rounds do not trigger pro-rata participation">
+                        Pro-rata suppressed for SAFE round
+                      </span>
+                    </div>
+                  ) : matchesLead ? (
                     <div className="repeater-row-caption">
                       <span className="repeater-row-caption-text" title={`Handled via ${investorName} round portion`}>
                         Pro-rata handled via {investorName} round portion
@@ -322,7 +330,13 @@ function PriorInvestorsSection({
                     </label>
                   </div>
                   <div className="repeater-col repeater-col--actions" aria-hidden="true" />
-                  {matchesLead ? (
+                  {isSafeRound && safe.proRata ? (
+                    <div className="repeater-row-caption">
+                      <span className="repeater-row-caption-text" title="SAFE rounds do not trigger pro-rata participation">
+                        Pro-rata suppressed for SAFE round
+                      </span>
+                    </div>
+                  ) : matchesLead ? (
                     <div className="repeater-row-caption">
                       <span className="repeater-row-caption-text" title={`Handled via ${investorName} round portion`}>
                         Pro-rata handled via {investorName} round portion
@@ -392,7 +406,9 @@ function PriorInvestorsSection({
         <div className="pro-rata-explanation pro-rata-explanation--compact">
           <div className="explanation-icon">ℹ️</div>
           <div className="explanation-text">
-            Pro-rata participants buy in proportional to ownership; allocation is deducted from the "Other" portion. Edit inline to adjust.
+            {isSafeRound
+              ? 'SAFE rounds model pro-forma dilution without triggering pro-rata participation.'
+              : 'Pro-rata participants buy in proportional to ownership; allocation is deducted from the "Other" portion. Edit inline to adjust.'}
           </div>
         </div>
       )}

--- a/react-app/src/components/ScenarioCard.jsx
+++ b/react-app/src/components/ScenarioCard.jsx
@@ -59,6 +59,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
       investorPortion: useCompanyInputs ? (sourceCompany.investorPortion || 0) : (isTwoStep ? scenario.step1.investorAmount : scenario.investorAmount),
       otherPortion: useCompanyInputs ? (sourceCompany.otherPortion || 0) : (isTwoStep ? scenario.step1.otherAmount : (scenario.otherAmountOriginal || scenario.otherAmount)),
       investorName: sourceCompany.investorName || investorName,
+      roundInstrument: sourceCompany.roundInstrument || scenario.roundInstrument || 'priced',
       showAdvanced: sourceCompany.showAdvanced ?? showAdvanced,
       proRataPercent: useCompanyInputs ? (sourceCompany.proRataPercent || 0) : (scenario.proRataPercentInput || 0),
       safes: useCompanyInputs ? (sourceCompany.safes || []) : (scenario.safes || []),
@@ -220,6 +221,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
     ? Number(scenario.totalSafeAmount)
     : safeDetails.reduce((sum, safe) => sum + (Number(safe.amount) || 0), 0)
   const safeProRataCount = safeDetails.filter(safe => (safe.proRataAmount || 0) > 0 || safe.proRata).length
+  const proRataSuppressed = Boolean(scenario.proRataSuppressed)
   const nonStandardSafeCount = safeDetails.filter(safe => ['fixed-percent', 'mfn', 'round-price'].includes(safe.conversionType)).length
   const companyWarnings = Array.isArray(company?.importWarnings) ? company.importWarnings : []
   let deltaLsvp = null
@@ -627,7 +629,9 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                     >
                       <div className="label">{isLast ? '└─' : '├─'} {investor.name}</div>
                       <div className="amount">
-                        {investor.proRataAmount > 0 ? (
+                        {proRataSuppressed && investor.hasProRataRights ? (
+                          <span className="amount-neutral">pro-rata suppressed</span>
+                        ) : investor.proRataAmount > 0 ? (
                           <span className="amount-positive">+{formatDollar(investor.proRataAmount)} (pro-rata)</span>
                         ) : (
                           <span className="amount-negative">-{investor.dilution.toFixed(1)}%</span>
@@ -675,7 +679,7 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                 <strong>SAFEs Total</strong>
                 <span className="section-row-meta">
                   {safeCount} notes
-                  {safeProRataCount > 0 ? `, ${safeProRataCount} pro-rata` : ''}
+                  {safeProRataCount > 0 ? `, ${safeProRataCount} ${proRataSuppressed ? 'suppressed pro-rata' : 'pro-rata'}` : ''}
                   {nonStandardSafeCount > 0 ? `, ${nonStandardSafeCount} non-standard` : ''}
                 </span>
               </div>
@@ -686,13 +690,14 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
             {!collapsed.safes && safeDetails.map((safe, safeIndex) => {
               const isLast = safeIndex === safeDetails.length - 1
               const showProRata = (safe.proRataAmount || 0) > 0
+              const showSuppressedProRata = proRataSuppressed && safe.proRata
               const safeDelay = `${Math.min(safeIndex, 6) * 0.035}s`
               const safeLabel = safe.investorName || `SAFE #${safe.index}`
               return (
                 <div key={safe.id || safeIndex} style={{ display: 'contents' }}>
                   <div className="table-row sub-row" style={{ animationDelay: safeDelay }}>
                     <div className="label">
-                      {isLast && !showProRata ? '└─' : '├─'} {safeLabel}
+                      {isLast && !showProRata && !showSuppressedProRata ? '└─' : '├─'} {safeLabel}
                       {safe.investorName && <span className="safe-attribution">SAFE #{safe.index}</span>}
                     </div>
                     <div className="amount amount-neutral">
@@ -709,6 +714,13 @@ const ScenarioCard = ({ scenario, index, isBase, onApplyScenario, onCopyPermalin
                       <div className="label">    {isLast ? '└─' : '├─'} pro-rata</div>
                       <div className="amount amount-positive">+{formatDollar(safe.proRataAmount)}</div>
                       <div className="percent">{formatPercent(safe.proRataPercent || 0)}</div>
+                    </div>
+                  )}
+                  {showSuppressedProRata && (
+                    <div className="table-row sub-sub-row">
+                      <div className="label">    {isLast ? '└─' : '├─'} pro-rata</div>
+                      <div className="amount amount-neutral">suppressed for SAFE round</div>
+                      <div className="percent">{formatPercent(0)}</div>
                     </div>
                   )}
                 </div>

--- a/react-app/src/utils/dataStructures.js
+++ b/react-app/src/utils/dataStructures.js
@@ -1,6 +1,7 @@
 import { buildScenarioOffsets, normalizeScenarioOffsets } from './scenarioOffsets'
 
 export const SAFE_CONVERSION_TYPES = new Set(['cap-discount', 'fixed-percent', 'round-price', 'mfn'])
+export const ROUND_INSTRUMENT_TYPES = new Set(['priced', 'safe'])
 
 /**
  * Data structure definitions for the enhanced valuation framework
@@ -197,6 +198,10 @@ function normalizeSafe(safe = {}) {
   }
 }
 
+function normalizeRoundInstrument(value) {
+  return ROUND_INSTRUMENT_TYPES.has(value) ? value : 'priced'
+}
+
 function normalizeStringArray(value) {
   return Array.isArray(value)
     ? value.map((item) => String(item || '').trim()).filter(Boolean)
@@ -216,6 +221,7 @@ function looksLikeSingleStoredCompany(value) {
     'otherPortion',
     'other',
     'investorName',
+    'roundInstrument',
     'showAdvanced',
     'proRataPercent',
     'preRoundFounderOwnership',
@@ -244,6 +250,7 @@ export function createDefaultCompany(companyName = 'New Company') {
     investorPortion: 2.75,
     otherPortion: 0.25,
     investorName: 'US',
+    roundInstrument: 'priced',
     showAdvanced: false,
     percentPrecision: 2,
     importWarnings: [],
@@ -328,6 +335,7 @@ export function migrateLegacyCompany(legacyCompany, fallbackName = 'New Company'
   migrated.investorName = typeof migrated.investorName === 'string' && migrated.investorName.trim()
     ? migrated.investorName.trim()
     : defaults.investorName
+  migrated.roundInstrument = normalizeRoundInstrument(migrated.roundInstrument)
   migrated.showAdvanced = Boolean(migrated.showAdvanced)
   migrated.esopTiming = migrated.esopTiming === 'post-close' ? 'post-close' : defaults.esopTiming
   delete migrated.postMoney

--- a/react-app/src/utils/multiPartyCalculations.js
+++ b/react-app/src/utils/multiPartyCalculations.js
@@ -138,6 +138,24 @@ function calculateProRataAllocations(priorInvestors, roundSize) {
   }
 }
 
+function calculateSuppressedProRataAllocations(priorInvestors) {
+  const proRataResults = Array.isArray(priorInvestors)
+    ? priorInvestors.map(investor => ({
+      id: investor.id,
+      name: investor.name,
+      preRoundOwnership: investor.ownershipPercent,
+      proRataAmount: 0,
+      calculatedProRataAmount: 0,
+      proRataPercent: 0,
+      hasRights: investor.hasProRataRights,
+      isOverridden: false,
+      suppressed: Boolean(investor.hasProRataRights)
+    }))
+    : []
+
+  return { proRataResults, totalProRataAmount: 0, totalProRataPercent: 0 }
+}
+
 /**
  * Calculate SAFE conversions (unchanged from original logic)
  */
@@ -238,6 +256,24 @@ function calculateSafeProRataAllocations(safeDetails, roundSize, investorName) {
   }
 }
 
+function calculateSuppressedSafeProRataAllocations(safeDetails) {
+  const safeProRataResults = Array.isArray(safeDetails)
+    ? safeDetails
+      .filter(safe => safe.proRata)
+      .map(safe => ({
+        id: safe.id,
+        investorName: safe.investorName || '',
+        preRoundSafePercent: safe.percent || 0,
+        proRataAmount: 0,
+        calculatedProRataAmount: 0,
+        isOverridden: false,
+        suppressed: true
+      }))
+    : []
+
+  return { safeProRataResults, totalSafeProRataAmount: 0 }
+}
+
 /**
  * Calculate ESOP dilution and timing effects
  *
@@ -330,6 +366,7 @@ function calculateTwoStepScenario(inputs) {
     investorPortion: s1Investor,
     otherPortion: s1Other,
     investorName = 'US',
+    roundInstrument = 'priced',
     showAdvanced = false,
     step2PostMoney: V2,
     step2Amount: S2,
@@ -344,6 +381,8 @@ function calculateTwoStepScenario(inputs) {
     esopTiming = 'pre-close',
     warrants = []
   } = migratedInputs
+  const isSafeRound = roundInstrument === 'safe'
+  const proRataSuppressed = isSafeRound
 
   if (V1 <= 0 || S1 <= 0 || V1 <= S1 || V2 <= 0 || S2 <= 0 || V2 <= S2) {
     return null
@@ -394,13 +433,17 @@ function calculateTwoStepScenario(inputs) {
 
   // --- Pro-rata from step 2's other portion ---
   const priorInvestorsForProRata = scaledPriorInvestors.map(inv =>
-    inv.name === investorName ? { ...inv, hasProRataRights: false } : inv
+    inv.name === investorName || isSafeRound ? { ...inv, hasProRataRights: false } : inv
   )
-  const proRataCalc = calculateProRataAllocations(priorInvestorsForProRata, S2)
+  const proRataCalc = isSafeRound
+    ? calculateSuppressedProRataAllocations(scaledPriorInvestors)
+    : calculateProRataAllocations(priorInvestorsForProRata, S2)
 
   // SAFE pro-rata also draws from step 2's other portion. Use pre-dilution SAFE percent
   // relative to step 2 round (treat safeCalc.totalSafePercent as the step-1 post-money % of SAFE).
-  const safeProRataCalc = calculateSafeProRataAllocations(safeCalc.safeDetails, S2, investorName)
+  const safeProRataCalc = isSafeRound
+    ? calculateSuppressedSafeProRataAllocations(safeCalc.safeDetails)
+    : calculateSafeProRataAllocations(safeCalc.safeDetails, S2, investorName)
 
   // Combined pro-rata clamped to available step 2 other portion
   const combinedRequestedProRata = r$(proRataCalc.totalProRataAmount + safeProRataCalc.totalSafeProRataAmount)
@@ -642,6 +685,8 @@ function calculateTwoStepScenario(inputs) {
     roundSize: r$(S1 + S2),
     preMoneyVal: preMoneyV1,
     investorName,
+    roundInstrument,
+    proRataSuppressed,
     twoStepEnabled: true,
 
     // Round composition — combined from both steps
@@ -847,6 +892,7 @@ export function calculateEnhancedScenario(inputs) {
     investorPortion, 
     otherPortion,
     investorName = 'US',
+    roundInstrument = 'priced',
     showAdvanced = false,
     // New multi-party structures
     priorInvestors = [],
@@ -859,6 +905,8 @@ export function calculateEnhancedScenario(inputs) {
     esopTiming = 'pre-close',
     warrants = []
   } = migratedInputs
+  const isSafeRound = roundInstrument === 'safe'
+  const proRataSuppressed = isSafeRound
 
   // When showAdvanced is false, ignore all advanced inputs
   const effectivePriorInvestors = showAdvanced ? priorInvestors : []
@@ -916,15 +964,19 @@ export function calculateEnhancedScenario(inputs) {
   // If a prior investor matches the lead investor name, skip their pro-rata —
   // their participation in the round already covers their pro-rata rights
   const priorInvestorsForProRata = scaledPriorInvestors.map(inv =>
-    inv.name === investorName ? { ...inv, hasProRataRights: false } : inv
+    inv.name === investorName || isSafeRound ? { ...inv, hasProRataRights: false } : inv
   )
-  const proRataCalc = calculateProRataAllocations(priorInvestorsForProRata, roundSize)
+  const proRataCalc = isSafeRound
+    ? calculateSuppressedProRataAllocations(scaledPriorInvestors)
+    : calculateProRataAllocations(priorInvestorsForProRata, roundSize)
 
   // Calculate SAFE conversions (needed before SAFE pro-rata)
   const safeCalc = calculateSafeConversions(effectiveSafes, preMoneyVal)
 
   // Calculate SAFE pro-rata on SAFEs flagged with pro-rata rights
-  const safeProRataCalc = calculateSafeProRataAllocations(safeCalc.safeDetails, roundSize, investorName)
+  const safeProRataCalc = isSafeRound
+    ? calculateSuppressedSafeProRataAllocations(safeCalc.safeDetails)
+    : calculateSafeProRataAllocations(safeCalc.safeDetails, roundSize, investorName)
 
   // Pro-rata (prior + SAFE) comes from the "Other" portion, not from round size
   const combinedProRataAmount = r$(proRataCalc.totalProRataAmount + safeProRataCalc.totalSafeProRataAmount)
@@ -936,7 +988,9 @@ export function calculateEnhancedScenario(inputs) {
       otherPortion,
       roundSize,
       postMoneyVal,
-      preMoneyVal
+      preMoneyVal,
+      roundInstrument,
+      proRataSuppressed
     }
   }
 
@@ -1148,6 +1202,8 @@ export function calculateEnhancedScenario(inputs) {
     roundSize: roundSize || 3,
     preMoneyVal: preMoneyVal || 10,
     investorName: investorName || 'US',
+    roundInstrument,
+    proRataSuppressed,
 
     // Round composition - ensure no undefined values
     newMoneyAmount: roundSize || 0,

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -10,6 +10,7 @@ const URL_PARAM_MAP = {
   investorPortion: 'ip',
   otherPortion: 'op',
   investorName: 'in',
+  roundInstrument: 'rt',
   showAdvanced: 'adv',
   proRataPercent: 'pr',
   // N SAFEs array will be encoded as 'safes' parameter
@@ -95,6 +96,14 @@ export function encodeScenarioToURL(scenarioData) {
           params.set(param, '1')
         }
         return // Don't include if false (default)
+      }
+
+      // Handle round instrument; priced is the default and omitted.
+      if (field === 'roundInstrument') {
+        if (value === 'safe') {
+          params.set(param, 'safe')
+        }
+        return
       }
       
       // Handle SAFEs array encoding
@@ -258,6 +267,7 @@ export function decodeScenarioFromURL(urlParams) {
       esopTiming: 'pre-close',
       // Warrants defaults
       warrants: [],
+      roundInstrument: 'priced',
       percentPrecision: 2,
       // 2-Step Round defaults
       twoStepEnabled: false,
@@ -274,6 +284,8 @@ export function decodeScenarioFromURL(urlParams) {
       if (value !== null) {
         if (field === 'investorName' || field === 'name') {
           scenarioData[field] = value
+        } else if (field === 'roundInstrument') {
+          scenarioData[field] = value === 'safe' ? 'safe' : 'priced'
         } else if (field === 'showAdvanced' || field === 'twoStepEnabled') {
           scenarioData[field] = value === '1'
         } else if (field === 'esopTiming') {

--- a/react-app/src/utils/permalink.js
+++ b/react-app/src/utils/permalink.js
@@ -125,6 +125,9 @@ export function encodeScenarioToURL(scenarioData) {
             if (safe.investorName && safe.investorName.trim()) {
               encoded.n = safe.investorName.trim()
             }
+            if (safe.notes && String(safe.notes).trim()) {
+              encoded.nt = String(safe.notes).trim()
+            }
             if (safe.proRata) {
               encoded.p = 1
               if (safe.proRataOverride != null && safe.proRataOverride >= 0) {
@@ -306,6 +309,9 @@ export function decodeScenarioFromURL(urlParams) {
                 conversionType: safe.t || 'cap-discount',
                 fixedOwnershipPercent: safe.fp || 0,
                 investorName: safe.n || '',
+                notes: typeof safe.nt === 'string'
+                  ? safe.nt.trim()
+                  : (typeof safe.notes === 'string' ? safe.notes.trim() : ''),
                 proRata: safe.p === 1 || safe.p === true,
                 proRataOverride: (typeof safe.po === 'number' && safe.po >= 0) ? safe.po : null
               }))

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -91,6 +91,35 @@ describe('Permalink Utilities', () => {
       expect(decodeScenarioFromURL(`${encoded.replace('rt=safe', 'rt=note')}`).roundInstrument).toBe('priced')
     })
 
+    it('should preserve SAFE round type and side-letter notes in hyperlinks', () => {
+      const encoded = encodeScenarioToURL({
+        ...mockScenario,
+        roundInstrument: 'safe',
+        showAdvanced: true,
+        safes: [
+          {
+            id: 1,
+            investorName: 'Bridge Investor',
+            amount: 1,
+            cap: 8,
+            discount: 0,
+            proRata: true,
+            notes: 'Side letter says pro-rata, but this SAFE round should not trigger it.'
+          }
+        ]
+      })
+
+      const params = new URLSearchParams(encoded)
+      expect(params.get('rt')).toBe('safe')
+      const safesData = JSON.parse(params.get('safes'))
+      expect(safesData[0].nt).toBe('Side letter says pro-rata, but this SAFE round should not trigger it.')
+
+      const decoded = decodeScenarioFromURL(encoded)
+      expect(decoded.roundInstrument).toBe('safe')
+      expect(decoded.safes[0].notes).toBe('Side letter says pro-rata, but this SAFE round should not trigger it.')
+      expect(decoded.safes[0].proRata).toBe(true)
+    })
+
     it('should encode advanced scenario data when showAdvanced is true', () => {
       const encoded = encodeScenarioToURL(mockAdvancedScenario)
       expect(encoded).toMatch(/pmv=13/)

--- a/react-app/src/utils/permalink.test.js
+++ b/react-app/src/utils/permalink.test.js
@@ -75,7 +75,20 @@ describe('Permalink Utilities', () => {
       expect(encoded).toMatch(/ip=2\.75/)
       expect(encoded).toMatch(/op=0\.25/)
       expect(encoded).toMatch(/in=US/)
+      expect(encoded).not.toMatch(/rt=/)
       expect(encoded).not.toMatch(/safes=/) // No SAFEs should not be included
+    })
+
+    it('should round-trip SAFE round instrument and omit priced default', () => {
+      const priced = encodeScenarioToURL({ ...mockScenario, roundInstrument: 'priced' })
+      expect(new URLSearchParams(priced).get('rt')).toBeNull()
+
+      const encoded = encodeScenarioToURL({ ...mockScenario, roundInstrument: 'safe' })
+      expect(new URLSearchParams(encoded).get('rt')).toBe('safe')
+
+      const decoded = decodeScenarioFromURL(encoded)
+      expect(decoded.roundInstrument).toBe('safe')
+      expect(decodeScenarioFromURL(`${encoded.replace('rt=safe', 'rt=note')}`).roundInstrument).toBe('priced')
     })
 
     it('should encode advanced scenario data when showAdvanced is true', () => {

--- a/react-app/src/utils/safe-pro-rata.test.js
+++ b/react-app/src/utils/safe-pro-rata.test.js
@@ -168,6 +168,33 @@ describe('SAFE Pro-Rata', () => {
     expect(result.totalOwnership + result.unknownOwnership).toBeCloseTo(100, 1)
   })
 
+  it('suppresses prior and SAFE pro-rata in a SAFE round while keeping pro-forma dilution', () => {
+    const result = calculateEnhancedScenario({
+      ...baseInputs,
+      roundInstrument: 'safe',
+      investorPortion: 20,
+      otherPortion: 0,
+      priorInvestors: [
+        { id: 10, name: 'Seed Co', ownershipPercent: 10, hasProRataRights: true, proRataOverride: null }
+      ],
+      founders: [{ id: 99, name: 'Founders', ownershipPercent: 70 }],
+      safes: [
+        { id: 1, amount: 1, cap: 10, discount: 0, investorName: 'Acme', proRata: true }
+      ]
+    })
+
+    expect(result.error).toBeFalsy()
+    expect(result.roundInstrument).toBe('safe')
+    expect(result.proRataSuppressed).toBe(true)
+    expect(result.totalProRataAmount).toBe(0)
+    expect(result.totalSafeProRataAmount).toBe(0)
+    expect(result.priorInvestors[0].proRataAmount).toBe(0)
+    expect(result.safeDetails[0].proRataAmount).toBe(0)
+    expect(result.otherAmount).toBe(0)
+    expect(result.totalSafePercent).toBeCloseTo(10, 2)
+    expect(result.founders[0].postRoundPercent).toBeCloseTo(49, 2)
+  })
+
   it('persists SAFE pro-rata fields in permalink round-trip', async () => {
     const { encodeScenarioToURL, decodeScenarioFromURL } = await import('./permalink')
     const encoded = encodeScenarioToURL({
@@ -205,5 +232,38 @@ describe('SAFE Pro-Rata in Two-Step Round', () => {
     expect(base.error).toBeFalsy()
     expect(base.totalSafeProRataAmount).toBeGreaterThan(0)
     expect(base.safeDetails[0].proRataAmount).toBeGreaterThan(0)
+  })
+
+  it('suppresses step-2 prior and SAFE pro-rata in a SAFE round', () => {
+    const scenarios = calculateEnhancedScenarios({
+      ...baseInputs,
+      roundInstrument: 'safe',
+      twoStepEnabled: true,
+      postMoneyVal: 50,
+      roundSize: 10,
+      investorPortion: 8,
+      otherPortion: 2,
+      step2PostMoney: 150,
+      step2Amount: 30,
+      step2InvestorPortion: 30,
+      step2OtherPortion: 0,
+      priorInvestors: [
+        { id: 10, name: 'Seed Co', ownershipPercent: 10, hasProRataRights: true, proRataOverride: null }
+      ],
+      founders: [{ id: 99, name: 'Founders', ownershipPercent: 70 }],
+      safes: [
+        { id: 1, amount: 1, cap: 10, discount: 0, investorName: 'Acme', proRata: true }
+      ]
+    })
+    const base = scenarios[0]
+
+    expect(base.error).toBeFalsy()
+    expect(base.roundInstrument).toBe('safe')
+    expect(base.proRataSuppressed).toBe(true)
+    expect(base.totalProRataAmount).toBe(0)
+    expect(base.totalSafeProRataAmount).toBe(0)
+    expect(base.priorInvestors[0].proRataAmount).toBe(0)
+    expect(base.safeDetails[0].proRataAmount).toBe(0)
+    expect(base.founders[0].postRoundPercent).toBeLessThan(70)
   })
 })


### PR DESCRIPTION
## Summary
- add a priced/SAFE round type and persist SAFE round permalinks
- suppress prior-investor and SAFE pro-rata allocations for SAFE rounds while keeping pro-forma dilution math
- show suppression copy in the input and scenario displays

## Tests
- npm run lint
- npx vitest run
- npm run build

## Manual check
- Vite served http://localhost:5173/ successfully; no browser automation dependency is installed in this repo for screenshot-level verification.